### PR TITLE
limitador-operator.v1.1.1

### DIFF
--- a/catalog/4.16/limitador-operator/catalog.yaml
+++ b/catalog/4.16/limitador-operator/catalog.yaml
@@ -7,13 +7,15 @@ name: limitador-operator
 schema: olm.package
 ---
 entries:
-- name: limitador-operator.v0.12.1
-- name: limitador-operator.v1.0.1
-  replaces: limitador-operator.v0.12.1
-- name: limitador-operator.v1.0.2
-  replaces: limitador-operator.v1.0.1
-- name: limitador-operator.v1.1.0
-  replaces: limitador-operator.v1.0.2
+  - name: limitador-operator.v0.12.1
+  - name: limitador-operator.v1.0.1
+    replaces: limitador-operator.v0.12.1
+  - name: limitador-operator.v1.0.2
+    replaces: limitador-operator.v1.0.1
+  - name: limitador-operator.v1.1.0
+    replaces: limitador-operator.v1.0.2
+  - name: limitador-operator.v1.1.1
+    replaces: limitador-operator.v1.1.0
 name: stable
 package: limitador-operator
 schema: olm.channel
@@ -22,474 +24,503 @@ image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:53fc5ce2a479fb
 name: limitador-operator.v0.12.1
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 0.12.1
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 0.12.1
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914
-      createdAt: "2024-10-18T10:24:00Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: The Operator to manage Limitador deployments. - Part of Red Hat Connectivity
-      Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914
+        createdAt: "2024-10-18T10:24:00Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: The Operator to manage Limitador deployments. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914
-  name: limitador-rhel9-operator-2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:b542037f744ec0ca8bb5dc770507c774cc8603cdc3072c9a8a2a78d1907ac961
-  name: limitador
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:53fc5ce2a479fb005f8b31bc6e58ef63b1e28cb2bf6946e01deb105f7e842889
-  name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914
+    name: limitador-rhel9-operator-2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:b542037f744ec0ca8bb5dc770507c774cc8603cdc3072c9a8a2a78d1907ac961
+    name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:53fc5ce2a479fb005f8b31bc6e58ef63b1e28cb2bf6946e01deb105f7e842889
+    name: ""
 schema: olm.bundle
 ---
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:d30fa5c4e7890f902429dd12456efa2170d0df6274af92c36c76d13c9f87e8c6
 name: limitador-operator.v1.0.1
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 1.0.1
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.0.1
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a
-      createdAt: "2024-10-18T10:24:00Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: Enables rate limiting for Gateways and applications in a Gateway
-      API network. - Part of Red Hat Connectivity Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a
+        createdAt: "2024-10-18T10:24:00Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: Enables rate limiting for Gateways and applications in a Gateway API network. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a
-  name: limitador-rhel9-operator-328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:19857349512b404537bfb6bb7672b5c47a6e315b18fdb8dc74a35bbe2c7631f6
-  name: limitador
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:d30fa5c4e7890f902429dd12456efa2170d0df6274af92c36c76d13c9f87e8c6
-  name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a
+    name: limitador-rhel9-operator-328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:19857349512b404537bfb6bb7672b5c47a6e315b18fdb8dc74a35bbe2c7631f6
+    name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:d30fa5c4e7890f902429dd12456efa2170d0df6274af92c36c76d13c9f87e8c6
+    name: ""
 schema: olm.bundle
 ---
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:e2c9dfc30d59bd4086ccfeada4fe79c04661c7cd2e6e7758ee97dfec95eaa4b7
 name: limitador-operator.v1.0.2
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 1.0.2
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.0.2
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f
-      createdAt: "2024-10-18T10:24:00Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: Enables rate limiting for Gateways and applications in a Gateway
-      API network. - Part of Red Hat Connectivity Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f
+        createdAt: "2024-10-18T10:24:00Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: Enables rate limiting for Gateways and applications in a Gateway API network. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f
-  name: limitador-rhel9-operator-3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:cd2c1a74faa084f4a215cd6537caf93e1727d03b3f28ba33cef167001960c0b8
-  name: limitador
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:e2c9dfc30d59bd4086ccfeada4fe79c04661c7cd2e6e7758ee97dfec95eaa4b7
-  name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f
+    name: limitador-rhel9-operator-3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:cd2c1a74faa084f4a215cd6537caf93e1727d03b3f28ba33cef167001960c0b8
+    name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:e2c9dfc30d59bd4086ccfeada4fe79c04661c7cd2e6e7758ee97dfec95eaa4b7
+    name: ""
 schema: olm.bundle
 ---
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
 name: limitador-operator.v1.1.0
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 1.1.0
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.1.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-      createdAt: "2025-04-07T15:52:04Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: Enables rate limiting for Gateways and applications in a Gateway
-      API network. - Part of Red Hat Connectivity Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+        createdAt: "2025-04-07T15:52:04Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: Enables rate limiting for Gateways and applications in a Gateway API network. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
-  name: ""
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-  name: limitador-rhel9-operator-edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:98f85a05da53fbf7f20845d1969441620407cc13a185fd52714308679f116425
-  name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+    name: limitador-rhel9-operator-edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:98f85a05da53fbf7f20845d1969441620407cc13a185fd52714308679f116425
+    name: limitador
+schema: olm.bundle
+---
+image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-1-limitador-operator-bundle@sha256:93c6f058da352883789f7db0150b1097a5f09e1268e24914ad964d5fdc83f6e1
+name: limitador-operator.v1.1.1
+package: limitador-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.1.1
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsiY29udHJvbGxlci1nZW4ua3ViZWJ1aWxkZXIuaW8vdmVyc2lvbiI6InYwLjE1LjAifSwiY3JlYXRpb25UaW1lc3RhbXAiOm51bGwsIm5hbWUiOiJsaW1pdGFkb3JzLmxpbWl0YWRvci5rdWFkcmFudC5pbyJ9LCJzcGVjIjp7Imdyb3VwIjoibGltaXRhZG9yLmt1YWRyYW50LmlvIiwibmFtZXMiOnsia2luZCI6IkxpbWl0YWRvciIsImxpc3RLaW5kIjoiTGltaXRhZG9yTGlzdCIsInBsdXJhbCI6ImxpbWl0YWRvcnMiLCJzaW5ndWxhciI6ImxpbWl0YWRvciJ9LCJzY29wZSI6Ik5hbWVzcGFjZWQiLCJ2ZXJzaW9ucyI6W3siYWRkaXRpb25hbFByaW50ZXJDb2x1bW5zIjpbeyJkZXNjcmlwdGlvbiI6IkxpbWl0YWRvciBSZWFkeSIsImpzb25QYXRoIjoiLnN0YXR1cy5jb25kaXRpb25zWz8oQC50eXBlPT1cIlJlYWR5XCIpXS5zdGF0dXMiLCJuYW1lIjoiUmVhZHkiLCJwcmlvcml0eSI6MiwidHlwZSI6InN0cmluZyJ9LHsianNvblBhdGgiOiIubWV0YWRhdGEuY3JlYXRpb25UaW1lc3RhbXAiLCJuYW1lIjoiQWdlIiwidHlwZSI6ImRhdGUifV0sIm5hbWUiOiJ2MWFscGhhMSIsInNjaGVtYSI6eyJvcGVuQVBJVjNTY2hlbWEiOnsiZGVzY3JpcHRpb24iOiJMaW1pdGFkb3IgaXMgdGhlIFNjaGVtYSBmb3IgdGhlIGxpbWl0YWRvcnMgQVBJIiwicHJvcGVydGllcyI6eyJhcGlWZXJzaW9uIjp7ImRlc2NyaXB0aW9uIjoiQVBJVmVyc2lvbiBkZWZpbmVzIHRoZSB2ZXJzaW9uZWQgc2NoZW1hIG9mIHRoaXMgcmVwcmVzZW50YXRpb24gb2YgYW4gb2JqZWN0LlxuU2VydmVycyBzaG91bGQgY29udmVydCByZWNvZ25pemVkIHNjaGVtYXMgdG8gdGhlIGxhdGVzdCBpbnRlcm5hbCB2YWx1ZSwgYW5kXG5tYXkgcmVqZWN0IHVucmVjb2duaXplZCB2YWx1ZXMuXG5Nb3JlIGluZm86IGh0dHBzOi8vZ2l0Lms4cy5pby9jb21tdW5pdHkvY29udHJpYnV0b3JzL2RldmVsL3NpZy1hcmNoaXRlY3R1cmUvYXBpLWNvbnZlbnRpb25zLm1kI3Jlc291cmNlcyIsInR5cGUiOiJzdHJpbmcifSwia2luZCI6eyJkZXNjcmlwdGlvbiI6IktpbmQgaXMgYSBzdHJpbmcgdmFsdWUgcmVwcmVzZW50aW5nIHRoZSBSRVNUIHJlc291cmNlIHRoaXMgb2JqZWN0IHJlcHJlc2VudHMuXG5TZXJ2ZXJzIG1heSBpbmZlciB0aGlzIGZyb20gdGhlIGVuZHBvaW50IHRoZSBjbGllbnQgc3VibWl0cyByZXF1ZXN0cyB0by5cbkNhbm5vdCBiZSB1cGRhdGVkLlxuSW4gQ2FtZWxDYXNlLlxuTW9yZSBpbmZvOiBodHRwczovL2dpdC5rOHMuaW8vY29tbXVuaXR5L2NvbnRyaWJ1dG9ycy9kZXZlbC9zaWctYXJjaGl0ZWN0dXJlL2FwaS1jb252ZW50aW9ucy5tZCN0eXBlcy1raW5kcyIsInR5cGUiOiJzdHJpbmcifSwibWV0YWRhdGEiOnsidHlwZSI6Im9iamVjdCJ9LCJzcGVjIjp7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yU3BlYyBkZWZpbmVzIHRoZSBkZXNpcmVkIHN0YXRlIG9mIExpbWl0YWRvciIsInByb3BlcnRpZXMiOnsiYWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJBZmZpbml0eSBpcyBhIGdyb3VwIG9mIGFmZmluaXR5IHNjaGVkdWxpbmcgcnVsZXMuIiwicHJvcGVydGllcyI6eyJub2RlQWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJEZXNjcmliZXMgbm9kZSBhZmZpbml0eSBzY2hlZHVsaW5nIHJ1bGVzIGZvciB0aGUgcG9kLiIsInByb3BlcnRpZXMiOnsicHJlZmVycmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJUaGUgc2NoZWR1bGVyIHdpbGwgcHJlZmVyIHRvIHNjaGVkdWxlIHBvZHMgdG8gbm9kZXMgdGhhdCBzYXRpc2Z5XG50aGUgYWZmaW5pdHkgZXhwcmVzc2lvbnMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQsIGJ1dCBpdCBtYXkgY2hvb3NlXG5hIG5vZGUgdGhhdCB2aW9sYXRlcyBvbmUgb3IgbW9yZSBvZiB0aGUgZXhwcmVzc2lvbnMuIFRoZSBub2RlIHRoYXQgaXNcbm1vc3QgcHJlZmVycmVkIGlzIHRoZSBvbmUgd2l0aCB0aGUgZ3JlYXRlc3Qgc3VtIG9mIHdlaWdodHMsIGkuZS5cbmZvciBlYWNoIG5vZGUgdGhhdCBtZWV0cyBhbGwgb2YgdGhlIHNjaGVkdWxpbmcgcmVxdWlyZW1lbnRzIChyZXNvdXJjZVxucmVxdWVzdCwgcmVxdWlyZWREdXJpbmdTY2hlZHVsaW5nIGFmZmluaXR5IGV4cHJlc3Npb25zLCBldGMuKSxcbmNvbXB1dGUgYSBzdW0gYnkgaXRlcmF0aW5nIHRocm91Z2ggdGhlIGVsZW1lbnRzIG9mIHRoaXMgZmllbGQgYW5kIGFkZGluZ1xuXCJ3ZWlnaHRcIiB0byB0aGUgc3VtIGlmIHRoZSBub2RlIG1hdGNoZXMgdGhlIGNvcnJlc3BvbmRpbmcgbWF0Y2hFeHByZXNzaW9uczsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBbiBlbXB0eSBwcmVmZXJyZWQgc2NoZWR1bGluZyB0ZXJtIG1hdGNoZXMgYWxsIG9iamVjdHMgd2l0aCBpbXBsaWNpdCB3ZWlnaHQgMFxuKGkuZS4gaXQncyBhIG5vLW9wKS4gQSBudWxsIHByZWZlcnJlZCBzY2hlZHVsaW5nIHRlcm0gbWF0Y2hlcyBubyBvYmplY3RzIChpLmUuIGlzIGFsc28gYSBuby1vcCkuIiwicHJvcGVydGllcyI6eyJwcmVmZXJlbmNlIjp7ImRlc2NyaXB0aW9uIjoiQSBub2RlIHNlbGVjdG9yIHRlcm0sIGFzc29jaWF0ZWQgd2l0aCB0aGUgY29ycmVzcG9uZGluZyB3ZWlnaHQuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoiQSBsaXN0IG9mIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnRzIGJ5IG5vZGUncyBsYWJlbHMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvclxudGhhdCByZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6IlRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoiUmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzLCBEb2VzTm90RXhpc3QuIEd0LCBhbmQgTHQuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJBbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEd0IG9yIEx0LCB0aGUgdmFsdWVzXG5hcnJheSBtdXN0IGhhdmUgYSBzaW5nbGUgZWxlbWVudCwgd2hpY2ggd2lsbCBiZSBpbnRlcnByZXRlZCBhcyBhbiBpbnRlZ2VyLlxuVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoRmllbGRzIjp7ImRlc2NyaXB0aW9uIjoiQSBsaXN0IG9mIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnRzIGJ5IG5vZGUncyBmaWVsZHMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvclxudGhhdCByZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6IlRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoiUmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzLCBEb2VzTm90RXhpc3QuIEd0LCBhbmQgTHQuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJBbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEd0IG9yIEx0LCB0aGUgdmFsdWVzXG5hcnJheSBtdXN0IGhhdmUgYSBzaW5nbGUgZWxlbWVudCwgd2hpY2ggd2lsbCBiZSBpbnRlcnByZXRlZCBhcyBhbiBpbnRlZ2VyLlxuVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIndlaWdodCI6eyJkZXNjcmlwdGlvbiI6IldlaWdodCBhc3NvY2lhdGVkIHdpdGggbWF0Y2hpbmcgdGhlIGNvcnJlc3BvbmRpbmcgbm9kZVNlbGVjdG9yVGVybSwgaW4gdGhlIHJhbmdlIDEtMTAwLiIsImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifX0sInJlcXVpcmVkIjpbInByZWZlcmVuY2UiLCJ3ZWlnaHQiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwicmVxdWlyZWREdXJpbmdTY2hlZHVsaW5nSWdub3JlZER1cmluZ0V4ZWN1dGlvbiI6eyJkZXNjcmlwdGlvbiI6IklmIHRoZSBhZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgYXJlIG5vdCBtZXQgYXRcbnNjaGVkdWxpbmcgdGltZSwgdGhlIHBvZCB3aWxsIG5vdCBiZSBzY2hlZHVsZWQgb250byB0aGUgbm9kZS5cbklmIHRoZSBhZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgY2Vhc2UgdG8gYmUgbWV0XG5hdCBzb21lIHBvaW50IGR1cmluZyBwb2QgZXhlY3V0aW9uIChlLmcuIGR1ZSB0byBhbiB1cGRhdGUpLCB0aGUgc3lzdGVtXG5tYXkgb3IgbWF5IG5vdCB0cnkgdG8gZXZlbnR1YWxseSBldmljdCB0aGUgcG9kIGZyb20gaXRzIG5vZGUuIiwicHJvcGVydGllcyI6eyJub2RlU2VsZWN0b3JUZXJtcyI6eyJkZXNjcmlwdGlvbiI6IlJlcXVpcmVkLiBBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciB0ZXJtcy4gVGhlIHRlcm1zIGFyZSBPUmVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBudWxsIG9yIGVtcHR5IG5vZGUgc2VsZWN0b3IgdGVybSBtYXRjaGVzIG5vIG9iamVjdHMuIFRoZSByZXF1aXJlbWVudHMgb2ZcbnRoZW0gYXJlIEFORGVkLlxuVGhlIFRvcG9sb2d5U2VsZWN0b3JUZXJtIHR5cGUgaW1wbGVtZW50cyBhIHN1YnNldCBvZiB0aGUgTm9kZVNlbGVjdG9yVGVybS4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudHMgYnkgbm9kZSdzIGxhYmVscy4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yXG50aGF0IHJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJSZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMsIERvZXNOb3RFeGlzdC4gR3QsIGFuZCBMdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6IkFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgR3Qgb3IgTHQsIHRoZSB2YWx1ZXNcbmFycmF5IG11c3QgaGF2ZSBhIHNpbmdsZSBlbGVtZW50LCB3aGljaCB3aWxsIGJlIGludGVycHJldGVkIGFzIGFuIGludGVnZXIuXG5UaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hGaWVsZHMiOnsiZGVzY3JpcHRpb24iOiJBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudHMgYnkgbm9kZSdzIGZpZWxkcy4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yXG50aGF0IHJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJSZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMsIERvZXNOb3RFeGlzdC4gR3QsIGFuZCBMdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6IkFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgR3Qgb3IgTHQsIHRoZSB2YWx1ZXNcbmFycmF5IG11c3QgaGF2ZSBhIHNpbmdsZSBlbGVtZW50LCB3aGljaCB3aWxsIGJlIGludGVycHJldGVkIGFzIGFuIGludGVnZXIuXG5UaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJub2RlU2VsZWN0b3JUZXJtcyJdLCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn19LCJ0eXBlIjoib2JqZWN0In0sInBvZEFmZmluaXR5Ijp7ImRlc2NyaXB0aW9uIjoiRGVzY3JpYmVzIHBvZCBhZmZpbml0eSBzY2hlZHVsaW5nIHJ1bGVzIChlLmcuIGNvLWxvY2F0ZSB0aGlzIHBvZCBpbiB0aGUgc2FtZSBub2RlLCB6b25lLCBldGMuIGFzIHNvbWUgb3RoZXIgcG9kKHMpKS4iLCJwcm9wZXJ0aWVzIjp7InByZWZlcnJlZER1cmluZ1NjaGVkdWxpbmdJZ25vcmVkRHVyaW5nRXhlY3V0aW9uIjp7ImRlc2NyaXB0aW9uIjoiVGhlIHNjaGVkdWxlciB3aWxsIHByZWZlciB0byBzY2hlZHVsZSBwb2RzIHRvIG5vZGVzIHRoYXQgc2F0aXNmeVxudGhlIGFmZmluaXR5IGV4cHJlc3Npb25zIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkLCBidXQgaXQgbWF5IGNob29zZVxuYSBub2RlIHRoYXQgdmlvbGF0ZXMgb25lIG9yIG1vcmUgb2YgdGhlIGV4cHJlc3Npb25zLiBUaGUgbm9kZSB0aGF0IGlzXG5tb3N0IHByZWZlcnJlZCBpcyB0aGUgb25lIHdpdGggdGhlIGdyZWF0ZXN0IHN1bSBvZiB3ZWlnaHRzLCBpLmUuXG5mb3IgZWFjaCBub2RlIHRoYXQgbWVldHMgYWxsIG9mIHRoZSBzY2hlZHVsaW5nIHJlcXVpcmVtZW50cyAocmVzb3VyY2VcbnJlcXVlc3QsIHJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZyBhZmZpbml0eSBleHByZXNzaW9ucywgZXRjLiksXG5jb21wdXRlIGEgc3VtIGJ5IGl0ZXJhdGluZyB0aHJvdWdoIHRoZSBlbGVtZW50cyBvZiB0aGlzIGZpZWxkIGFuZCBhZGRpbmdcblwid2VpZ2h0XCIgdG8gdGhlIHN1bSBpZiB0aGUgbm9kZSBoYXMgcG9kcyB3aGljaCBtYXRjaGVzIHRoZSBjb3JyZXNwb25kaW5nIHBvZEFmZmluaXR5VGVybTsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJUaGUgd2VpZ2h0cyBvZiBhbGwgb2YgdGhlIG1hdGNoZWQgV2VpZ2h0ZWRQb2RBZmZpbml0eVRlcm0gZmllbGRzIGFyZSBhZGRlZCBwZXItbm9kZSB0byBmaW5kIHRoZSBtb3N0IHByZWZlcnJlZCBub2RlKHMpIiwicHJvcGVydGllcyI6eyJwb2RBZmZpbml0eVRlcm0iOnsiZGVzY3JpcHRpb24iOiJSZXF1aXJlZC4gQSBwb2QgYWZmaW5pdHkgdGVybSwgYXNzb2NpYXRlZCB3aXRoIHRoZSBjb3JyZXNwb25kaW5nIHdlaWdodC4iLCJwcm9wZXJ0aWVzIjp7ImxhYmVsU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgYSBzZXQgb2YgcmVzb3VyY2VzLCBpbiB0aGlzIGNhc2UgcG9kcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciB0aGUgc2V0IG9mIG5hbWVzcGFjZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgc2VsZWN0ZWQgYnkgdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIGxpc3RlZCBpbiB0aGUgbmFtZXNwYWNlcyBmaWVsZC5cbm51bGwgc2VsZWN0b3IgYW5kIG51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi5cbkFuIGVtcHR5IHNlbGVjdG9yICh7fSkgbWF0Y2hlcyBhbGwgbmFtZXNwYWNlcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VzIjp7ImRlc2NyaXB0aW9uIjoibmFtZXNwYWNlcyBzcGVjaWZpZXMgYSBzdGF0aWMgbGlzdCBvZiBuYW1lc3BhY2UgbmFtZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgbGlzdGVkIGluIHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBzZWxlY3RlZCBieSBuYW1lc3BhY2VTZWxlY3Rvci5cbm51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IGFuZCBudWxsIG5hbWVzcGFjZVNlbGVjdG9yIG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJ0b3BvbG9neUtleSI6eyJkZXNjcmlwdGlvbiI6IlRoaXMgcG9kIHNob3VsZCBiZSBjby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGggdGhlIHBvZHMgbWF0Y2hpbmdcbnRoZSBsYWJlbFNlbGVjdG9yIGluIHRoZSBzcGVjaWZpZWQgbmFtZXNwYWNlcywgd2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlXG53aG9zZSB2YWx1ZSBvZiB0aGUgbGFiZWwgd2l0aCBrZXkgdG9wb2xvZ3lLZXkgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoIGFueSBvZiB0aGVcbnNlbGVjdGVkIHBvZHMgaXMgcnVubmluZy5cbkVtcHR5IHRvcG9sb2d5S2V5IGlzIG5vdCBhbGxvd2VkLiIsInR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInRvcG9sb2d5S2V5Il0sInR5cGUiOiJvYmplY3QifSwid2VpZ2h0Ijp7ImRlc2NyaXB0aW9uIjoid2VpZ2h0IGFzc29jaWF0ZWQgd2l0aCBtYXRjaGluZyB0aGUgY29ycmVzcG9uZGluZyBwb2RBZmZpbml0eVRlcm0sXG5pbiB0aGUgcmFuZ2UgMS0xMDAuIiwiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwicmVxdWlyZWQiOlsicG9kQWZmaW5pdHlUZXJtIiwid2VpZ2h0Il0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sInJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJJZiB0aGUgYWZmaW5pdHkgcmVxdWlyZW1lbnRzIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkIGFyZSBub3QgbWV0IGF0XG5zY2hlZHVsaW5nIHRpbWUsIHRoZSBwb2Qgd2lsbCBub3QgYmUgc2NoZWR1bGVkIG9udG8gdGhlIG5vZGUuXG5JZiB0aGUgYWZmaW5pdHkgcmVxdWlyZW1lbnRzIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkIGNlYXNlIHRvIGJlIG1ldFxuYXQgc29tZSBwb2ludCBkdXJpbmcgcG9kIGV4ZWN1dGlvbiAoZS5nLiBkdWUgdG8gYSBwb2QgbGFiZWwgdXBkYXRlKSwgdGhlXG5zeXN0ZW0gbWF5IG9yIG1heSBub3QgdHJ5IHRvIGV2ZW50dWFsbHkgZXZpY3QgdGhlIHBvZCBmcm9tIGl0cyBub2RlLlxuV2hlbiB0aGVyZSBhcmUgbXVsdGlwbGUgZWxlbWVudHMsIHRoZSBsaXN0cyBvZiBub2RlcyBjb3JyZXNwb25kaW5nIHRvIGVhY2hcbnBvZEFmZmluaXR5VGVybSBhcmUgaW50ZXJzZWN0ZWQsIGkuZS4gYWxsIHRlcm1zIG11c3QgYmUgc2F0aXNmaWVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiRGVmaW5lcyBhIHNldCBvZiBwb2RzIChuYW1lbHkgdGhvc2UgbWF0Y2hpbmcgdGhlIGxhYmVsU2VsZWN0b3JcbnJlbGF0aXZlIHRvIHRoZSBnaXZlbiBuYW1lc3BhY2UocykpIHRoYXQgdGhpcyBwb2Qgc2hvdWxkIGJlXG5jby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGgsXG53aGVyZSBjby1sb2NhdGVkIGlzIGRlZmluZWQgYXMgcnVubmluZyBvbiBhIG5vZGUgd2hvc2UgdmFsdWUgb2ZcbnRoZSBsYWJlbCB3aXRoIGtleSBcdTAwM2N0b3BvbG9neUtleVx1MDAzZSBtYXRjaGVzIHRoYXQgb2YgYW55IG5vZGUgb24gd2hpY2hcbmEgcG9kIG9mIHRoZSBzZXQgb2YgcG9kcyBpcyBydW5uaW5nIiwicHJvcGVydGllcyI6eyJsYWJlbFNlbGVjdG9yIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBxdWVyeSBvdmVyIGEgc2V0IG9mIHJlc291cmNlcywgaW4gdGhpcyBjYXNlIHBvZHMuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoibWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvciB0aGF0XG5yZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6ImtleSBpcyB0aGUgbGFiZWwga2V5IHRoYXQgdGhlIHNlbGVjdG9yIGFwcGxpZXMgdG8uIiwidHlwZSI6InN0cmluZyJ9LCJvcGVyYXRvciI6eyJkZXNjcmlwdGlvbiI6Im9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLlxuVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LiIsInR5cGUiOiJzdHJpbmcifSwidmFsdWVzIjp7ImRlc2NyaXB0aW9uIjoidmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpY1xubWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoTGFiZWxzIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjp7InR5cGUiOiJzdHJpbmcifSwiZGVzY3JpcHRpb24iOiJtYXRjaExhYmVscyBpcyBhIG1hcCBvZiB7a2V5LHZhbHVlfSBwYWlycy4gQSBzaW5nbGUge2tleSx2YWx1ZX0gaW4gdGhlIG1hdGNoTGFiZWxzXG5tYXAgaXMgZXF1aXZhbGVudCB0byBhbiBlbGVtZW50IG9mIG1hdGNoRXhwcmVzc2lvbnMsIHdob3NlIGtleSBmaWVsZCBpcyBcImtleVwiLCB0aGVcbm9wZXJhdG9yIGlzIFwiSW5cIiwgYW5kIHRoZSB2YWx1ZXMgYXJyYXkgY29udGFpbnMgb25seSBcInZhbHVlXCIuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwibmFtZXNwYWNlU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgdGhlIHNldCBvZiBuYW1lc3BhY2VzIHRoYXQgdGhlIHRlcm0gYXBwbGllcyB0by5cblRoZSB0ZXJtIGlzIGFwcGxpZWQgdG8gdGhlIHVuaW9uIG9mIHRoZSBuYW1lc3BhY2VzIHNlbGVjdGVkIGJ5IHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBsaXN0ZWQgaW4gdGhlIG5hbWVzcGFjZXMgZmllbGQuXG5udWxsIHNlbGVjdG9yIGFuZCBudWxsIG9yIGVtcHR5IG5hbWVzcGFjZXMgbGlzdCBtZWFucyBcInRoaXMgcG9kJ3MgbmFtZXNwYWNlXCIuXG5BbiBlbXB0eSBzZWxlY3RvciAoe30pIG1hdGNoZXMgYWxsIG5hbWVzcGFjZXMuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoibWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvciB0aGF0XG5yZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6ImtleSBpcyB0aGUgbGFiZWwga2V5IHRoYXQgdGhlIHNlbGVjdG9yIGFwcGxpZXMgdG8uIiwidHlwZSI6InN0cmluZyJ9LCJvcGVyYXRvciI6eyJkZXNjcmlwdGlvbiI6Im9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLlxuVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LiIsInR5cGUiOiJzdHJpbmcifSwidmFsdWVzIjp7ImRlc2NyaXB0aW9uIjoidmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpY1xubWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoTGFiZWxzIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjp7InR5cGUiOiJzdHJpbmcifSwiZGVzY3JpcHRpb24iOiJtYXRjaExhYmVscyBpcyBhIG1hcCBvZiB7a2V5LHZhbHVlfSBwYWlycy4gQSBzaW5nbGUge2tleSx2YWx1ZX0gaW4gdGhlIG1hdGNoTGFiZWxzXG5tYXAgaXMgZXF1aXZhbGVudCB0byBhbiBlbGVtZW50IG9mIG1hdGNoRXhwcmVzc2lvbnMsIHdob3NlIGtleSBmaWVsZCBpcyBcImtleVwiLCB0aGVcbm9wZXJhdG9yIGlzIFwiSW5cIiwgYW5kIHRoZSB2YWx1ZXMgYXJyYXkgY29udGFpbnMgb25seSBcInZhbHVlXCIuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwibmFtZXNwYWNlcyI6eyJkZXNjcmlwdGlvbiI6Im5hbWVzcGFjZXMgc3BlY2lmaWVzIGEgc3RhdGljIGxpc3Qgb2YgbmFtZXNwYWNlIG5hbWVzIHRoYXQgdGhlIHRlcm0gYXBwbGllcyB0by5cblRoZSB0ZXJtIGlzIGFwcGxpZWQgdG8gdGhlIHVuaW9uIG9mIHRoZSBuYW1lc3BhY2VzIGxpc3RlZCBpbiB0aGlzIGZpZWxkXG5hbmQgdGhlIG9uZXMgc2VsZWN0ZWQgYnkgbmFtZXNwYWNlU2VsZWN0b3IuXG5udWxsIG9yIGVtcHR5IG5hbWVzcGFjZXMgbGlzdCBhbmQgbnVsbCBuYW1lc3BhY2VTZWxlY3RvciBtZWFucyBcInRoaXMgcG9kJ3MgbmFtZXNwYWNlXCIuIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifSwidG9wb2xvZ3lLZXkiOnsiZGVzY3JpcHRpb24iOiJUaGlzIHBvZCBzaG91bGQgYmUgY28tbG9jYXRlZCAoYWZmaW5pdHkpIG9yIG5vdCBjby1sb2NhdGVkIChhbnRpLWFmZmluaXR5KSB3aXRoIHRoZSBwb2RzIG1hdGNoaW5nXG50aGUgbGFiZWxTZWxlY3RvciBpbiB0aGUgc3BlY2lmaWVkIG5hbWVzcGFjZXMsIHdoZXJlIGNvLWxvY2F0ZWQgaXMgZGVmaW5lZCBhcyBydW5uaW5nIG9uIGEgbm9kZVxud2hvc2UgdmFsdWUgb2YgdGhlIGxhYmVsIHdpdGgga2V5IHRvcG9sb2d5S2V5IG1hdGNoZXMgdGhhdCBvZiBhbnkgbm9kZSBvbiB3aGljaCBhbnkgb2YgdGhlXG5zZWxlY3RlZCBwb2RzIGlzIHJ1bm5pbmcuXG5FbXB0eSB0b3BvbG9neUtleSBpcyBub3QgYWxsb3dlZC4iLCJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJ0b3BvbG9neUtleSJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9fSwidHlwZSI6Im9iamVjdCJ9LCJwb2RBbnRpQWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJEZXNjcmliZXMgcG9kIGFudGktYWZmaW5pdHkgc2NoZWR1bGluZyBydWxlcyAoZS5nLiBhdm9pZCBwdXR0aW5nIHRoaXMgcG9kIGluIHRoZSBzYW1lIG5vZGUsIHpvbmUsIGV0Yy4gYXMgc29tZSBvdGhlciBwb2QocykpLiIsInByb3BlcnRpZXMiOnsicHJlZmVycmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJUaGUgc2NoZWR1bGVyIHdpbGwgcHJlZmVyIHRvIHNjaGVkdWxlIHBvZHMgdG8gbm9kZXMgdGhhdCBzYXRpc2Z5XG50aGUgYW50aS1hZmZpbml0eSBleHByZXNzaW9ucyBzcGVjaWZpZWQgYnkgdGhpcyBmaWVsZCwgYnV0IGl0IG1heSBjaG9vc2VcbmEgbm9kZSB0aGF0IHZpb2xhdGVzIG9uZSBvciBtb3JlIG9mIHRoZSBleHByZXNzaW9ucy4gVGhlIG5vZGUgdGhhdCBpc1xubW9zdCBwcmVmZXJyZWQgaXMgdGhlIG9uZSB3aXRoIHRoZSBncmVhdGVzdCBzdW0gb2Ygd2VpZ2h0cywgaS5lLlxuZm9yIGVhY2ggbm9kZSB0aGF0IG1lZXRzIGFsbCBvZiB0aGUgc2NoZWR1bGluZyByZXF1aXJlbWVudHMgKHJlc291cmNlXG5yZXF1ZXN0LCByZXF1aXJlZER1cmluZ1NjaGVkdWxpbmcgYW50aS1hZmZpbml0eSBleHByZXNzaW9ucywgZXRjLiksXG5jb21wdXRlIGEgc3VtIGJ5IGl0ZXJhdGluZyB0aHJvdWdoIHRoZSBlbGVtZW50cyBvZiB0aGlzIGZpZWxkIGFuZCBhZGRpbmdcblwid2VpZ2h0XCIgdG8gdGhlIHN1bSBpZiB0aGUgbm9kZSBoYXMgcG9kcyB3aGljaCBtYXRjaGVzIHRoZSBjb3JyZXNwb25kaW5nIHBvZEFmZmluaXR5VGVybTsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJUaGUgd2VpZ2h0cyBvZiBhbGwgb2YgdGhlIG1hdGNoZWQgV2VpZ2h0ZWRQb2RBZmZpbml0eVRlcm0gZmllbGRzIGFyZSBhZGRlZCBwZXItbm9kZSB0byBmaW5kIHRoZSBtb3N0IHByZWZlcnJlZCBub2RlKHMpIiwicHJvcGVydGllcyI6eyJwb2RBZmZpbml0eVRlcm0iOnsiZGVzY3JpcHRpb24iOiJSZXF1aXJlZC4gQSBwb2QgYWZmaW5pdHkgdGVybSwgYXNzb2NpYXRlZCB3aXRoIHRoZSBjb3JyZXNwb25kaW5nIHdlaWdodC4iLCJwcm9wZXJ0aWVzIjp7ImxhYmVsU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgYSBzZXQgb2YgcmVzb3VyY2VzLCBpbiB0aGlzIGNhc2UgcG9kcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciB0aGUgc2V0IG9mIG5hbWVzcGFjZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgc2VsZWN0ZWQgYnkgdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIGxpc3RlZCBpbiB0aGUgbmFtZXNwYWNlcyBmaWVsZC5cbm51bGwgc2VsZWN0b3IgYW5kIG51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi5cbkFuIGVtcHR5IHNlbGVjdG9yICh7fSkgbWF0Y2hlcyBhbGwgbmFtZXNwYWNlcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VzIjp7ImRlc2NyaXB0aW9uIjoibmFtZXNwYWNlcyBzcGVjaWZpZXMgYSBzdGF0aWMgbGlzdCBvZiBuYW1lc3BhY2UgbmFtZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgbGlzdGVkIGluIHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBzZWxlY3RlZCBieSBuYW1lc3BhY2VTZWxlY3Rvci5cbm51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IGFuZCBudWxsIG5hbWVzcGFjZVNlbGVjdG9yIG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJ0b3BvbG9neUtleSI6eyJkZXNjcmlwdGlvbiI6IlRoaXMgcG9kIHNob3VsZCBiZSBjby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGggdGhlIHBvZHMgbWF0Y2hpbmdcbnRoZSBsYWJlbFNlbGVjdG9yIGluIHRoZSBzcGVjaWZpZWQgbmFtZXNwYWNlcywgd2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlXG53aG9zZSB2YWx1ZSBvZiB0aGUgbGFiZWwgd2l0aCBrZXkgdG9wb2xvZ3lLZXkgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoIGFueSBvZiB0aGVcbnNlbGVjdGVkIHBvZHMgaXMgcnVubmluZy5cbkVtcHR5IHRvcG9sb2d5S2V5IGlzIG5vdCBhbGxvd2VkLiIsInR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInRvcG9sb2d5S2V5Il0sInR5cGUiOiJvYmplY3QifSwid2VpZ2h0Ijp7ImRlc2NyaXB0aW9uIjoid2VpZ2h0IGFzc29jaWF0ZWQgd2l0aCBtYXRjaGluZyB0aGUgY29ycmVzcG9uZGluZyBwb2RBZmZpbml0eVRlcm0sXG5pbiB0aGUgcmFuZ2UgMS0xMDAuIiwiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwicmVxdWlyZWQiOlsicG9kQWZmaW5pdHlUZXJtIiwid2VpZ2h0Il0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sInJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJJZiB0aGUgYW50aS1hZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgYXJlIG5vdCBtZXQgYXRcbnNjaGVkdWxpbmcgdGltZSwgdGhlIHBvZCB3aWxsIG5vdCBiZSBzY2hlZHVsZWQgb250byB0aGUgbm9kZS5cbklmIHRoZSBhbnRpLWFmZmluaXR5IHJlcXVpcmVtZW50cyBzcGVjaWZpZWQgYnkgdGhpcyBmaWVsZCBjZWFzZSB0byBiZSBtZXRcbmF0IHNvbWUgcG9pbnQgZHVyaW5nIHBvZCBleGVjdXRpb24gKGUuZy4gZHVlIHRvIGEgcG9kIGxhYmVsIHVwZGF0ZSksIHRoZVxuc3lzdGVtIG1heSBvciBtYXkgbm90IHRyeSB0byBldmVudHVhbGx5IGV2aWN0IHRoZSBwb2QgZnJvbSBpdHMgbm9kZS5cbldoZW4gdGhlcmUgYXJlIG11bHRpcGxlIGVsZW1lbnRzLCB0aGUgbGlzdHMgb2Ygbm9kZXMgY29ycmVzcG9uZGluZyB0byBlYWNoXG5wb2RBZmZpbml0eVRlcm0gYXJlIGludGVyc2VjdGVkLCBpLmUuIGFsbCB0ZXJtcyBtdXN0IGJlIHNhdGlzZmllZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkRlZmluZXMgYSBzZXQgb2YgcG9kcyAobmFtZWx5IHRob3NlIG1hdGNoaW5nIHRoZSBsYWJlbFNlbGVjdG9yXG5yZWxhdGl2ZSB0byB0aGUgZ2l2ZW4gbmFtZXNwYWNlKHMpKSB0aGF0IHRoaXMgcG9kIHNob3VsZCBiZVxuY28tbG9jYXRlZCAoYWZmaW5pdHkpIG9yIG5vdCBjby1sb2NhdGVkIChhbnRpLWFmZmluaXR5KSB3aXRoLFxud2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlIHdob3NlIHZhbHVlIG9mXG50aGUgbGFiZWwgd2l0aCBrZXkgXHUwMDNjdG9wb2xvZ3lLZXlcdTAwM2UgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoXG5hIHBvZCBvZiB0aGUgc2V0IG9mIHBvZHMgaXMgcnVubmluZyIsInByb3BlcnRpZXMiOnsibGFiZWxTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciBhIHNldCBvZiByZXNvdXJjZXMsIGluIHRoaXMgY2FzZSBwb2RzLiIsInByb3BlcnRpZXMiOnsibWF0Y2hFeHByZXNzaW9ucyI6eyJkZXNjcmlwdGlvbiI6Im1hdGNoRXhwcmVzc2lvbnMgaXMgYSBsaXN0IG9mIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50cy4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50IGlzIGEgc2VsZWN0b3IgdGhhdCBjb250YWlucyB2YWx1ZXMsIGEga2V5LCBhbmQgYW4gb3BlcmF0b3IgdGhhdFxucmVsYXRlcyB0aGUga2V5IGFuZCB2YWx1ZXMuIiwicHJvcGVydGllcyI6eyJrZXkiOnsiZGVzY3JpcHRpb24iOiJrZXkgaXMgdGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6InZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWNcbm1lcmdlIHBhdGNoLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJrZXkiLCJvcGVyYXRvciJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJtYXRjaExhYmVscyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJ0eXBlIjoic3RyaW5nIn0sImRlc2NyaXB0aW9uIjoibWF0Y2hMYWJlbHMgaXMgYSBtYXAgb2Yge2tleSx2YWx1ZX0gcGFpcnMuIEEgc2luZ2xlIHtrZXksdmFsdWV9IGluIHRoZSBtYXRjaExhYmVsc1xubWFwIGlzIGVxdWl2YWxlbnQgdG8gYW4gZWxlbWVudCBvZiBtYXRjaEV4cHJlc3Npb25zLCB3aG9zZSBrZXkgZmllbGQgaXMgXCJrZXlcIiwgdGhlXG5vcGVyYXRvciBpcyBcIkluXCIsIGFuZCB0aGUgdmFsdWVzIGFycmF5IGNvbnRhaW5zIG9ubHkgXCJ2YWx1ZVwiLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIm5hbWVzcGFjZVNlbGVjdG9yIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBxdWVyeSBvdmVyIHRoZSBzZXQgb2YgbmFtZXNwYWNlcyB0aGF0IHRoZSB0ZXJtIGFwcGxpZXMgdG8uXG5UaGUgdGVybSBpcyBhcHBsaWVkIHRvIHRoZSB1bmlvbiBvZiB0aGUgbmFtZXNwYWNlcyBzZWxlY3RlZCBieSB0aGlzIGZpZWxkXG5hbmQgdGhlIG9uZXMgbGlzdGVkIGluIHRoZSBuYW1lc3BhY2VzIGZpZWxkLlxubnVsbCBzZWxlY3RvciBhbmQgbnVsbCBvciBlbXB0eSBuYW1lc3BhY2VzIGxpc3QgbWVhbnMgXCJ0aGlzIHBvZCdzIG5hbWVzcGFjZVwiLlxuQW4gZW1wdHkgc2VsZWN0b3IgKHt9KSBtYXRjaGVzIGFsbCBuYW1lc3BhY2VzLiIsInByb3BlcnRpZXMiOnsibWF0Y2hFeHByZXNzaW9ucyI6eyJkZXNjcmlwdGlvbiI6Im1hdGNoRXhwcmVzc2lvbnMgaXMgYSBsaXN0IG9mIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50cy4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50IGlzIGEgc2VsZWN0b3IgdGhhdCBjb250YWlucyB2YWx1ZXMsIGEga2V5LCBhbmQgYW4gb3BlcmF0b3IgdGhhdFxucmVsYXRlcyB0aGUga2V5IGFuZCB2YWx1ZXMuIiwicHJvcGVydGllcyI6eyJrZXkiOnsiZGVzY3JpcHRpb24iOiJrZXkgaXMgdGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6InZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWNcbm1lcmdlIHBhdGNoLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJrZXkiLCJvcGVyYXRvciJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJtYXRjaExhYmVscyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJ0eXBlIjoic3RyaW5nIn0sImRlc2NyaXB0aW9uIjoibWF0Y2hMYWJlbHMgaXMgYSBtYXAgb2Yge2tleSx2YWx1ZX0gcGFpcnMuIEEgc2luZ2xlIHtrZXksdmFsdWV9IGluIHRoZSBtYXRjaExhYmVsc1xubWFwIGlzIGVxdWl2YWxlbnQgdG8gYW4gZWxlbWVudCBvZiBtYXRjaEV4cHJlc3Npb25zLCB3aG9zZSBrZXkgZmllbGQgaXMgXCJrZXlcIiwgdGhlXG5vcGVyYXRvciBpcyBcIkluXCIsIGFuZCB0aGUgdmFsdWVzIGFycmF5IGNvbnRhaW5zIG9ubHkgXCJ2YWx1ZVwiLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIm5hbWVzcGFjZXMiOnsiZGVzY3JpcHRpb24iOiJuYW1lc3BhY2VzIHNwZWNpZmllcyBhIHN0YXRpYyBsaXN0IG9mIG5hbWVzcGFjZSBuYW1lcyB0aGF0IHRoZSB0ZXJtIGFwcGxpZXMgdG8uXG5UaGUgdGVybSBpcyBhcHBsaWVkIHRvIHRoZSB1bmlvbiBvZiB0aGUgbmFtZXNwYWNlcyBsaXN0ZWQgaW4gdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIHNlbGVjdGVkIGJ5IG5hbWVzcGFjZVNlbGVjdG9yLlxubnVsbCBvciBlbXB0eSBuYW1lc3BhY2VzIGxpc3QgYW5kIG51bGwgbmFtZXNwYWNlU2VsZWN0b3IgbWVhbnMgXCJ0aGlzIHBvZCdzIG5hbWVzcGFjZVwiLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In0sInRvcG9sb2d5S2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhpcyBwb2Qgc2hvdWxkIGJlIGNvLWxvY2F0ZWQgKGFmZmluaXR5KSBvciBub3QgY28tbG9jYXRlZCAoYW50aS1hZmZpbml0eSkgd2l0aCB0aGUgcG9kcyBtYXRjaGluZ1xudGhlIGxhYmVsU2VsZWN0b3IgaW4gdGhlIHNwZWNpZmllZCBuYW1lc3BhY2VzLCB3aGVyZSBjby1sb2NhdGVkIGlzIGRlZmluZWQgYXMgcnVubmluZyBvbiBhIG5vZGVcbndob3NlIHZhbHVlIG9mIHRoZSBsYWJlbCB3aXRoIGtleSB0b3BvbG9neUtleSBtYXRjaGVzIHRoYXQgb2YgYW55IG5vZGUgb24gd2hpY2ggYW55IG9mIHRoZVxuc2VsZWN0ZWQgcG9kcyBpcyBydW5uaW5nLlxuRW1wdHkgdG9wb2xvZ3lLZXkgaXMgbm90IGFsbG93ZWQuIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsidG9wb2xvZ3lLZXkiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifX0sInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QifSwiaW1hZ2UiOnsidHlwZSI6InN0cmluZyJ9LCJpbWFnZVB1bGxTZWNyZXRzIjp7Iml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwidHlwZSI6ImFycmF5In0sImxpbWl0cyI6eyJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IlJhdGVMaW1pdCBkZWZpbmVzIHRoZSBkZXNpcmVkIExpbWl0YWRvciBsaW1pdCIsInByb3BlcnRpZXMiOnsiY29uZGl0aW9ucyI6eyJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJtYXhfdmFsdWUiOnsidHlwZSI6ImludGVnZXIifSwibmFtZSI6eyJ0eXBlIjoic3RyaW5nIn0sIm5hbWVzcGFjZSI6eyJ0eXBlIjoic3RyaW5nIn0sInNlY29uZHMiOnsidHlwZSI6ImludGVnZXIifSwidmFyaWFibGVzIjp7Iml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJjb25kaXRpb25zIiwibWF4X3ZhbHVlIiwibmFtZXNwYWNlIiwic2Vjb25kcyIsInZhcmlhYmxlcyJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJsaXN0ZW5lciI6eyJwcm9wZXJ0aWVzIjp7ImdycGMiOnsicHJvcGVydGllcyI6eyJwb3J0Ijp7ImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifX0sInR5cGUiOiJvYmplY3QifSwiaHR0cCI6eyJwcm9wZXJ0aWVzIjp7InBvcnQiOnsiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9LCJwZGIiOnsicHJvcGVydGllcyI6eyJtYXhVbmF2YWlsYWJsZSI6eyJhbnlPZiI6W3sidHlwZSI6ImludGVnZXIifSx7InR5cGUiOiJzdHJpbmcifV0sImRlc2NyaXB0aW9uIjoiQW4gZXZpY3Rpb24gaXMgYWxsb3dlZCBpZiBhdCBtb3N0IFwibWF4VW5hdmFpbGFibGVcIiBsaW1pdGFkb3IgcG9kc1xuYXJlIHVuYXZhaWxhYmxlIGFmdGVyIHRoZSBldmljdGlvbiwgaS5lLiBldmVuIGluIGFic2VuY2Ugb2ZcbnRoZSBldmljdGVkIHBvZC4gRm9yIGV4YW1wbGUsIG9uZSBjYW4gcHJldmVudCBhbGwgdm9sdW50YXJ5IGV2aWN0aW9uc1xuYnkgc3BlY2lmeWluZyAwLiBUaGlzIGlzIGEgbXV0dWFsbHkgZXhjbHVzaXZlIHNldHRpbmcgd2l0aCBcIm1pbkF2YWlsYWJsZVwiLiIsIngta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nIjp0cnVlfSwibWluQXZhaWxhYmxlIjp7ImFueU9mIjpbeyJ0eXBlIjoiaW50ZWdlciJ9LHsidHlwZSI6InN0cmluZyJ9XSwiZGVzY3JpcHRpb24iOiJBbiBldmljdGlvbiBpcyBhbGxvd2VkIGlmIGF0IGxlYXN0IFwibWluQXZhaWxhYmxlXCIgbGltaXRhZG9yIHBvZHMgd2lsbFxuc3RpbGwgYmUgYXZhaWxhYmxlIGFmdGVyIHRoZSBldmljdGlvbiwgaS5lLiBldmVuIGluIHRoZSBhYnNlbmNlIG9mXG50aGUgZXZpY3RlZCBwb2QuICBTbyBmb3IgZXhhbXBsZSB5b3UgY2FuIHByZXZlbnQgYWxsIHZvbHVudGFyeVxuZXZpY3Rpb25zIGJ5IHNwZWNpZnlpbmcgXCIxMDAlXCIuIiwieC1rdWJlcm5ldGVzLWludC1vci1zdHJpbmciOnRydWV9fSwidHlwZSI6Im9iamVjdCJ9LCJyYXRlTGltaXRIZWFkZXJzIjp7ImRlc2NyaXB0aW9uIjoiUmF0ZUxpbWl0SGVhZGVyc1R5cGUgZGVmaW5lcyB0aGUgdmFsaWQgb3B0aW9ucyBmb3IgdGhlIC0tcmF0ZS1saW1pdC1oZWFkZXJzIGFyZyIsImVudW0iOlsiTk9ORSIsIkRSQUZUX1ZFUlNJT05fMDMiXSwidHlwZSI6InN0cmluZyJ9LCJyZXBsaWNhcyI6eyJ0eXBlIjoiaW50ZWdlciJ9LCJyZXNvdXJjZVJlcXVpcmVtZW50cyI6eyJkZXNjcmlwdGlvbiI6IlJlc291cmNlUmVxdWlyZW1lbnRzIGRlc2NyaWJlcyB0aGUgY29tcHV0ZSByZXNvdXJjZSByZXF1aXJlbWVudHMuIiwicHJvcGVydGllcyI6eyJjbGFpbXMiOnsiZGVzY3JpcHRpb24iOiJDbGFpbXMgbGlzdHMgdGhlIG5hbWVzIG9mIHJlc291cmNlcywgZGVmaW5lZCBpbiBzcGVjLnJlc291cmNlQ2xhaW1zLFxudGhhdCBhcmUgdXNlZCBieSB0aGlzIGNvbnRhaW5lci5cblxuXG5UaGlzIGlzIGFuIGFscGhhIGZpZWxkIGFuZCByZXF1aXJlcyBlbmFibGluZyB0aGVcbkR5bmFtaWNSZXNvdXJjZUFsbG9jYXRpb24gZmVhdHVyZSBnYXRlLlxuXG5cblRoaXMgZmllbGQgaXMgaW1tdXRhYmxlLiBJdCBjYW4gb25seSBiZSBzZXQgZm9yIGNvbnRhaW5lcnMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJSZXNvdXJjZUNsYWltIHJlZmVyZW5jZXMgb25lIGVudHJ5IGluIFBvZFNwZWMuUmVzb3VyY2VDbGFpbXMuIiwicHJvcGVydGllcyI6eyJuYW1lIjp7ImRlc2NyaXB0aW9uIjoiTmFtZSBtdXN0IG1hdGNoIHRoZSBuYW1lIG9mIG9uZSBlbnRyeSBpbiBwb2Quc3BlYy5yZXNvdXJjZUNsYWltcyBvZlxudGhlIFBvZCB3aGVyZSB0aGlzIGZpZWxkIGlzIHVzZWQuIEl0IG1ha2VzIHRoYXQgcmVzb3VyY2UgYXZhaWxhYmxlXG5pbnNpZGUgYSBjb250YWluZXIuIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsibmFtZSJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSIsIngta3ViZXJuZXRlcy1saXN0LW1hcC1rZXlzIjpbIm5hbWUiXSwieC1rdWJlcm5ldGVzLWxpc3QtdHlwZSI6Im1hcCJ9LCJsaW1pdHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsiYW55T2YiOlt7InR5cGUiOiJpbnRlZ2VyIn0seyJ0eXBlIjoic3RyaW5nIn1dLCJwYXR0ZXJuIjoiXihcXCt8LSk/KChbMC05XSsoXFwuWzAtOV0qKT8pfChcXC5bMC05XSspKSgoW0tNR1RQRV1pKXxbbnVta01HVFBFXXwoW2VFXShcXCt8LSk/KChbMC05XSsoXFwuWzAtOV0qKT8pfChcXC5bMC05XSspKSkpPyQiLCJ4LWt1YmVybmV0ZXMtaW50LW9yLXN0cmluZyI6dHJ1ZX0sImRlc2NyaXB0aW9uIjoiTGltaXRzIGRlc2NyaWJlcyB0aGUgbWF4aW11bSBhbW91bnQgb2YgY29tcHV0ZSByZXNvdXJjZXMgYWxsb3dlZC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvY29uZmlndXJhdGlvbi9tYW5hZ2UtcmVzb3VyY2VzLWNvbnRhaW5lcnMvIiwidHlwZSI6Im9iamVjdCJ9LCJyZXF1ZXN0cyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJhbnlPZiI6W3sidHlwZSI6ImludGVnZXIifSx7InR5cGUiOiJzdHJpbmcifV0sInBhdHRlcm4iOiJeKFxcK3wtKT8oKFswLTldKyhcXC5bMC05XSopPyl8KFxcLlswLTldKykpKChbS01HVFBFXWkpfFtudW1rTUdUUEVdfChbZUVdKFxcK3wtKT8oKFswLTldKyhcXC5bMC05XSopPyl8KFxcLlswLTldKykpKSk/JCIsIngta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nIjp0cnVlfSwiZGVzY3JpcHRpb24iOiJSZXF1ZXN0cyBkZXNjcmliZXMgdGhlIG1pbmltdW0gYW1vdW50IG9mIGNvbXB1dGUgcmVzb3VyY2VzIHJlcXVpcmVkLlxuSWYgUmVxdWVzdHMgaXMgb21pdHRlZCBmb3IgYSBjb250YWluZXIsIGl0IGRlZmF1bHRzIHRvIExpbWl0cyBpZiB0aGF0IGlzIGV4cGxpY2l0bHkgc3BlY2lmaWVkLFxub3RoZXJ3aXNlIHRvIGFuIGltcGxlbWVudGF0aW9uLWRlZmluZWQgdmFsdWUuIFJlcXVlc3RzIGNhbm5vdCBleGNlZWQgTGltaXRzLlxuTW9yZSBpbmZvOiBodHRwczovL2t1YmVybmV0ZXMuaW8vZG9jcy9jb25jZXB0cy9jb25maWd1cmF0aW9uL21hbmFnZS1yZXNvdXJjZXMtY29udGFpbmVycy8iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In0sInN0b3JhZ2UiOnsiZGVzY3JpcHRpb24iOiJTdG9yYWdlIGNvbnRhaW5zIHRoZSBvcHRpb25zIGZvciBMaW1pdGFkb3IgY291bnRlcnMgZGF0YWJhc2Ugb3IgaW4tbWVtb3J5IGRhdGEgc3RvcmFnZSIsInByb3BlcnRpZXMiOnsiZGlzayI6eyJwcm9wZXJ0aWVzIjp7Im9wdGltaXplIjp7ImRlc2NyaXB0aW9uIjoiRGlza09wdGltaXplVHlwZSBkZWZpbmVzIHRoZSB2YWxpZCBvcHRpb25zIGZvciBcIm9wdGltaXplXCIgb3B0aW9uIG9mIHRoZSBkaXNrIHBlcnNpc3RlbmNlIHR5cGUiLCJlbnVtIjpbInRocm91Z2hwdXQiLCJkaXNrIl0sInR5cGUiOiJzdHJpbmcifSwicGVyc2lzdGVudFZvbHVtZUNsYWltIjp7InByb3BlcnRpZXMiOnsicmVzb3VyY2VzIjp7ImRlc2NyaXB0aW9uIjoiUmVzb3VyY2VzIHJlcHJlc2VudHMgdGhlIG1pbmltdW0gcmVzb3VyY2VzIHRoZSB2b2x1bWUgc2hvdWxkIGhhdmUuXG5JZ25vcmVkIHdoZW4gVm9sdW1lTmFtZSBmaWVsZCBpcyBzZXQiLCJwcm9wZXJ0aWVzIjp7InJlcXVlc3RzIjp7ImFueU9mIjpbeyJ0eXBlIjoiaW50ZWdlciJ9LHsidHlwZSI6InN0cmluZyJ9XSwiZGVzY3JpcHRpb24iOiJTdG9yYWdlIFJlc291cmNlIHJlcXVlc3RzIHRvIGJlIHVzZWQgb24gdGhlIFBlcnNpc3RlbnRWb2x1bWVDbGFpbS5cblRvIGxlYXJuIG1vcmUgYWJvdXQgcmVzb3VyY2UgcmVxdWVzdHMgc2VlOlxuaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvY29uZmlndXJhdGlvbi9tYW5hZ2UtcmVzb3VyY2VzLWNvbnRhaW5lcnMvIiwicGF0dGVybiI6Il4oXFwrfC0pPygoWzAtOV0rKFxcLlswLTldKik/KXwoXFwuWzAtOV0rKSkoKFtLTUdUUEVdaSl8W251bWtNR1RQRV18KFtlRV0oXFwrfC0pPygoWzAtOV0rKFxcLlswLTldKik/KXwoXFwuWzAtOV0rKSkpKT8kIiwieC1rdWJlcm5ldGVzLWludC1vci1zdHJpbmciOnRydWV9fSwicmVxdWlyZWQiOlsicmVxdWVzdHMiXSwidHlwZSI6Im9iamVjdCJ9LCJzdG9yYWdlQ2xhc3NOYW1lIjp7InR5cGUiOiJzdHJpbmcifSwidm9sdW1lTmFtZSI6eyJkZXNjcmlwdGlvbiI6IlZvbHVtZU5hbWUgaXMgdGhlIGJpbmRpbmcgcmVmZXJlbmNlIHRvIHRoZSBQZXJzaXN0ZW50Vm9sdW1lIGJhY2tpbmcgdGhpcyBjbGFpbS4iLCJ0eXBlIjoic3RyaW5nIn19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In0sInJlZGlzIjp7InByb3BlcnRpZXMiOnsiY29uZmlnU2VjcmV0UmVmIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifX0sInR5cGUiOiJvYmplY3QifSwicmVkaXMtY2FjaGVkIjp7InByb3BlcnRpZXMiOnsiY29uZmlnU2VjcmV0UmVmIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwib3B0aW9ucyI6eyJwcm9wZXJ0aWVzIjp7ImJhdGNoLXNpemUiOnsiZGVzY3JpcHRpb24iOiJCYXRjaFNpemUgZGVmaW5lcyB0aGUgc2l6ZSBvZiBlbnRyaWVzIHRvIGZsdXNoIGluIGFzIHNpbmdsZSBmbHVzaCBbZGVmYXVsdDogMTAwXSIsInR5cGUiOiJpbnRlZ2VyIn0sImZsdXNoLXBlcmlvZCI6eyJkZXNjcmlwdGlvbiI6IkZsdXNoUGVyaW9kIGZvciBjb3VudGVycyBpbiBtaWxsaXNlY29uZHMgW2RlZmF1bHQ6IDEwMDBdIiwidHlwZSI6ImludGVnZXIifSwibWF4LWNhY2hlZCI6eyJkZXNjcmlwdGlvbiI6Ik1heENhY2hlZCByZWZlcnMgdG8gdGhlIG1heGltdW0gYW1vdW50IG9mIGNvdW50ZXJzIGNhY2hlZCBbZGVmYXVsdDogMTAwMDBdIiwidHlwZSI6ImludGVnZXIifSwicmVzcG9uc2UtdGltZW91dCI6eyJkZXNjcmlwdGlvbiI6IlJlc3BvbnNlVGltZW91dCBkZWZpbmVzIHRoZSB0aW1lb3V0IGZvciBSZWRpcyBjb21tYW5kcyBpbiBtaWxsaXNlY29uZHMgW2RlZmF1bHQ6IDM1MF0iLCJ0eXBlIjoiaW50ZWdlciJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9LCJ0ZWxlbWV0cnkiOnsiZGVzY3JpcHRpb24iOiJUZWxlbWV0cnkgZGVmaW5lcyB0aGUgbGV2ZWwgb2YgbWV0cmljcyBMaW1pdGFkb3Igd2lsbCBleHBvc2UgdG8gdGhlIHVzZXIiLCJlbnVtIjpbImJhc2ljIiwiZXhoYXVzdGl2ZSJdLCJ0eXBlIjoic3RyaW5nIn0sInRyYWNpbmciOnsicHJvcGVydGllcyI6eyJlbmRwb2ludCI6eyJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJlbmRwb2ludCJdLCJ0eXBlIjoib2JqZWN0In0sInZlcmJvc2l0eSI6eyJkZXNjcmlwdGlvbiI6IlNldHMgdGhlIGxldmVsIG9mIHZlcmJvc2l0eSIsIm1heGltdW0iOjQsIm1pbmltdW0iOjEsInR5cGUiOiJpbnRlZ2VyIn0sInZlcnNpb24iOnsiZGVzY3JpcHRpb24iOiJbRGVwcmVjYXRlZF0gVXNlIHNwZWMuaW1hZ2UgaW5zdGVhZC5cbiBEb2NrZXIgdGFnIHVzZWQgYXMgbGltaXRhZG9yIGltYWdlLiBUaGUgcmVwbyBpcyBoYXJkY29kZWQgdG8gcXVheS5pby9rdWFkcmFudC9saW1pdGFkb3IiLCJ0eXBlIjoic3RyaW5nIn19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLXZhbGlkYXRpb25zIjpbeyJtZXNzYWdlIjoiZGlzayBzdG9yYWdlIGRvZXMgbm90IGFsbG93IG11bHRpcGxlIHJlcGxpY2FzIiwicnVsZSI6IighaGFzKHNlbGYuc3RvcmFnZSkgfHwgIWhhcyhzZWxmLnN0b3JhZ2UuZGlzaykpIHx8ICghaGFzKHNlbGYucmVwbGljYXMpIHx8IHNlbGYucmVwbGljYXMgXHUwMDNjIDIpIn1dfSwic3RhdHVzIjp7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yU3RhdHVzIGRlZmluZXMgdGhlIG9ic2VydmVkIHN0YXRlIG9mIExpbWl0YWRvciIsInByb3BlcnRpZXMiOnsiY29uZGl0aW9ucyI6eyJkZXNjcmlwdGlvbiI6IlJlcHJlc2VudHMgdGhlIG9ic2VydmF0aW9ucyBvZiBhIGZvbydzIGN1cnJlbnQgc3RhdGUuXG5Lbm93biAuc3RhdHVzLmNvbmRpdGlvbnMudHlwZSBhcmU6IFwiUmVhZHlcIiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQ29uZGl0aW9uIGNvbnRhaW5zIGRldGFpbHMgZm9yIG9uZSBhc3BlY3Qgb2YgdGhlIGN1cnJlbnQgc3RhdGUgb2YgdGhpcyBBUEkgUmVzb3VyY2UuXG4tLS1cblRoaXMgc3RydWN0IGlzIGludGVuZGVkIGZvciBkaXJlY3QgdXNlIGFzIGFuIGFycmF5IGF0IHRoZSBmaWVsZCBwYXRoIC5zdGF0dXMuY29uZGl0aW9ucy4gIEZvciBleGFtcGxlLFxuXG5cblx0dHlwZSBGb29TdGF0dXMgc3RydWN0e1xuXHQgICAgLy8gUmVwcmVzZW50cyB0aGUgb2JzZXJ2YXRpb25zIG9mIGEgZm9vJ3MgY3VycmVudCBzdGF0ZS5cblx0ICAgIC8vIEtub3duIC5zdGF0dXMuY29uZGl0aW9ucy50eXBlIGFyZTogXCJBdmFpbGFibGVcIiwgXCJQcm9ncmVzc2luZ1wiLCBhbmQgXCJEZWdyYWRlZFwiXG5cdCAgICAvLyArcGF0Y2hNZXJnZUtleT10eXBlXG5cdCAgICAvLyArcGF0Y2hTdHJhdGVneT1tZXJnZVxuXHQgICAgLy8gK2xpc3RUeXBlPW1hcFxuXHQgICAgLy8gK2xpc3RNYXBLZXk9dHlwZVxuXHQgICAgQ29uZGl0aW9ucyBbXW1ldGF2MS5Db25kaXRpb24gYGpzb246XCJjb25kaXRpb25zLG9taXRlbXB0eVwiIHBhdGNoU3RyYXRlZ3k6XCJtZXJnZVwiIHBhdGNoTWVyZ2VLZXk6XCJ0eXBlXCIgcHJvdG9idWY6XCJieXRlcywxLHJlcCxuYW1lPWNvbmRpdGlvbnNcImBcblxuXG5cdCAgICAvLyBvdGhlciBmaWVsZHNcblx0fSIsInByb3BlcnRpZXMiOnsibGFzdFRyYW5zaXRpb25UaW1lIjp7ImRlc2NyaXB0aW9uIjoibGFzdFRyYW5zaXRpb25UaW1lIGlzIHRoZSBsYXN0IHRpbWUgdGhlIGNvbmRpdGlvbiB0cmFuc2l0aW9uZWQgZnJvbSBvbmUgc3RhdHVzIHRvIGFub3RoZXIuXG5UaGlzIHNob3VsZCBiZSB3aGVuIHRoZSB1bmRlcmx5aW5nIGNvbmRpdGlvbiBjaGFuZ2VkLiAgSWYgdGhhdCBpcyBub3Qga25vd24sIHRoZW4gdXNpbmcgdGhlIHRpbWUgd2hlbiB0aGUgQVBJIGZpZWxkIGNoYW5nZWQgaXMgYWNjZXB0YWJsZS4iLCJmb3JtYXQiOiJkYXRlLXRpbWUiLCJ0eXBlIjoic3RyaW5nIn0sIm1lc3NhZ2UiOnsiZGVzY3JpcHRpb24iOiJtZXNzYWdlIGlzIGEgaHVtYW4gcmVhZGFibGUgbWVzc2FnZSBpbmRpY2F0aW5nIGRldGFpbHMgYWJvdXQgdGhlIHRyYW5zaXRpb24uXG5UaGlzIG1heSBiZSBhbiBlbXB0eSBzdHJpbmcuIiwibWF4TGVuZ3RoIjozMjc2OCwidHlwZSI6InN0cmluZyJ9LCJvYnNlcnZlZEdlbmVyYXRpb24iOnsiZGVzY3JpcHRpb24iOiJvYnNlcnZlZEdlbmVyYXRpb24gcmVwcmVzZW50cyB0aGUgLm1ldGFkYXRhLmdlbmVyYXRpb24gdGhhdCB0aGUgY29uZGl0aW9uIHdhcyBzZXQgYmFzZWQgdXBvbi5cbkZvciBpbnN0YW5jZSwgaWYgLm1ldGFkYXRhLmdlbmVyYXRpb24gaXMgY3VycmVudGx5IDEyLCBidXQgdGhlIC5zdGF0dXMuY29uZGl0aW9uc1t4XS5vYnNlcnZlZEdlbmVyYXRpb24gaXMgOSwgdGhlIGNvbmRpdGlvbiBpcyBvdXQgb2YgZGF0ZVxud2l0aCByZXNwZWN0IHRvIHRoZSBjdXJyZW50IHN0YXRlIG9mIHRoZSBpbnN0YW5jZS4iLCJmb3JtYXQiOiJpbnQ2NCIsIm1pbmltdW0iOjAsInR5cGUiOiJpbnRlZ2VyIn0sInJlYXNvbiI6eyJkZXNjcmlwdGlvbiI6InJlYXNvbiBjb250YWlucyBhIHByb2dyYW1tYXRpYyBpZGVudGlmaWVyIGluZGljYXRpbmcgdGhlIHJlYXNvbiBmb3IgdGhlIGNvbmRpdGlvbidzIGxhc3QgdHJhbnNpdGlvbi5cblByb2R1Y2VycyBvZiBzcGVjaWZpYyBjb25kaXRpb24gdHlwZXMgbWF5IGRlZmluZSBleHBlY3RlZCB2YWx1ZXMgYW5kIG1lYW5pbmdzIGZvciB0aGlzIGZpZWxkLFxuYW5kIHdoZXRoZXIgdGhlIHZhbHVlcyBhcmUgY29uc2lkZXJlZCBhIGd1YXJhbnRlZWQgQVBJLlxuVGhlIHZhbHVlIHNob3VsZCBiZSBhIENhbWVsQ2FzZSBzdHJpbmcuXG5UaGlzIGZpZWxkIG1heSBub3QgYmUgZW1wdHkuIiwibWF4TGVuZ3RoIjoxMDI0LCJtaW5MZW5ndGgiOjEsInBhdHRlcm4iOiJeW0EtWmEtel0oW0EtWmEtejAtOV8sOl0qW0EtWmEtejAtOV9dKT8kIiwidHlwZSI6InN0cmluZyJ9LCJzdGF0dXMiOnsiZGVzY3JpcHRpb24iOiJzdGF0dXMgb2YgdGhlIGNvbmRpdGlvbiwgb25lIG9mIFRydWUsIEZhbHNlLCBVbmtub3duLiIsImVudW0iOlsiVHJ1ZSIsIkZhbHNlIiwiVW5rbm93biJdLCJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOnsiZGVzY3JpcHRpb24iOiJ0eXBlIG9mIGNvbmRpdGlvbiBpbiBDYW1lbENhc2Ugb3IgaW4gZm9vLmV4YW1wbGUuY29tL0NhbWVsQ2FzZS5cbi0tLVxuTWFueSAuY29uZGl0aW9uLnR5cGUgdmFsdWVzIGFyZSBjb25zaXN0ZW50IGFjcm9zcyByZXNvdXJjZXMgbGlrZSBBdmFpbGFibGUsIGJ1dCBiZWNhdXNlIGFyYml0cmFyeSBjb25kaXRpb25zIGNhbiBiZVxudXNlZnVsIChzZWUgLm5vZGUuc3RhdHVzLmNvbmRpdGlvbnMpLCB0aGUgYWJpbGl0eSB0byBkZWNvbmZsaWN0IGlzIGltcG9ydGFudC5cblRoZSByZWdleCBpdCBtYXRjaGVzIGlzIChkbnMxMTIzU3ViZG9tYWluRm10Lyk/KHF1YWxpZmllZE5hbWVGbXQpIiwibWF4TGVuZ3RoIjozMTYsInBhdHRlcm4iOiJeKFthLXowLTldKFstYS16MC05XSpbYS16MC05XSk/KFxcLlthLXowLTldKFstYS16MC05XSpbYS16MC05XSk/KSovKT8oKFtBLVphLXowLTldWy1BLVphLXowLTlfLl0qKT9bQS1aYS16MC05XSkkIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsibGFzdFRyYW5zaXRpb25UaW1lIiwibWVzc2FnZSIsInJlYXNvbiIsInN0YXR1cyIsInR5cGUiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkiLCJ4LWt1YmVybmV0ZXMtbGlzdC1tYXAta2V5cyI6WyJ0eXBlIl0sIngta3ViZXJuZXRlcy1saXN0LXR5cGUiOiJtYXAifSwib2JzZXJ2ZWRHZW5lcmF0aW9uIjp7ImRlc2NyaXB0aW9uIjoiT2JzZXJ2ZWRHZW5lcmF0aW9uIHJlZmxlY3RzIHRoZSBnZW5lcmF0aW9uIG9mIHRoZSBtb3N0IHJlY2VudGx5IG9ic2VydmVkIHNwZWMuIiwiZm9ybWF0IjoiaW50NjQiLCJ0eXBlIjoiaW50ZWdlciJ9LCJzZXJ2aWNlIjp7ImRlc2NyaXB0aW9uIjoiU2VydmljZSBwcm92aWRlcyBpbmZvcm1hdGlvbiBhYm91dCB0aGUgc2VydmljZSBleHBvc2luZyBsaW1pdGFkb3IgQVBJIiwicHJvcGVydGllcyI6eyJob3N0Ijp7InR5cGUiOiJzdHJpbmcifSwicG9ydHMiOnsicHJvcGVydGllcyI6eyJncnBjIjp7ImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifSwiaHR0cCI6eyJmb3JtYXQiOiJpbnQzMiIsInR5cGUiOiJpbnRlZ2VyIn19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJzZXJ2ZWQiOnRydWUsInN0b3JhZ2UiOnRydWUsInN1YnJlc291cmNlcyI6eyJzdGF0dXMiOnt9fX1dfSwic3RhdHVzIjp7ImFjY2VwdGVkTmFtZXMiOnsia2luZCI6IiIsInBsdXJhbCI6IiJ9LCJjb25kaXRpb25zIjpudWxsLCJzdG9yZWRWZXJzaW9ucyI6bnVsbH19
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsiYWxtLWV4YW1wbGVzIjoiW1xuICB7XG4gICAgXCJhcGlWZXJzaW9uXCI6IFwibGltaXRhZG9yLmt1YWRyYW50LmlvL3YxYWxwaGExXCIsXG4gICAgXCJraW5kXCI6IFwiTGltaXRhZG9yXCIsXG4gICAgXCJtZXRhZGF0YVwiOiB7XG4gICAgICBcIm5hbWVcIjogXCJsaW1pdGFkb3Itc2FtcGxlXCJcbiAgICB9LFxuICAgIFwic3BlY1wiOiB7XG4gICAgICBcImxpbWl0c1wiOiBbXG4gICAgICAgIHtcbiAgICAgICAgICBcImNvbmRpdGlvbnNcIjogW1xuICAgICAgICAgICAgXCJnZXRfdG95ID09ICd5ZXMnXCJcbiAgICAgICAgICBdLFxuICAgICAgICAgIFwibWF4X3ZhbHVlXCI6IDIsXG4gICAgICAgICAgXCJuYW1lXCI6IFwidG95X2dldF9yb3V0ZVwiLFxuICAgICAgICAgIFwibmFtZXNwYWNlXCI6IFwidG95c3RvcmUtYXBwXCIsXG4gICAgICAgICAgXCJzZWNvbmRzXCI6IDMwLFxuICAgICAgICAgIFwidmFyaWFibGVzXCI6IFtdXG4gICAgICAgIH1cbiAgICAgIF0sXG4gICAgICBcImxpc3RlbmVyXCI6IHtcbiAgICAgICAgXCJncnBjXCI6IHtcbiAgICAgICAgICBcInBvcnRcIjogODA4MVxuICAgICAgICB9LFxuICAgICAgICBcImh0dHBcIjoge1xuICAgICAgICAgIFwicG9ydFwiOiA4MDgwXG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9XG4gIH1cbl0iLCJjYXBhYmlsaXRpZXMiOiJCYXNpYyBJbnN0YWxsIiwiY2F0ZWdvcmllcyI6IkludGVncmF0aW9uIFx1MDAyNiBEZWxpdmVyeSIsImNvbnRhaW5lckltYWdlIjoicmVnaXN0cnkucmVkaGF0LmlvL3JoY2wtMS9saW1pdGFkb3ItcmhlbDktb3BlcmF0b3JAc2hhMjU2OmIzMWJhMjkzODEyNzg4ZGM3ZTIxYzE0NzAzYWM2MWZkZDViZmYwMTA5NDhhZGEzMzcxNTU0NGJhNTA3ODUxZjciLCJjcmVhdGVkQXQiOiIyMyBTZXAgMjAyNSwgMTI6MTkiLCJkZXNjcmlwdGlvbiI6IkVuYWJsZXMgcmF0ZSBsaW1pdGluZyBmb3IgR2F0ZXdheXMgYW5kIGFwcGxpY2F0aW9ucyBpbiBhIEdhdGV3YXkgQVBJIG5ldHdvcmsiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2NuZiI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby9jbmkiOiJmYWxzZSIsImZlYXR1cmVzLm9wZXJhdG9ycy5vcGVuc2hpZnQuaW8vY3NpIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2Rpc2Nvbm5lY3RlZCI6InRydWUiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2ZpcHMtY29tcGxpYW50IjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Byb3h5LWF3YXJlIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Rscy1wcm9maWxlcyI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby90b2tlbi1hdXRoLWF3cyI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby90b2tlbi1hdXRoLWF6dXJlIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Rva2VuLWF1dGgtZ2NwIjoiZmFsc2UiLCJvcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3ZhbGlkLXN1YnNjcmlwdGlvbiI6IltcIlJlZCBIYXQgQ29ubmVjdGl2aXR5IExpbmtcIl0iLCJvcGVyYXRvcnMub3BlcmF0b3JmcmFtZXdvcmsuaW8vYnVpbGRlciI6Im9wZXJhdG9yLXNkay12MS4zMi4wIiwib3BlcmF0b3JzLm9wZXJhdG9yZnJhbWV3b3JrLmlvL3Byb2plY3RfbGF5b3V0IjoiZ28ua3ViZWJ1aWxkZXIuaW8vdjMiLCJyZXBvc2l0b3J5IjoiaHR0cHM6Ly9naXRodWIuY29tL2t1YWRyYW50L2xpbWl0YWRvci1vcGVyYXRvciIsInN1cHBvcnQiOiJrdWFkcmFudCJ9LCJsYWJlbHMiOnsib3BlcmF0b3JmcmFtZXdvcmsuaW8vb3MubGludXgiOiJzdXBwb3J0ZWQifSwibmFtZSI6ImxpbWl0YWRvci1vcGVyYXRvci52MS4xLjEiLCJuYW1lc3BhY2UiOiJwbGFjZWhvbGRlciJ9LCJzcGVjIjp7ImFwaXNlcnZpY2VkZWZpbml0aW9ucyI6e30sImN1c3RvbXJlc291cmNlZGVmaW5pdGlvbnMiOnsib3duZWQiOlt7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yIGlzIHRoZSBTY2hlbWEgZm9yIHRoZSBsaW1pdGFkb3JzIEFQSSIsImRpc3BsYXlOYW1lIjoiTGltaXRhZG9yIiwia2luZCI6IkxpbWl0YWRvciIsIm5hbWUiOiJsaW1pdGFkb3JzLmxpbWl0YWRvci5rdWFkcmFudC5pbyIsInZlcnNpb24iOiJ2MWFscGhhMSJ9XX0sImRlc2NyaXB0aW9uIjoiVGhlIExpbWl0YWRvciBvcGVyYXRvciBpbnN0YWxscyBhbmQgbWFpbnRhaW5zIGxpbWl0YWRvciBpbnN0YW5jZXMiLCJkaXNwbGF5TmFtZSI6IkxpbWl0YWRvciIsImljb24iOlt7ImJhc2U2NGRhdGEiOiJpVkJPUncwS0dnb0FBQUFOU1VoRVVnQUFBWHdBQUFGOENBWUFBQURNNXdES0FBQUFDWEJJV1hNQUFHNjZBQUJ1dWdIVzNyRVhBQUFnQUVsRVFWUjRuTzNkZjJ6VDE3My84VGNRbDhRRTI4T0FETVVrc0lrb0lWbmNhRlNEUmpmNWE1cGEzWkpxZjFTcjdsZGswdjRvdXQ4Sjc0K3BXeldKSU8xMlEvc25hSnJhUHlZVmRMOXF0VCttaG43VmFkby9KVmZRVG1OcUhTV0FFcTJRa0FJV0VHb2JFNXZhbFB1SEU2QWRGSC9PT1o5Zi9qd2ZValhwWG81OVZLa3ZIODU1bi9kWmNmZnVYUUVBTkw2VmJrOEFBT0FNQWg4QUFvTEFCNENBSVBBQklDQUlmQUFJQ0FJZkFBS0N3QWVBZ0NEd0FTQWdDSHdBQ0lnbXR5ZlFxTHE2dXZwWHJWcjFuVkFvTkxCeTVjcHZORGMzZDZ4YXRhcFpSQ1FhamNiY25oL2d0bncrbnhNUnVYUG5UcmxjTGs5LzhjVVhuMVVxbGZFN2QrNzg0K3pac3lmZG5sOGpXa0ZyQlgwOVBUM3BWYXRXZmIrbHBlVmJMUzB0bTF0YlcxdmNuaFBnZDhWaXNWUXFsUzdmdm4xN3NsS3BqRTlPVG82NlBTZS9JL0F0NnV6c2JIdmlpU2RlWHIxNjlmZGJXMXM3Q0hmQU9jVmlzVlFzRnFkdjM3NzlsODgvLy95TmMrZk96Yms5Sno4aDhPdlEzZDM5WW5OejgvNUlKUEkwQVE5NFI3RllMQlVLaGIrWHkrWFhwNmFtL3VqMmZMeU93SCtFN3U3dUY4UGg4TTlqc1ZoM2MzTXpaeDJBeDVYTDVXb3VsNXRhWEZ6OERlSC9jQVQrQTdxNnV2ckQ0ZkN2MXExYjl3d2hEL2hYdVZ5dTNyaHg0OVRpNHVJdk9RQytqOEFYa1ZRcTlZZG9OUG9EcW1lQXhwUFA1M1A1ZlA1UG1Vem14MjdQeFcyQkRmek96czYyTld2V0hHTTFEd1REOHFyLzFxMWIrNEo2MkJ1NHdPL3E2dXB2YlczOTNmcjE2M3VibXBwV3VEMGZBTTZxVnF0M3IxKy9QbEVzRm44U3RPMmV3QVIrVjFkWGZ6UWFQYnBodzRadnVqMFhBTjV3N2RxMVQvTDUvSEJRZ3IvaEEzOTU2MmJ6NXMwRGJzOEZnRGRkdm54NVBBaGJQUTBkK0gxOWZlOGtFb205Yk4wQWVKeHF0WG8zbTgwZS8raWpqMTV3ZXk1MmFjakE3K25wU1cvYXRPbTNYajJNclZRcVVpZ1VIdnIvVzFoWWNIZzJnSDNpOGZoRC8rK1JTRVJDb1pERHM2bFB1Vnl1WHJseTVXZU4yTXFob1FLL3M3T3pMUjZQLzIzZHVuVUp0K2RTS0JSa2NYRlJDb1dDNVBQNWV5RmZxVlRjbmhyZ0dhRlE2Rjc0UjZOUmlVUWlFZzZISlJLSnVEMDF1WEhqUm5aaFllRzdqYlROMHpDQjcrYjJUYWxVa3V2WHI5OExkMWJwZ0w1NFBIN3ZSMkQ5K3ZYUzB1SjhWNU5HMitieGZlQjNkbmEyYmR5NE1lUDBwYWxzTmlzTEN3dVN6V1psY1hIUnlhOEdBaWtjRGtzaWtaQjRQQzZKaExOL2ljL244N21yVjYrbS9MN2E5M1hnOS9iMi92ckpKNTk4eFlsVmZhVlNrV3cyZSs4ZkFPNUtKQkwzL25IaVBLQmFyZDY5ZE9uUzRZbUppVi9ZL21VMjhXWGdkM1oydHExZHUzWXNrVWlrN1A2dTVZQ2ZuNSszKzZzQUtFb21rL2ZDMzI3WmJEWno4K2JOSVQrdTluMFgrRjFkWGYySlJPS3ZkcllwcmxRcWN1SENCWm1mbjJlN0J2Q1JjRGdzeVdSU3RtM2JadXVxdjFnc2xyTFo3UGY4ZG1ITFY0RnY5eFpPcVZTUzZlbHBWdk5BQTBnbWs5TFIwV0hiWWE4ZnQzaDhFL2g5ZlgzdmJObXlaY2lPejE1WVdKRHo1OCt6Tnc4MG9FUWlJZHUzYjMva25RQmRuMzc2NlpoZnFuaDhFZmk3ZCsvK3B4MDljRXFsa256ODhjZVVVUUlCRUkvSDVhbW5uckpseFgvdDJyVlBQdnp3dzI4Wi8yRERQQjM0ZHBWY1Zpb1ZPWFBtREZzM1FBQWxrMG5adVhPbjhUMStQNVJ1ZWpid096czcyelp0Mm5UTzlPSHN6TXlNbkQ5L25odXZRSUNGUWlIWnZuMjc3Tml4dytqbkZvdkYwcFVyVnpxOUd2cWVEUHlubjM3NjI2MnRyWDh6R2ZZTEN3c3lOVFgxeUI0MkFJSW5Fb2xJZDNlMzBmMTlMNGUrNXdLL3U3djd4YTFidDc1dHFoS25VcW5jVzlVRHdNTXNyL1pOYmZOVXE5VzdGeTllL0tIWEhsUDNWT0NiRHZ0Q29TQ25UNSttbGg3QVk0WERZZG0xYTVleHhtMWVESDNQQlA2V0xWdSsvZTF2Znp0akt1eG5abVprZW5yYXhFY0JDSkNPamc1amUvdlZhdlh1aFFzWHRubGxlOGNUZ1cveWdMWlNxY2pwMDZjcHRRU2dMQjZQeTY1ZHU0eHM4WGhwVDkvMXdEY1o5b1ZDUVQ3NDRBTXFjQUJvQzRWQ3NtZlBIaU5iUEY0Si9aVnVmcm1JeU1hTkd6TW13bjUrZmw3R3g4Y0pld0JHVkNvVkdSOGZOM0pmcDdXMXRXWGp4bzBaQTlQUzRtcmc3OTY5KzU4bUxsWE56TXhJSnVQNnYwc0FEU2lUeWNqTXpJejI1MFNqMGRqdTNidi9hV0JLeWx3TC9MNit2bmRNdEV2SVpESWN6Z0t3MWZUMHRKRkY1WVlORzc3WjE5ZjNqb0VwS1hFbDhIdDdlMyt0MndpdFVxbElKcE9oUFFJQVI4elB6MHNtazlIZU50NnlaY3RRYjIvdnJ3MU55eExIRDIyN3VycjYyOXZiLzBlbi9MSlNxY2dISDN6QXJWa0Fqb3RFSXJKbnp4NnRDcDVxdFhwM2RuYjIzNXp1cCsvb0NyK3pzN010a1VqOGxiQUg0RmNtcWdHYm1wcFdKQktKdjNaMmRyWVpuTnBqT1JyNGE5ZXVIZE9weUNIc0FYaUJpZEJ2YlcxdFdidDI3WmpCYVQyV1k0SGYyOXY3YTkwM2FNK2NPVVBZQS9DRVFxRWdaODZjMGZxTVJDS1JjbkkvMzVFOS9NN096clp0MjdaZDBObks0WUFXZ0JjbGswbEpwZFRYc2s2MlgzQmtoYjl4NDBhdEhqa3pNek9FUFFCUG1wK2YxNnJUYjJwcVd1SFVwU3piQTcrdnIrOGRuY3RWOC9QejFOa0Q4TFRwNldtdFJXazBHbzA1VVo5dmErQXZWZVhzVlIxZktCUzRRUXZBRnpLWmpOWVpZeUtSMkd0MzFZNnRnUitQeC8rbXVwV3pYSkVEQUg2aFU3blQxTlMwSWg2UC84M3dsTDdFdHNEdjZlbEpyMXUzTHFFNi92VHAwelJDQStBcnkrM1pWYTFidHk3UjA5T1ROamlsTDdFdDhEZHQydlJiMWJFek16UDBzd2ZnU3dzTEMxcUh1RHJaK1RpMkJINWZYOTg3emMzTlRTcGpDNFVDaDdRQWZHMTZlbHA1UDcrNXVibkpyZ05jNDRHdmMxQ3IrOWNoQVBBS25XMXB1dzV3alFmK21qVnJqcWtlMU03TXpQRGdPSUNHc0xpNHFMeTEwOVRVdEdMTm1qWEhERS9KYk9CM2RYWDFiOTY4ZVVCbDdNTENncHcvZjk3a2RBREFWZWZQbjFjK2o5eThlZk5BVjFkWHY4bjVHQTM4YURSNlZIWHMxTlNVd1prQWdEZm9aSnRPcGo2TXNjRHY2dXJxVjMzQmFtWm1ocVpvQUJwU29WQlEzdHJac0dIRE4wMnU4bzBGZm10cjYrOVV4bFVxRmJaeUFEUzA4K2ZQS3gvZ3FtYnJ3eGdKL003T3pyYjE2OWYzcW93OWMrWU1GNndBTkxSS3BhTGNTbm45K3ZXOXBpcDJqQVMrYW1WT3FWU2lDeWFBUUppZm41ZFNxV1I1bk1tS0hTT0J2MjdkdW1kVXhuMzg4Y2Ntdmg0QWZFRTE4MVF6OXF1MEF6K1ZTdjFCNVZidHdzSUM3Uk1BQklwcTdqVTNOemVsVXFrLzZINi9kdUJIbzlFZnFJempvQlpBRUtsbW4ycldQa2dyOEx1NnV2cFZIamNwbFVxU3pXWjF2aG9BZkNtYnpTcnQ1VWVqMFpodWlhWlc0SWZENFYrcGpLTTVHb0FnVTgxQTFjeGRwaFg0S2djSmxVcUZ5aHdBZ1RZL1A2OVVqcTU3ZUtzYytOM2QzUytxSE5aZXVIQkI5U3NCb0dHb1pHRnpjM05UZDNmM2k2cmZxUno0NFhENDV5cmpXTjBEZ0hvV3FtYXZpRWJneDJLeGJxdGpzdGtzN1k4QlFHcnRrMVdLVjFTeWQ1bFM0S3R1NTFDWkF3RDNxV1NpenJhT1V1QTNOemZ2dHpxR3cxb0ErRExWdzF1VkRCWlJEUHhJSlBLMDFUR3M3Z0hnWDZsa28wb0dpeWdFZm1kbloxdHJhMnVMMVhFRVBnRDhLNVZzYkcxdGJWSHBvR2s1OEo5NDRvbVhyWTRSSWZBQjRHRlVzMUVsaXkwSC91clZxNzl2ZFF4aER3Q1BwcEtSS2xsc09mQmJXMXM3ckk2aEt5WUFQSnBLUnFwa3NVcmdzMzhQQUFhcDd1TmJIV01wOEh0NmV0Sld2NkJVS25IWkNnQyt4dUxpb2xJSFRhdVpiQ253VzFwYUxPOFpYYjkrM2VvUUFBZ2NsYXdNaFVJRFZ2NjhwY0JmdFdyVnQ2eE5SNlJRS0ZnZEFnQ0JvNUtWcTFldjdySHk1NjJ1OERkYm00NUlQcCszT2dRQUFrY2xLNjFtc3FYQVZ6a2tvRUlIQUI1UHNWTEhVaWJYSGZncVQydXhuUU1BOVZQSlRDdlpYSGZncjFxMTZqdFdKMEoxRGdEVVR5VXpyV1J6M1lGdjlUUlloQlUrQUZpaGtwbFdzcm51d0YrNWN1VTNyRTZFQTFzQXFKOUtabHJKNXJvRHY3bTUyZkkxWHBVK3p3QVFWSXE5OGV2T1ppdDcrTTFXSjhLV0RnRFVUeVV6cldTejhwdTI5V0NGRHdEMXN6c3o2dzc4YURRYXMvTEJoRDBBV0djMU82MWtzMjByZkxaekFNQTZPN1BUMWkwZEFJQjNFUGdBRUJBRVBnQUVCSUVQQUFGUlYrQS8vL3p6N1ZZL21Db2RBSERHaWhVcjJ1djVjM1VGL3J2dnZqdHJkUUpVNlFDQWRTcnRGZTdldlR0Yno1OWpTd2NBUEtSYXJkcjIyUVErQUFRRWdROEFBVUhnQTBCQUVQZ0FFQkFFUGdBRUJJRVBBQUZCNEFOQVFCRDRBQkFRQkQ0QUJBU0JEd0FCUWVBRFFFQVErQUFRRUFRK0FBUUVnUThBQVVIZ0EwQkFFUGdBRUJBRVBnQUVCSUVQQUFGQjRBTkFRQkQ0QUJBUUJENEFCRVNUMnhPQW5sZ3NKcWxVeXUxcGFEdHg0b1NyMzk4aklsRlhaK0I5a3lLU2Qzc1MwRUxnKzFRc0ZwUFIwVkhadDIrZjIxTXhZbTV1VGtaR1J1VG8wYU9PZnU5ekl2S2FpQ1FkL1ZiL2VsdEVYaFdDMzYvWTB2R2hXQ3dtSjA2Y2FKaXdGeEZwYTJ1VE45OTgwOUhBZjBWRS9sc0lleXQrS0NML1gvamJrRjhSK0Q0ME5qWW12YjI5YmsvREZ2djI3Wk9ob1NIYnYrYzVxUVUrck9zV2tmL245aVNnaE1EM21hR2hJUmtZR0hCN0dyWWFIUjIxL1R0ZXMvMGJHdHN6VXZ2UmhMOFErRDZ5dkcvZjZOcmEybVJ3Y05DMnozOUYyTVl4Z1I5Ti95SHdmU1NkVGt0Ylc1dmIwL0MxcUlqc2Qzc1NEU0lwYkl2NURZSHZFKzN0N1pKT3A5MmVodSs5SmlJUnR5ZlJRUGFMeUZhM0o0RzZFZmcrTVRJeUl0RW90UkU2K3FWV1pRSnpJc0lxMzA4SWZCOFlIQnhzcUJMTXg1bWJtN1BsSWhiQlpJOGZTdTNIRk41SDRQdkF5TWlJMjFOd2xCMWJWeTlKcmJJRTl1REgxQjhJZkk4YkhoNXUrRExNQngwN2Rrekd4c2FNZm1aVUNDUzdQU08xSDFWNEc0SHZZVUVwd3hTcGJlTzg4TUlMTWp3OGJQeXpYeGJLTUozd21uQUQxK3ZvcGVOaDZYUmErYUQyUnovNmtjek96cHFka0kzc2FwNjJWZFRMTUUrSnlHR0RjL0dMSGhINUw0VnhFYW45dUFieDM1bGZFUGdlMWQ3ZUxnY1BIbFFhT3o0KzduZ1RNcS9TS2NOOFZXb2RJb1BtcElnOEsycG5IcTlJcmNIYVJhTXpnaWxzNlhpVXpsYU9IZHNpZnRRdnRlQlM4WVlFTSt5WC9hZkdXRzdnZWhlQjcwR0RnNE95ZCs5ZXBiRkhqaHp4MVZhT25WU0RweUJzUzF5VTJvK2VpbWVGTWsydkl2QTlTSFYxbjgvbkExZkMrU2d2U2Eycm80ckRRcjkza2RxL2g0TGlXRmI1M2tUZ2UwdzZuVlp1ZlR3eU1pSzVYTTd3alB3bkt1cUJNeThpcnh1Y2k1L2xSZjF2T3QxQ3p5SXZJdkE5SkJhTEthL1FKeVltQWxQQytUaXZpUHBCcmM3ZWRTTjZYVVNtRk1lK0lwUnBlZzJCN3lFNi9YSm9yRmF6VldxbGdTcE9TYTFDQlYvMnF1STQrdXg0RDRIdkVlM3Q3WExnd0FHbHNjZVBIM2Y5RVhDditMM0dXRmIzRDNkU1JQNnNPUFpsb1p1bWx4RDRIcUZUTjgvcXZxWmYxUHZsSEJacXg3K082aXBmUk85SEdHWVIrQjZnODJ6aG9VT0hLTU5jb2hvc0JWRXZRUXlLaTZKK2dQdU1VS2JwRlFTK0IraVVZWEpRVzdOZjFQdmx2Q3FVWWRiakRWRXYwMlNWN3cwRXZzdEdSa2FVbnkxTXA5T1VZWXBlTjh3cEVYbkw0RndhV1Y3VXQzWjREdEViQ0h3WHhXSXg1ZjEzK3VYY3A5c3ZCL1Y3UzJyVlRDcjJDMldhYmlQd1hUUTZPcXBjaHNtTjJwb2VVWCsyOEcyaERGT0Y2bDUrUkxpQjZ6WUMzeVdwVkVyNTJjSmp4NDVSaHJtRWZqbk9PeW0xSDBzVlA1VGFqelRjUWVDN2hINDUrcDRUOVRMTTE0VXlUQjMwMmZFbkF0OEZPczhXam82T1VvYTVSS2RmRG1XWWVpNktlcytoWjZUMll3M25FZmdPMCttWE16YzN4K3AreVN1aVhvWkpOMHd6M3BEYWo2Y0tua04wQjRIdnNIUTZyVldHQ2YxbkN5bkRORU8zVEZPMTV4SFVFZmdPYW05djF5ckRIQnNiTXp3amY5THBoa2tacGxudmlWNlpKbjEybkVYZ080aHVtUHI2UmE4TU04alBGdHFGYnByK1FlQTdaSEJ3VUtzTU01UEpHSjZSUDZrR1JFRlkzZHRsVXZUS05PbXo0eHdDM3lFNlpaaXM3bXRlRXIweVRBNXE3Zk9xVUticEJ3UytBNGFIaDNtMlVKUHVzNFZjc3JKWFh0VExOTHVsOW1NTyt4SDROb3ZGWXNxcis3bTVPYnBoTG5sWk9LajF1c05DbWFiWEVmZzJTNmZUeWdlMXc4UERaaWZqVTF0RmZlLytsTlFxU2VBTTFWZkRJa0tacGhNSWZCdTF0N2ZMd1lNSGxjYU9qNC9UTDJlSnpoNHZ6eFk2NjZTb2wybStJcFJwMm8zQXQ1SE9kZ3lyKzVwK0VYbFdjZXdiUXI4Y04rajh5SEtBYXk4QzN5YURnNE95ZCs5ZXBiRkhqaHloWDg0U3VtSDZ6MFZSNzFYMHJGQ21hU2NDM3lhcWo1UFFEZk8rL1ZLcjRGQkJ2eHgzNlhUVDVEbEUreEQ0TnREdGwwTVpwdDZ6aGZPaVhpSUlNM1Q3N0tqMlNzTFhJL0FOMCttR09URXh3Yk9GUzNUNjVYQlE2dzF2U2UzTllCV3ZDR1dhZGlEd0RhTmZqcjZ0b2w2aTkyZmgyVUl2b2MrT3R4RDRCcVZTS1RsdzRJRFMyT1BIajFPR3VVUm5ENWRMVnQ1eVVtby93aXBlRnNvMFRTUHdEZElwdzJSMVg5TXY2djF5RGd0bG1GNms4eVBNQWE1WkJMNGhRME5EeXM4V0hqcDBpRExNSmFyL2dSZUVad3U5NnFLb2w4anlIS0paQkw0aDlNdlJwL05zNGF0Q0dhYVg2VDZIQ0RNSWZBTkdSa2FVeXpEcGhsa1RGWjR0YkdSNVVWL2xKNFVEWEZNSWZFMnhXRXpyMlVMS01HdGVFL1V5VEc3VStzTmJvdmNjSW1XYStnaDhUYU9qbzhwbG1OeW9yZWtSdldjTEtjUDBEOVVmNTRpd3RXTUNnYTlCOTlsQ3lqQnI2SmNUSENkRjd6bkVIb056Q1NJQ1g0UHFDcDErT2ZjOUozclBGbEtHNlQ4NmZYWlk1ZXNoOEJVTkR3OHJsMkdPam81U2hpbjZ6eFpTaHVsUEYwVzkxOUV6d25PSU9naDhCVHI5Y3VibTVsamRMM2xaS01NTUtwM25FT216bzQ3QVY2RGJEUk8xSy9NNlpaZzhXK2gvT3QwMGVRNVJEWUZ2VVh0N3UxWVo1dGpZbU9FWitaTk9OMHo2NVRTRzkwU3ZUSk0rTzlZUitCYnBsR0d5dXEvcEY3MHl6RW1EYzdGYkxCYVR3Y0ZCR1JrWmtjSEJRV2x2YjNkN1NwNmkwMDJUQTF6ckNId0xkSjh0ekdReWhtZmtUenBsbUg1WjNjZGlNVGw2OUtoODl0bG44djc3Nzh2Qmd3ZmwvZmZmbHdzWExzaUpFeWNJL2lXVHduT0lUaUx3TFZEdGVVTVo1bjB2aWZxemhhK0xQdzVxMjl2YlpYWjI5cEYzTkFZR0JpU1R5VWdxbFhKNFp0NUVtYVp6Q1B3NkRROFBTMjl2cjlKWSt1WFU2SlpoK3VXUzFkalkyR08zL2FMUnFJeU5qVWtzRm5Ob1Z0NmwwMmVuV3lqVHRJTEFyNU5PR1NiZE1HdGVrc1ovdHRES3dxQ3RyVTJHaDRmdG5aQlB2QzU2Wlpxb0Q0RmZoOEhCUWVVeVRQNkR2dTlaeFhHbnhCLzljbUt4bU9VZjk2R2hJWnRtNHorcVArcEpZUysvWGdTK2pjYkh4K21YOHdEVkZncCtXZDJydkdlc2VsdTdFWjBVOVRKTkxtTFZoOENIcDcwaC91aVgwOTdlcnZ5ZU1lQVVBcjhPcWdldUF3TURNamc0YUhZeVBtWjE5ZWFuYnBpcTd4cU1qNCtibllpUDZieG43SWRGZ1JjUStIWElaREl5Tnplbk5KWUhUdTc3czhVL2YxajhVWVk1T0Rpb3ZEWER6ZXY3Vk44em5oZC9YY1p6RTRGZko5VXFuYmEyTm03WUxubEw2cS9FbUJMMWpvcE9VLzFSeitmekxBaVc3QmYxUm5wKytWdWdGeEQ0ZFRwNjlLaE1URXdvalIwWkdhSGVXbXFyOWYrUXgxK3lLU3o5T1QvUWJhVEgvWXphZ2F0cWFlV1U4SjZ4RlFTK0Jhb3I5V2cweWszYkpaTWk4bS95NlAzOHQwV2tWL3l4SjZ2VEpwdjNqTytqa1o1ekNId0xUcHc0SWNlUEgxY2FlK0RBQWE3U0w3a29Jdjh1SWlrUmVWNUUvdS9TLzI2VFdnbW1IL2J0UlhqUDJJUWVVVzkxL0dmeHgvME1MeUh3TFVxbjA1TFBxMFVTTjI2LzdLTFUvb045YStsLy9STDBJaUtwVklyM2pBMElRaU05THlId0xacWRuVlVPN29HQkFXNVdOZ2dhNmVualBXUG5FZmdLUmtkSGxjczBXZVg3MzlEUUVPOFpHOEI3eHM0ajhCWGtjam10TWsxV2VQNmwwaTluR1kzMDdudEY5TW93L2JUOTV5VUV2cUtqUjQ4cTM1Sk1wOU04Z09GVGxHSHEwMzNQbURKTWRRUytCdFdWT21XYS9zUjd4bVpRaHVrZUFsL0RpUk1uNU5peFkwcGo5KzNiUjU4ZG4xSHBocm1NMjlZMVFYclAySXNJZkUwNlpacXM4djFqY0hCUXF3eVQ5NHhyVkcvVVVvWnBCb0d2S1pmTGFaVnA4a0NLUDZqK09PZnplVmIzUzE0U3ZUSk1EbXIxRWZnR2pJeU1LSmRwMG1mSCs0YUhoN1hLTURtbzFldVg0NmYzakwyT3dEZEVkUlZITjAxdjB5M0RaTnV1NW1WUkw4TmtLOGNjQXQrUXNiRXg1VExOZ3djUFVxYnBVZWwwV3ZtZ2x1MjZtcTJpdnJvL0pTTHZHWnhMMEJINEJ1bXMxTG1RNHozdDdlMXk4T0JCcGJHOFozeWY2bzFhRWYrOFord1hCTDVCbVV4R2podzVvalIyNzk2OWxHbDZqTTZQTUt2N21uNFJlVlp4ckYvZU0vWVRBdCt3a1pFUnVtazJnTUhCUWRtN2Q2L1MyQ05IanRBdlo0bE9OMHdPYXMwajhBM1Q2YlBUMjl2THl0QWo2SWFwN3lVUjZWWWNTNzhjZXhENE50RHRwa21acHJ2UzZiVDA5dllxajZVTXMxYUdxZE1OMHkvdkdmc05nVzhUMVpVNmZYYmNwZk5zNGNURUJNOFdMdEhwbDhOQnJYMElmSnZvUG9kSW1hWTc2SmVqYjZ2d2JLRlhFZmcyMGdrQVZvck9hMjl2bHdNSERpaU5QWDc4T0dXWVMzNnZNWlpMVnZZaThHMDBPenNyaHc0ZFVobzdNREJBbWFiRGRINWtXZDNYOUl0NnY1ekRRaG1tM1FoOG00Mk9qaXFYYWJMS2Q0N09zNFdIRGgyaURIT0o2dXErSUR4YjZBUUMzMmE1WEk0K096N0FzNFg2OW90ZXZ4ektNTzFINER2ZzZOR2pNakV4b1RTV2JwcjJHeGtaVVg2MmNHUmtoREpNMGV1R09TVThXK2dVQXQ4aHFpdjFhRFRLQ3RKR3NWaE02OWxDdHQxcVhoT2VMZlFEQXQ4aHVzOGhwbElwd3pPQ1NHMHJSN1VNay9zU05UMmk5MndoWlpqT0lmQWRSSjhkYjBtbFVsclBGbEtHV1VPL0hQOGc4QjAwT3p1cjlSemkwTkNRNFJrRkcvMXk5RDBuZXM4V1VvYnBMQUxmWWJwOWRtQ0c3ck9GbEdIcTk4dWhETk41Qkw3RGRMcHB0clcxc2JJMFFLZGZEczhXM3FmN2JDRmxtTTRqOEYxdzlPaFI1ZWNRMCtrMGZYWTBwZE5wNVRKTTdrWFViSlZhM2IwS25pMTBENEh2RXAweVRWYVk2dHJiMjdYS01NZkd4Z3pQeUo5MHVtRlNodWtlQXQ4bG1VeEdxMHlUUGp0cTZJYXByMS8weWpBbkRjNEYxaEQ0TGtxbjA4cGxtcXp5clJzY0hOUXF3OHhrTW9abjVFK3FOMm9Md3VyZWJRUytpM0s1bkZhWkpzOGhXcU5UaHNucXZ1WWwwU3ZENUtEV1hRUyt5MFpHUm5nTzBRSER3OFBLenhiU0w2ZEd0d3lUUzFidUkvQTlRT2NBbDVYbjQ4VmlNYnBoR3ZDeThHeWgzeEg0SGpBMk5xWmNwbm53NEVIS05COGpuVTRySDlTeWJWYXpWZFQzN2s4Si9YSzhnc0QzQ0oxZ1lRWDZhTzN0N1hMdzRFR2xzZVBqNC9UTFdhSzZsU1BDNnQ1TENIeVBtSjJkbFNOSGppaU4zYnQzTDJXYWo2RFR2cGpWZlUyL2lEeXJPUFlOb1YrT2x4RDRIa0kzVGJNR0J3ZDV0dEFBdW1FMkRnTGZRM1Q2N1BUMjluS0EreFdxcS90OFBzOFA2Skw5SXRLdE9QYXdVSWJwTlFTK3g0eU9qdkljb2dHNi9YSW93OVIvdHZCMWczT0JHUVMrQjlGblI0OU9OOHlKaVFtZUxWeEN2NXpHUStCNzBJa1RKK1Q0OGVOS1l3OGNPQkQ0TWszNjVlamJLclc2ZXhWL0Zzb3d2WXJBOXlpZDRBbnlDaldWU3NtQkF3ZVV4aDQvZnB3eXpDVy8xeGpMNnQ2N210eWVBQjV1ZG5aV0RoMDZwRlJEdnR4bko0aFZKcXBiT1hiM3krbTM3WlBONnhIMWZqbUhoVEpNTHlQd1BXeDBkRlQ1bHVpYmI3NXB3NHdhbDEzUEZqNG50YkpHMVplaC9LUWdQRnZvZFd6cGVGZ3VsMk5QMlFGMjljdjV2WWo4dHdRajdFVjR0dEFQQ0h5UDAza09FZld4b3h2bWM2TCtTSWdmblJLUnQ5eWVCQjZMd1BjQlNpM3RNejQrYnNzaHQwN3ZHVC9pUnEwL0VQZytjT0xFQ2VYbkVQSDE3UGd4N1pmZ2JPT0kxSjR0cEF6VEh3aDhuOURwczRPSE8zYnNHR1dZbXVpWDR5OEV2ay9NenM3UzM4VWduaTAwNDNXaEROTlBDSHdmR1IwZFZYNE9FVjgyT2pwS3Z4eE5QRnZvUHdTK2oxQ21hY2JjM0p5dEIrRW5wUmFHalk0YnRmNUQ0UHVNem5PSXFISGlSN1BSdy9DVWlMem45aVJnR1lIdlEwTkRROG90bElQdXB6LzlxWXlOamRuK1BlOUpyWHFsRVUySnlIKzRQUWtvSWZCOUtKZkx5ZURnb1BLVGlFRTBOemNuTDd6d2dxTUgzLzhwSXY5SEdtdDc1MjBSK1hmaFJxMWYwVXZIcDViMzgwZEdSaVNWU3JrOUhVL0w1WEtTeVdSYytlNzNsdjdwa2RxREluNDJLUVM5M3hINFBwZkw1YWdsOTRGSnR5Y0FDRnM2QUJBWUJENEFCQVNCRHdBQlFlQURRRUFRK0FBUUVBUStBQVFFZ1E4QUFVSGdBMEJBRVBnQUVCQUVQZ0FFQklFUEFBRkI0QU5BUUJENEFCQVFCRDRBQkFTQkR3QUJRZUFEUUVBUStBQVFFQVErQUFRRWdROEFBVUhnQTBCQUVQZ0FFQkFFUGdBRWhHMkJINGxFN1Bwb0FHaFk4WGpjOHBqbm4zKyt2WjQvWjF2Z2gwSWh1ejRhQVBDQWQ5OTlkN2FlUDhlV0RnQUVCSUVQQUFGQjRBTkFRQkQ0QUJBUVZPa0FnSWZZbVoxMUIzNCtuODlaK1dDcWRBREFPcXZaYVNXYmJkM1NJZlFCb0g1MloyYmRnWC9uenAyeTFROW5Xd2NBNnFlU21WYXl1ZTdBTDVmTDAxWW53Z29mQU9xbmtwbFdzcm51d1AvaWl5OCtzenFSYURScWRRZ0FCSlpLWmxySjVyb0R2MUtwakZ1ZENGczZBRkEvbGN5MGtzMVc5dkQvWVhVaTRYRFk2aEFBQ0N5VnpMU1N6WFVIL3RtelowOWFuUWdyZkFDb24wcG1Xc2xtUzJXWnhXS3haSFV5S3EwK0FTQm9WTExTYWlaYkN2eFNxWFRaMm5RNHVBV0FlcWhrcGRWTXRocjQvN1EySGJaMUFLQWVLbGw1Ky9idFNTdC8zbExnMzdsejV5L1dwaU95ZnYxNnEwTUFJSEJVc3RKcTlhU2x3SitjbkJ5MU5oMlJscFlXcW5VQTRHdUV3MkZwYVdteFBNNXFKbHZ1cGFOeWNKdElKS3dPQVlEQVVNbElsU3hXQ1h6TExSYW8xQUdBUjFPczBMR2N4WllELy9idDI1YjM4Vm5oQThDanFXU2tTaFpiRHZ6UFAvLzhEYXRqUkFoOUFIZ1kxV3hVeVdMTGdYL3UzTGs1OXZFQndBelYvZnR6NTg3TldSMm45QUJLb1ZENHU5VXhCRDRBL0N1VmJGVEpZQkhGd0MrWHk2OWJIUk1LaFNTWlRLcDhIUUEwcEdReXFkb0QzM0lHaXlnRy90VFUxQi9MNVhMVjZqaFcrUUJ3bjBvbWxzdmw2dFRVMUI5VnZrLzVUZHRjTGpkbGRVd2lrZUFTRmdCSTdiS1ZTdUNyWk84eTVjQmZYRno4amNvNHRuVUFRRDBMVmJOWFJDUHdWYmQxdG0zYnB2cVZBTkF3VkxKUVp6dEhSQ1B3UlVSdTNMaHh5dW9ZRG04QkJKM3FZYTFLNWo1SUsvQVhGeGQvcVRLdW82TkQ1MnNCd05kVU0xQTFjNWRwQmY3WnMyZFA1dlA1bk5WeExTMHRWT3dBQ0tSRUlxSFVHVE9meitkVW5wcDlrRmJnTDAzaVR5cmp0bS9mcnZ2VkFPQTdxdG1ubXJVUDBnNzhUQ2J6WTVYRDIzZzhUaGROQUlHaW1udmxjcm1heVdSK3JQdjkyb0V2b242UThOUlRUNW40ZWdEd0JkWE0wejJzWFdZazhHL2R1cld2V3EzZXRUcXVwYVdGaWgwQWdaQk1KcFgyN3F2VjZ0MWJ0Mjd0TXpFSEk0Ri83dHk1dWV2WHIwK29qTjI1YzZkU2VSSUErRVVvRkpLZE8zY3FqYjErL2ZxRVNtZk1oekVTK0NJaXhXTHhKeXJqUXFFUUI3Z0FHdHIyN2R1VkY3YXEyZEw3SzFRQUFBZ0dTVVJCVlBvd3hnTC83Tm16SjY5ZHUvYUp5dGdkTzNaSUpCSXhOUlVBOEl4SUpDSTdkdXhRR252dDJyVlBkRXN4SDJRczhFVkU4dm44c09yWTd1NXVnek1CQUcvUXlUYWRUSDBZbzRGLzl1elprNWN2WHg1WEdSdVB4OW5hQWRCUXRtL2ZybHgrZnZueTVYR1RxM3NSdzRFdm9sNnhJMUxiMnFGOU1vQkdFQTZIbGJkeVRGYm1QTWg0NEo4N2QyNHVtODBlVnhrYkNvVmsxNjVkcHFjRUFJN2J0V3VYOGtGdE5wczlicW95NTBIR0ExOUU1S09QUG5wQjVmYXRTTzJBZytacUFQeXNvNk5EdVJDbFhDNVhQL3Jvb3hjTVQwbEViQXA4RVpFclY2NzhUSFhzamgwN2FMc0F3SmZpOGJqeVZvNklYblkram0yQlB6azVPWHJqeG8yczZuaWR2dzRCZ0J0MHQ2VnYzTGlSblp5Y0hEVTRwUyt4TGZCRlJCWVdGcjZyZW9BYkNvVmt6NTQ5cHFjRUFMYlpzMmVQOGtLMVdxM2VYVmhZK0s3aEtYMkpyWUd2YzRBclV0dlBUNlZTSnFjRUFMWklwVkphRjBqdE9xaDlrSzJCTDFJN3dGVjVKR1ZaTXBua0VCZUFwM1YwZEdnMWdzem44em03RG1vZlpIdmdpNGhjdlhvMXBicTFJMUk3eEtXckpnQXZTaWFUV29lMDFXcjE3dFdyVngzWnluQWs4TStkT3pkMzZkS2x3enFma1VxbENIMEFucEpNSnJXM25TOWR1blRZN3EyY1pZNEV2b2pJeE1URUw3TFpiRWJuTTNidTNFbVROUUNlRUlsRWxGc2VMOHRtczVtSmlZbGZHSnJTWXprVytDSWlOMi9lSENvV2l5WFY4Y3VWTzRRK0FEZEZJaEd0aWh3UmtXS3hXTHA1OCthUXdXazlscU9CdjFTMTh6MmQvWHhDSDRDYlRJUjl0VnE5bTgxbXYrZlVWczR5UndOZnBOWlJVM2MvZnpuMDJkTUg0S1JrTXFrZDlpSzFmWHZUblREcnNlTHVYZVhGdHBhK3ZyNTN0bXpab3YzWG1Vd21JL1B6OHlhbUJBQ1BaT0tBVmtUazAwOC9IWE9pQlBOaFhBdDhFWkhkdTNmL2M4T0dEZC9VL1p5Wm1SbVpucDQyTVNVQStCY2RIUjFhcFpmTHJsMjc5c21ISDM3NExRTlRVdUpxNEl1SURBd01mQmFOUm1PNm56TS9QeStaakZZUkVBRDhDMU1sNGZsOFBqYytQdjROQTFOUzV2Z2UvbGRkdlhvMXBWTzVzeXlaVE1yQXdBQU4xd0FZRVFxRlpHQmd3RWpZRjR2RmtsT1hxNzZPNnl0OEVaSE96czYyVFpzMm5XdHRiVzNSL2F4S3BTS25UNStXaFlVRkUxTURFRUR4ZU54WXg5NWlzVmk2Y3VWS3A5TVZPUS9qaWNBWHFZWCt0bTNiTGpRMU5hMHc4WG5zNndOUVlXcS9YcVJXZm5uaHdvVnRYZ2g3RVE4RnZvaElkM2YzaTF1M2JuM2JWT2dYQ2dVNWZmcTBMQzR1bXZnNEFBMHNIQTdMcmwyN2pOM3hxVmFyZHk5ZXZQakRxYW1wUHhyNVFBTThGZmdpNWtPL1Vxbkl6TXlNbkQ5LzNzVEhBV2hBMjdkdmx4MDdkaGc3QS9SaTJJdDRNUEJGek83cEwxdFlXSkNwcVNrcEZBcW1QaEtBejBVaUVlbnU3amI2cEtxWDl1eS95cE9CTDJKUDZJdkl2ZFYrcFZJeCtiRUFmQ1FVQ3QxYjFadms1YkFYOFhEZ2k5UkNmK1BHalJrVGRmb1BxbFFxY3ViTUdXN29BZ0dVVENabDU4NmR4a3U0OC9sODd1clZxeW12aHIySXh3Ti9tYWtidVY5VktwWGs0NDgvcG9RVENJQjRQQzVQUGZXVXRMUVkzVFFRRWZkdjBOYkxGNEV2WXE3M3pzTXNMQ3pJK2ZQbkpadk4ydkh4QUZ5VVNDUmsrL2J0UnZmcEgrUm1ieHlyZkJQNElpSzl2YjIvZnZMSkoxOHhWY0h6VmFWU1NhYW5wOW5xQVJyQThudllkcXpvUldxVk9KY3VYVHJzNUFNbXVud1YrQ0lpWFYxZC9ZbEU0cSttRDNNZlZLbFU1TUtGQ3pJL1AwOE5QK0FqNFhCWWtzbWtiTnUyemRZMks4VmlzWlROWnIvblJvdGpIYjRMZkpIYVllN2F0V3ZIRW9tRTdiMHBzdG1zWkxOWlZ2MkFoeVdUU1Vra0VwSklKR3ovcm13Mm03bDU4K2FRbHc5bkg4V1hnYi9NN2kyZUIxVXFsWHZoejE0LzRMN2xnRThrRW80MFRmVGpGczVYK1Ryd1Jld3IzWHljYkRZckN3c0xrczFtMmZZQkhCQU9oeVdSU0VnOEhuZGtKZjhnUDVSYzFzUDNnYitzcjYvdm5VUWlzZGVKMWY1WGxVb2x1WDc5dWhRS0Jjbm44NVI1QWdiRTQzR0pScU1TaVVSay9mcjF0aDIrZnAybHQyZVArNlVLNTNFYUp2QkZhcXY5ZUR6K3QzWHIxam43OC84UWhVSkJGaGNYNy8wSVZDb1ZLUlFLM1BBRkhoQUtoU1FTaVVnb0ZMb1g3dUZ3MkZnRE14MDNidHpJTGl3c2ZOZnZxL29ITlZUZ0wrdnA2VWx2MnJUcHQ4M056VTF1eitWUkh2VzNBUDUyZ0VieXFOcjM1WkQzb25LNVhMMXk1Y3JQSmljblI5MmVpMmtOR2ZqTDNOem1BZUF2amJaOTh6QU5IZmdpdFcyZU5XdldITnU4ZWZPQTIzTUI0RTJYTDE4ZXYzWHIxcjVHMnI1NW1JWVAvR1ZkWFYzOTBXajBxQjA5ZVFENDA3VnIxejdKNS9QRGZydEFwU293Z2Irc3E2dXJ2N1cxOVhmcjE2L3ZaYXNIQ0o1cXRYcjMrdlhyRThWaThTZEJDZnBsZ1F2OFpjdGJQZXZXclh2R3k0ZTdBTXdvbDh2Vkd6ZHVuQXJDMXMyakJEYndINVJLcGY0UWpVWi80UFRsTFFEMnkrZnp1WHcrLzZkTUp2Tmp0K2ZpTmdML0FWMWRYZjNoY1BoWHJQb0JmMXRlelM4dUx2NHlhTnMyWDRmQWY0VHU3dTRYdytId3oyT3hXRGZoRDNoZnVWeXU1bks1cWNYRnhkOTQ3ZkZ3cnlEdzY5RGQzZjFpYzNQei9rZ2s4clNkYlprQldGTXNGa3VGUXVIdjVYTDVkVUwrOFFoOGl6bzdPOXVlZU9LSmwxZXZYdjM5MXRiV0RuNEFBT2NVaThWU3NWaWN2bjM3OWw4Ky8venpONEo2K0txS3dEZWdwNmNuSFFxRkJsYXZYdDNUMHRLeW1SOEJRRit4V0N5VlNxWEx0Mi9mbnF4VUt1T04yT3JBYVFTK1RicTZ1dnBYclZyMW5WQW9OTEJ5NWNwdk5EYzNkNnhhdGFwWlJJUnFJS0JXUFNNaWN1Zk9uWEs1WEo3KzRvc3ZQcXRVS3VOMzd0ejVCd2V0OWlEd0FTQWdWcm85QVFDQU13aDhBQWdJQWg4QUFvTEFCNENBSVBBQklDQUlmQUFJQ0FJZkFBS0N3QWVBZ0NEd0FTQWcvaGZuYUh3a3pmaTdnZ0FBQUFCSlJVNUVya0pnZ2c9PSIsIm1lZGlhdHlwZSI6ImltYWdlL3BuZyJ9XSwiaW5zdGFsbCI6eyJzcGVjIjp7ImNsdXN0ZXJQZXJtaXNzaW9ucyI6W3sicnVsZXMiOlt7ImFwaUdyb3VwcyI6WyIiXSwicmVzb3VyY2VzIjpbImNvbmZpZ21hcHMiLCJwZXJzaXN0ZW50dm9sdW1lY2xhaW1zIiwic2VjcmV0cyIsInNlcnZpY2VzIl0sInZlcmJzIjpbImNyZWF0ZSIsImRlbGV0ZSIsImdldCIsImxpc3QiLCJ1cGRhdGUiLCJ3YXRjaCJdfSx7ImFwaUdyb3VwcyI6WyIiXSwicmVzb3VyY2VzIjpbInBvZHMiXSwidmVyYnMiOlsibGlzdCIsInVwZGF0ZSIsIndhdGNoIl19LHsiYXBpR3JvdXBzIjpbImFwcHMiXSwicmVzb3VyY2VzIjpbImRlcGxveW1lbnRzIl0sInZlcmJzIjpbImNyZWF0ZSIsImRlbGV0ZSIsImdldCIsImxpc3QiLCJ1cGRhdGUiLCJ3YXRjaCJdfSx7ImFwaUdyb3VwcyI6WyJsaW1pdGFkb3Iua3VhZHJhbnQuaW8iXSwicmVzb3VyY2VzIjpbImxpbWl0YWRvcnMiXSwidmVyYnMiOlsiY3JlYXRlIiwiZGVsZXRlIiwiZ2V0IiwibGlzdCIsInBhdGNoIiwidXBkYXRlIiwid2F0Y2giXX0seyJhcGlHcm91cHMiOlsibGltaXRhZG9yLmt1YWRyYW50LmlvIl0sInJlc291cmNlcyI6WyJsaW1pdGFkb3JzL2ZpbmFsaXplcnMiXSwidmVyYnMiOlsidXBkYXRlIl19LHsiYXBpR3JvdXBzIjpbImxpbWl0YWRvci5rdWFkcmFudC5pbyJdLCJyZXNvdXJjZXMiOlsibGltaXRhZG9ycy9zdGF0dXMiXSwidmVyYnMiOlsiZ2V0IiwicGF0Y2giLCJ1cGRhdGUiXX0seyJhcGlHcm91cHMiOlsicG9saWN5Il0sInJlc291cmNlcyI6WyJwb2RkaXNydXB0aW9uYnVkZ2V0cyJdLCJ2ZXJicyI6WyJjcmVhdGUiLCJkZWxldGUiLCJnZXQiLCJsaXN0IiwidXBkYXRlIiwid2F0Y2giXX1dLCJzZXJ2aWNlQWNjb3VudE5hbWUiOiJsaW1pdGFkb3Itb3BlcmF0b3ItY29udHJvbGxlci1tYW5hZ2VyIn1dLCJkZXBsb3ltZW50cyI6W3sibGFiZWwiOnsiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9LCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciIsInNwZWMiOnsicmVwbGljYXMiOjEsInNlbGVjdG9yIjp7Im1hdGNoTGFiZWxzIjp7ImNvbnRyb2wtcGxhbmUiOiJjb250cm9sbGVyLW1hbmFnZXIifX0sInN0cmF0ZWd5Ijp7fSwidGVtcGxhdGUiOnsibWV0YWRhdGEiOnsibGFiZWxzIjp7ImFwcCI6ImxpbWl0YWRvci1vcGVyYXRvciIsImNvbnRyb2wtcGxhbmUiOiJjb250cm9sbGVyLW1hbmFnZXIifX0sInNwZWMiOnsiY29udGFpbmVycyI6W3siYXJncyI6WyItLWxlYWRlci1lbGVjdCJdLCJjb21tYW5kIjpbIi9tYW5hZ2VyIl0sImVudiI6W3sibmFtZSI6IlJFTEFURURfSU1BR0VfTElNSVRBRE9SIiwidmFsdWUiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOUBzaGEyNTY6OTQ3MWFhZGNlMWExN2FhY2IxYmY2NTNiNzVlMGQ3OTI0ZjhmOWUxNDQ5NTQ0NDBlMGQ5YzliZTZmZDQzMmU4YyJ9XSwiaW1hZ2UiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOS1vcGVyYXRvckBzaGEyNTY6YjMxYmEyOTM4MTI3ODhkYzdlMjFjMTQ3MDNhYzYxZmRkNWJmZjAxMDk0OGFkYTMzNzE1NTQ0YmE1MDc4NTFmNyIsImxpdmVuZXNzUHJvYmUiOnsiaHR0cEdldCI6eyJwYXRoIjoiL2hlYWx0aHoiLCJwb3J0Ijo4MDgxfSwiaW5pdGlhbERlbGF5U2Vjb25kcyI6MTUsInBlcmlvZFNlY29uZHMiOjIwfSwibmFtZSI6Im1hbmFnZXIiLCJwb3J0cyI6W3siY29udGFpbmVyUG9ydCI6ODA4MCwibmFtZSI6Im1ldHJpY3MifV0sInJlYWRpbmVzc1Byb2JlIjp7Imh0dHBHZXQiOnsicGF0aCI6Ii9yZWFkeXoiLCJwb3J0Ijo4MDgxfSwiaW5pdGlhbERlbGF5U2Vjb25kcyI6NSwicGVyaW9kU2Vjb25kcyI6MTB9LCJyZXNvdXJjZXMiOnsibGltaXRzIjp7ImNwdSI6IjIwMG0iLCJtZW1vcnkiOiIzMDBNaSJ9LCJyZXF1ZXN0cyI6eyJjcHUiOiIyMDBtIiwibWVtb3J5IjoiMjAwTWkifX0sInNlY3VyaXR5Q29udGV4dCI6eyJhbGxvd1ByaXZpbGVnZUVzY2FsYXRpb24iOmZhbHNlfX1dLCJzZWN1cml0eUNvbnRleHQiOnsicnVuQXNOb25Sb290Ijp0cnVlfSwic2VydmljZUFjY291bnROYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciIsInRlcm1pbmF0aW9uR3JhY2VQZXJpb2RTZWNvbmRzIjoxMH19fX1dLCJwZXJtaXNzaW9ucyI6W3sicnVsZXMiOlt7ImFwaUdyb3VwcyI6WyIiLCJjb29yZGluYXRpb24uazhzLmlvIl0sInJlc291cmNlcyI6WyJjb25maWdtYXBzIiwibGVhc2VzIl0sInZlcmJzIjpbImdldCIsImxpc3QiLCJ3YXRjaCIsImNyZWF0ZSIsInVwZGF0ZSIsInBhdGNoIiwiZGVsZXRlIl19LHsiYXBpR3JvdXBzIjpbIiJdLCJyZXNvdXJjZXMiOlsiZXZlbnRzIl0sInZlcmJzIjpbImNyZWF0ZSIsInBhdGNoIl19XSwic2VydmljZUFjY291bnROYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciJ9XX0sInN0cmF0ZWd5IjoiZGVwbG95bWVudCJ9LCJpbnN0YWxsTW9kZXMiOlt7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJPd25OYW1lc3BhY2UifSx7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJTaW5nbGVOYW1lc3BhY2UifSx7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJNdWx0aU5hbWVzcGFjZSJ9LHsic3VwcG9ydGVkIjp0cnVlLCJ0eXBlIjoiQWxsTmFtZXNwYWNlcyJ9XSwia2V5d29yZHMiOlsiYXBpIiwicmF0ZS1saW1pdCIsImt1YWRyYW50Il0sImxpbmtzIjpbeyJuYW1lIjoiTGltaXRhZG9yIE9wZXJhdG9yIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL0t1YWRyYW50L2xpbWl0YWRvci1vcGVyYXRvciJ9LHsibmFtZSI6Ikt1YWRyYW50IERvY3MiLCJ1cmwiOiJodHRwczovL2t1YWRyYW50LmlvIn1dLCJtYWludGFpbmVycyI6W3siZW1haWwiOiJlYXN0aXpsZUByZWRoYXQuY29tIiwibmFtZSI6IkVndXpraSBBc3RpeiBMZXphdW4ifSx7ImVtYWlsIjoiYXNuYXBzQHJlZGhhdC5jb20iLCJuYW1lIjoiQWxleCBTbmFwcyJ9LHsiZW1haWwiOiJkaWRpZXJAcmVkaGF0LmNvbSIsIm5hbWUiOiJEaWRpZXIgRGkgQ2VzYXJlIn1dLCJtYXR1cml0eSI6ImFscGhhIiwibWluS3ViZVZlcnNpb24iOiIxLjI1LjAiLCJwcm92aWRlciI6eyJuYW1lIjoiUmVkIEhhdCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9LdWFkcmFudC9saW1pdGFkb3Itb3BlcmF0b3IifSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOUBzaGEyNTY6OTQ3MWFhZGNlMWExN2FhY2IxYmY2NTNiNzVlMGQ3OTI0ZjhmOWUxNDQ5NTQ0NDBlMGQ5YzliZTZmZDQzMmU4YyIsIm5hbWUiOiJsaW1pdGFkb3IifV0sInZlcnNpb24iOiIxLjEuMSJ9fQ==
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoicmJhYy5hdXRob3JpemF0aW9uLms4cy5pby92MSIsImtpbmQiOiJDbHVzdGVyUm9sZSIsIm1ldGFkYXRhIjp7ImNyZWF0aW9uVGltZXN0YW1wIjpudWxsLCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLW1ldHJpY3MtcmVhZGVyIn0sInJ1bGVzIjpbeyJub25SZXNvdXJjZVVSTHMiOlsiL21ldHJpY3MiXSwidmVyYnMiOlsiZ2V0Il19XX0=
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoidjEiLCJkYXRhIjp7ImNvbnRyb2xsZXJfbWFuYWdlcl9jb25maWcueWFtbCI6ImFwaVZlcnNpb246IGNvbnRyb2xsZXItcnVudGltZS5zaWdzLms4cy5pby92MWFscGhhMVxua2luZDogQ29udHJvbGxlck1hbmFnZXJDb25maWdcbmhlYWx0aDpcbiAgaGVhbHRoUHJvYmVCaW5kQWRkcmVzczogOjgwODFcbm1ldHJpY3M6XG4gIGJpbmRBZGRyZXNzOiA6ODA4MFxud2ViaG9vazpcbiAgcG9ydDogOTQ0M1xubGVhZGVyRWxlY3Rpb246XG4gIGxlYWRlckVsZWN0OiB0cnVlXG4gIHJlc291cmNlTmFtZTogMzc0NWExNmUua3VhZHJhbnQuaW9cbiJ9LCJraW5kIjoiQ29uZmlnTWFwIiwibWV0YWRhdGEiOnsibmFtZSI6ImxpbWl0YWRvci1vcGVyYXRvci1tYW5hZ2VyLWNvbmZpZyJ9fQ==
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoidjEiLCJraW5kIjoiU2VydmljZSIsIm1ldGFkYXRhIjp7ImNyZWF0aW9uVGltZXN0YW1wIjpudWxsLCJsYWJlbHMiOnsiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9LCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLW1ldHJpY3MifSwic3BlYyI6eyJwb3J0cyI6W3sibmFtZSI6Im1ldHJpY3MiLCJwb3J0Ijo4MDgwLCJ0YXJnZXRQb3J0IjoibWV0cmljcyJ9XSwic2VsZWN0b3IiOnsiYXBwIjoibGltaXRhZG9yLW9wZXJhdG9yIiwiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9fSwic3RhdHVzIjp7ImxvYWRCYWxhbmNlciI6e319fQ==
+relatedImages:
+  - image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-1-limitador-operator-bundle@sha256:93c6f058da352883789f7db0150b1097a5f09e1268e24914ad964d5fdc83f6e1
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:b31ba293812788dc7e21c14703ac61fdd5bff010948ada33715544ba507851f7
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:9471aadce1a17aacb1bf653b75e0d7924f8f9e144954440e0d9c9be6fd432e8c
+    name: limitador
 schema: olm.bundle

--- a/catalog/4.17/limitador-operator/catalog.yaml
+++ b/catalog/4.17/limitador-operator/catalog.yaml
@@ -7,13 +7,15 @@ name: limitador-operator
 schema: olm.package
 ---
 entries:
-- name: limitador-operator.v0.12.1
-- name: limitador-operator.v1.0.1
-  replaces: limitador-operator.v0.12.1
-- name: limitador-operator.v1.0.2
-  replaces: limitador-operator.v1.0.1
-- name: limitador-operator.v1.1.0
-  replaces: limitador-operator.v1.0.2
+  - name: limitador-operator.v0.12.1
+  - name: limitador-operator.v1.0.1
+    replaces: limitador-operator.v0.12.1
+  - name: limitador-operator.v1.0.2
+    replaces: limitador-operator.v1.0.1
+  - name: limitador-operator.v1.1.0
+    replaces: limitador-operator.v1.0.2
+  - name: limitador-operator.v1.1.1
+    replaces: limitador-operator.v1.1.0
 name: stable
 package: limitador-operator
 schema: olm.channel
@@ -22,474 +24,503 @@ image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:53fc5ce2a479fb
 name: limitador-operator.v0.12.1
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 0.12.1
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 0.12.1
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914
-      createdAt: "2024-10-18T10:24:00Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: The Operator to manage Limitador deployments. - Part of Red Hat Connectivity
-      Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914
+        createdAt: "2024-10-18T10:24:00Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: The Operator to manage Limitador deployments. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914
-  name: limitador-rhel9-operator-2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:b542037f744ec0ca8bb5dc770507c774cc8603cdc3072c9a8a2a78d1907ac961
-  name: limitador
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:53fc5ce2a479fb005f8b31bc6e58ef63b1e28cb2bf6946e01deb105f7e842889
-  name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914
+    name: limitador-rhel9-operator-2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:2543f482fa0139d5bcbd8e1008dc27c7a693852d75809e09f12fc5d828902914
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:b542037f744ec0ca8bb5dc770507c774cc8603cdc3072c9a8a2a78d1907ac961
+    name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:53fc5ce2a479fb005f8b31bc6e58ef63b1e28cb2bf6946e01deb105f7e842889
+    name: ""
 schema: olm.bundle
 ---
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:d30fa5c4e7890f902429dd12456efa2170d0df6274af92c36c76d13c9f87e8c6
 name: limitador-operator.v1.0.1
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 1.0.1
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.0.1
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a
-      createdAt: "2024-10-18T10:24:00Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: Enables rate limiting for Gateways and applications in a Gateway
-      API network. - Part of Red Hat Connectivity Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a
+        createdAt: "2024-10-18T10:24:00Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: Enables rate limiting for Gateways and applications in a Gateway API network. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a
-  name: limitador-rhel9-operator-328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:19857349512b404537bfb6bb7672b5c47a6e315b18fdb8dc74a35bbe2c7631f6
-  name: limitador
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:d30fa5c4e7890f902429dd12456efa2170d0df6274af92c36c76d13c9f87e8c6
-  name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a
+    name: limitador-rhel9-operator-328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:328db156c930a9914adcdd7ba6b0392d8470470bdd45771e2677b18152dbb57a
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:19857349512b404537bfb6bb7672b5c47a6e315b18fdb8dc74a35bbe2c7631f6
+    name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:d30fa5c4e7890f902429dd12456efa2170d0df6274af92c36c76d13c9f87e8c6
+    name: ""
 schema: olm.bundle
 ---
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:e2c9dfc30d59bd4086ccfeada4fe79c04661c7cd2e6e7758ee97dfec95eaa4b7
 name: limitador-operator.v1.0.2
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 1.0.2
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.0.2
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f
-      createdAt: "2024-10-18T10:24:00Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: Enables rate limiting for Gateways and applications in a Gateway
-      API network. - Part of Red Hat Connectivity Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f
+        createdAt: "2024-10-18T10:24:00Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: Enables rate limiting for Gateways and applications in a Gateway API network. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f
-  name: limitador-rhel9-operator-3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:cd2c1a74faa084f4a215cd6537caf93e1727d03b3f28ba33cef167001960c0b8
-  name: limitador
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:e2c9dfc30d59bd4086ccfeada4fe79c04661c7cd2e6e7758ee97dfec95eaa4b7
-  name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f
+    name: limitador-rhel9-operator-3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:3b777600e4d8ad924b38c8311d756e195cb9995bf30b4a59dfd3e9c6cc3ebf4f
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:cd2c1a74faa084f4a215cd6537caf93e1727d03b3f28ba33cef167001960c0b8
+    name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:e2c9dfc30d59bd4086ccfeada4fe79c04661c7cd2e6e7758ee97dfec95eaa4b7
+    name: ""
 schema: olm.bundle
 ---
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
 name: limitador-operator.v1.1.0
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 1.1.0
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.1.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-      createdAt: "2025-04-07T15:52:04Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: Enables rate limiting for Gateways and applications in a Gateway
-      API network. - Part of Red Hat Connectivity Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+        createdAt: "2025-04-07T15:52:04Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: Enables rate limiting for Gateways and applications in a Gateway API network. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
-  name: ""
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-  name: limitador-rhel9-operator-edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:98f85a05da53fbf7f20845d1969441620407cc13a185fd52714308679f116425
-  name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+    name: limitador-rhel9-operator-edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:98f85a05da53fbf7f20845d1969441620407cc13a185fd52714308679f116425
+    name: limitador
+schema: olm.bundle
+---
+image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-1-limitador-operator-bundle@sha256:93c6f058da352883789f7db0150b1097a5f09e1268e24914ad964d5fdc83f6e1
+name: limitador-operator.v1.1.1
+package: limitador-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.1.1
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsiY29udHJvbGxlci1nZW4ua3ViZWJ1aWxkZXIuaW8vdmVyc2lvbiI6InYwLjE1LjAifSwiY3JlYXRpb25UaW1lc3RhbXAiOm51bGwsIm5hbWUiOiJsaW1pdGFkb3JzLmxpbWl0YWRvci5rdWFkcmFudC5pbyJ9LCJzcGVjIjp7Imdyb3VwIjoibGltaXRhZG9yLmt1YWRyYW50LmlvIiwibmFtZXMiOnsia2luZCI6IkxpbWl0YWRvciIsImxpc3RLaW5kIjoiTGltaXRhZG9yTGlzdCIsInBsdXJhbCI6ImxpbWl0YWRvcnMiLCJzaW5ndWxhciI6ImxpbWl0YWRvciJ9LCJzY29wZSI6Ik5hbWVzcGFjZWQiLCJ2ZXJzaW9ucyI6W3siYWRkaXRpb25hbFByaW50ZXJDb2x1bW5zIjpbeyJkZXNjcmlwdGlvbiI6IkxpbWl0YWRvciBSZWFkeSIsImpzb25QYXRoIjoiLnN0YXR1cy5jb25kaXRpb25zWz8oQC50eXBlPT1cIlJlYWR5XCIpXS5zdGF0dXMiLCJuYW1lIjoiUmVhZHkiLCJwcmlvcml0eSI6MiwidHlwZSI6InN0cmluZyJ9LHsianNvblBhdGgiOiIubWV0YWRhdGEuY3JlYXRpb25UaW1lc3RhbXAiLCJuYW1lIjoiQWdlIiwidHlwZSI6ImRhdGUifV0sIm5hbWUiOiJ2MWFscGhhMSIsInNjaGVtYSI6eyJvcGVuQVBJVjNTY2hlbWEiOnsiZGVzY3JpcHRpb24iOiJMaW1pdGFkb3IgaXMgdGhlIFNjaGVtYSBmb3IgdGhlIGxpbWl0YWRvcnMgQVBJIiwicHJvcGVydGllcyI6eyJhcGlWZXJzaW9uIjp7ImRlc2NyaXB0aW9uIjoiQVBJVmVyc2lvbiBkZWZpbmVzIHRoZSB2ZXJzaW9uZWQgc2NoZW1hIG9mIHRoaXMgcmVwcmVzZW50YXRpb24gb2YgYW4gb2JqZWN0LlxuU2VydmVycyBzaG91bGQgY29udmVydCByZWNvZ25pemVkIHNjaGVtYXMgdG8gdGhlIGxhdGVzdCBpbnRlcm5hbCB2YWx1ZSwgYW5kXG5tYXkgcmVqZWN0IHVucmVjb2duaXplZCB2YWx1ZXMuXG5Nb3JlIGluZm86IGh0dHBzOi8vZ2l0Lms4cy5pby9jb21tdW5pdHkvY29udHJpYnV0b3JzL2RldmVsL3NpZy1hcmNoaXRlY3R1cmUvYXBpLWNvbnZlbnRpb25zLm1kI3Jlc291cmNlcyIsInR5cGUiOiJzdHJpbmcifSwia2luZCI6eyJkZXNjcmlwdGlvbiI6IktpbmQgaXMgYSBzdHJpbmcgdmFsdWUgcmVwcmVzZW50aW5nIHRoZSBSRVNUIHJlc291cmNlIHRoaXMgb2JqZWN0IHJlcHJlc2VudHMuXG5TZXJ2ZXJzIG1heSBpbmZlciB0aGlzIGZyb20gdGhlIGVuZHBvaW50IHRoZSBjbGllbnQgc3VibWl0cyByZXF1ZXN0cyB0by5cbkNhbm5vdCBiZSB1cGRhdGVkLlxuSW4gQ2FtZWxDYXNlLlxuTW9yZSBpbmZvOiBodHRwczovL2dpdC5rOHMuaW8vY29tbXVuaXR5L2NvbnRyaWJ1dG9ycy9kZXZlbC9zaWctYXJjaGl0ZWN0dXJlL2FwaS1jb252ZW50aW9ucy5tZCN0eXBlcy1raW5kcyIsInR5cGUiOiJzdHJpbmcifSwibWV0YWRhdGEiOnsidHlwZSI6Im9iamVjdCJ9LCJzcGVjIjp7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yU3BlYyBkZWZpbmVzIHRoZSBkZXNpcmVkIHN0YXRlIG9mIExpbWl0YWRvciIsInByb3BlcnRpZXMiOnsiYWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJBZmZpbml0eSBpcyBhIGdyb3VwIG9mIGFmZmluaXR5IHNjaGVkdWxpbmcgcnVsZXMuIiwicHJvcGVydGllcyI6eyJub2RlQWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJEZXNjcmliZXMgbm9kZSBhZmZpbml0eSBzY2hlZHVsaW5nIHJ1bGVzIGZvciB0aGUgcG9kLiIsInByb3BlcnRpZXMiOnsicHJlZmVycmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJUaGUgc2NoZWR1bGVyIHdpbGwgcHJlZmVyIHRvIHNjaGVkdWxlIHBvZHMgdG8gbm9kZXMgdGhhdCBzYXRpc2Z5XG50aGUgYWZmaW5pdHkgZXhwcmVzc2lvbnMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQsIGJ1dCBpdCBtYXkgY2hvb3NlXG5hIG5vZGUgdGhhdCB2aW9sYXRlcyBvbmUgb3IgbW9yZSBvZiB0aGUgZXhwcmVzc2lvbnMuIFRoZSBub2RlIHRoYXQgaXNcbm1vc3QgcHJlZmVycmVkIGlzIHRoZSBvbmUgd2l0aCB0aGUgZ3JlYXRlc3Qgc3VtIG9mIHdlaWdodHMsIGkuZS5cbmZvciBlYWNoIG5vZGUgdGhhdCBtZWV0cyBhbGwgb2YgdGhlIHNjaGVkdWxpbmcgcmVxdWlyZW1lbnRzIChyZXNvdXJjZVxucmVxdWVzdCwgcmVxdWlyZWREdXJpbmdTY2hlZHVsaW5nIGFmZmluaXR5IGV4cHJlc3Npb25zLCBldGMuKSxcbmNvbXB1dGUgYSBzdW0gYnkgaXRlcmF0aW5nIHRocm91Z2ggdGhlIGVsZW1lbnRzIG9mIHRoaXMgZmllbGQgYW5kIGFkZGluZ1xuXCJ3ZWlnaHRcIiB0byB0aGUgc3VtIGlmIHRoZSBub2RlIG1hdGNoZXMgdGhlIGNvcnJlc3BvbmRpbmcgbWF0Y2hFeHByZXNzaW9uczsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBbiBlbXB0eSBwcmVmZXJyZWQgc2NoZWR1bGluZyB0ZXJtIG1hdGNoZXMgYWxsIG9iamVjdHMgd2l0aCBpbXBsaWNpdCB3ZWlnaHQgMFxuKGkuZS4gaXQncyBhIG5vLW9wKS4gQSBudWxsIHByZWZlcnJlZCBzY2hlZHVsaW5nIHRlcm0gbWF0Y2hlcyBubyBvYmplY3RzIChpLmUuIGlzIGFsc28gYSBuby1vcCkuIiwicHJvcGVydGllcyI6eyJwcmVmZXJlbmNlIjp7ImRlc2NyaXB0aW9uIjoiQSBub2RlIHNlbGVjdG9yIHRlcm0sIGFzc29jaWF0ZWQgd2l0aCB0aGUgY29ycmVzcG9uZGluZyB3ZWlnaHQuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoiQSBsaXN0IG9mIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnRzIGJ5IG5vZGUncyBsYWJlbHMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvclxudGhhdCByZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6IlRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoiUmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzLCBEb2VzTm90RXhpc3QuIEd0LCBhbmQgTHQuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJBbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEd0IG9yIEx0LCB0aGUgdmFsdWVzXG5hcnJheSBtdXN0IGhhdmUgYSBzaW5nbGUgZWxlbWVudCwgd2hpY2ggd2lsbCBiZSBpbnRlcnByZXRlZCBhcyBhbiBpbnRlZ2VyLlxuVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoRmllbGRzIjp7ImRlc2NyaXB0aW9uIjoiQSBsaXN0IG9mIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnRzIGJ5IG5vZGUncyBmaWVsZHMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvclxudGhhdCByZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6IlRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoiUmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzLCBEb2VzTm90RXhpc3QuIEd0LCBhbmQgTHQuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJBbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEd0IG9yIEx0LCB0aGUgdmFsdWVzXG5hcnJheSBtdXN0IGhhdmUgYSBzaW5nbGUgZWxlbWVudCwgd2hpY2ggd2lsbCBiZSBpbnRlcnByZXRlZCBhcyBhbiBpbnRlZ2VyLlxuVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIndlaWdodCI6eyJkZXNjcmlwdGlvbiI6IldlaWdodCBhc3NvY2lhdGVkIHdpdGggbWF0Y2hpbmcgdGhlIGNvcnJlc3BvbmRpbmcgbm9kZVNlbGVjdG9yVGVybSwgaW4gdGhlIHJhbmdlIDEtMTAwLiIsImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifX0sInJlcXVpcmVkIjpbInByZWZlcmVuY2UiLCJ3ZWlnaHQiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwicmVxdWlyZWREdXJpbmdTY2hlZHVsaW5nSWdub3JlZER1cmluZ0V4ZWN1dGlvbiI6eyJkZXNjcmlwdGlvbiI6IklmIHRoZSBhZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgYXJlIG5vdCBtZXQgYXRcbnNjaGVkdWxpbmcgdGltZSwgdGhlIHBvZCB3aWxsIG5vdCBiZSBzY2hlZHVsZWQgb250byB0aGUgbm9kZS5cbklmIHRoZSBhZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgY2Vhc2UgdG8gYmUgbWV0XG5hdCBzb21lIHBvaW50IGR1cmluZyBwb2QgZXhlY3V0aW9uIChlLmcuIGR1ZSB0byBhbiB1cGRhdGUpLCB0aGUgc3lzdGVtXG5tYXkgb3IgbWF5IG5vdCB0cnkgdG8gZXZlbnR1YWxseSBldmljdCB0aGUgcG9kIGZyb20gaXRzIG5vZGUuIiwicHJvcGVydGllcyI6eyJub2RlU2VsZWN0b3JUZXJtcyI6eyJkZXNjcmlwdGlvbiI6IlJlcXVpcmVkLiBBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciB0ZXJtcy4gVGhlIHRlcm1zIGFyZSBPUmVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBudWxsIG9yIGVtcHR5IG5vZGUgc2VsZWN0b3IgdGVybSBtYXRjaGVzIG5vIG9iamVjdHMuIFRoZSByZXF1aXJlbWVudHMgb2ZcbnRoZW0gYXJlIEFORGVkLlxuVGhlIFRvcG9sb2d5U2VsZWN0b3JUZXJtIHR5cGUgaW1wbGVtZW50cyBhIHN1YnNldCBvZiB0aGUgTm9kZVNlbGVjdG9yVGVybS4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudHMgYnkgbm9kZSdzIGxhYmVscy4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yXG50aGF0IHJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJSZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMsIERvZXNOb3RFeGlzdC4gR3QsIGFuZCBMdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6IkFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgR3Qgb3IgTHQsIHRoZSB2YWx1ZXNcbmFycmF5IG11c3QgaGF2ZSBhIHNpbmdsZSBlbGVtZW50LCB3aGljaCB3aWxsIGJlIGludGVycHJldGVkIGFzIGFuIGludGVnZXIuXG5UaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hGaWVsZHMiOnsiZGVzY3JpcHRpb24iOiJBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudHMgYnkgbm9kZSdzIGZpZWxkcy4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yXG50aGF0IHJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJSZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMsIERvZXNOb3RFeGlzdC4gR3QsIGFuZCBMdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6IkFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgR3Qgb3IgTHQsIHRoZSB2YWx1ZXNcbmFycmF5IG11c3QgaGF2ZSBhIHNpbmdsZSBlbGVtZW50LCB3aGljaCB3aWxsIGJlIGludGVycHJldGVkIGFzIGFuIGludGVnZXIuXG5UaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJub2RlU2VsZWN0b3JUZXJtcyJdLCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn19LCJ0eXBlIjoib2JqZWN0In0sInBvZEFmZmluaXR5Ijp7ImRlc2NyaXB0aW9uIjoiRGVzY3JpYmVzIHBvZCBhZmZpbml0eSBzY2hlZHVsaW5nIHJ1bGVzIChlLmcuIGNvLWxvY2F0ZSB0aGlzIHBvZCBpbiB0aGUgc2FtZSBub2RlLCB6b25lLCBldGMuIGFzIHNvbWUgb3RoZXIgcG9kKHMpKS4iLCJwcm9wZXJ0aWVzIjp7InByZWZlcnJlZER1cmluZ1NjaGVkdWxpbmdJZ25vcmVkRHVyaW5nRXhlY3V0aW9uIjp7ImRlc2NyaXB0aW9uIjoiVGhlIHNjaGVkdWxlciB3aWxsIHByZWZlciB0byBzY2hlZHVsZSBwb2RzIHRvIG5vZGVzIHRoYXQgc2F0aXNmeVxudGhlIGFmZmluaXR5IGV4cHJlc3Npb25zIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkLCBidXQgaXQgbWF5IGNob29zZVxuYSBub2RlIHRoYXQgdmlvbGF0ZXMgb25lIG9yIG1vcmUgb2YgdGhlIGV4cHJlc3Npb25zLiBUaGUgbm9kZSB0aGF0IGlzXG5tb3N0IHByZWZlcnJlZCBpcyB0aGUgb25lIHdpdGggdGhlIGdyZWF0ZXN0IHN1bSBvZiB3ZWlnaHRzLCBpLmUuXG5mb3IgZWFjaCBub2RlIHRoYXQgbWVldHMgYWxsIG9mIHRoZSBzY2hlZHVsaW5nIHJlcXVpcmVtZW50cyAocmVzb3VyY2VcbnJlcXVlc3QsIHJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZyBhZmZpbml0eSBleHByZXNzaW9ucywgZXRjLiksXG5jb21wdXRlIGEgc3VtIGJ5IGl0ZXJhdGluZyB0aHJvdWdoIHRoZSBlbGVtZW50cyBvZiB0aGlzIGZpZWxkIGFuZCBhZGRpbmdcblwid2VpZ2h0XCIgdG8gdGhlIHN1bSBpZiB0aGUgbm9kZSBoYXMgcG9kcyB3aGljaCBtYXRjaGVzIHRoZSBjb3JyZXNwb25kaW5nIHBvZEFmZmluaXR5VGVybTsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJUaGUgd2VpZ2h0cyBvZiBhbGwgb2YgdGhlIG1hdGNoZWQgV2VpZ2h0ZWRQb2RBZmZpbml0eVRlcm0gZmllbGRzIGFyZSBhZGRlZCBwZXItbm9kZSB0byBmaW5kIHRoZSBtb3N0IHByZWZlcnJlZCBub2RlKHMpIiwicHJvcGVydGllcyI6eyJwb2RBZmZpbml0eVRlcm0iOnsiZGVzY3JpcHRpb24iOiJSZXF1aXJlZC4gQSBwb2QgYWZmaW5pdHkgdGVybSwgYXNzb2NpYXRlZCB3aXRoIHRoZSBjb3JyZXNwb25kaW5nIHdlaWdodC4iLCJwcm9wZXJ0aWVzIjp7ImxhYmVsU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgYSBzZXQgb2YgcmVzb3VyY2VzLCBpbiB0aGlzIGNhc2UgcG9kcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciB0aGUgc2V0IG9mIG5hbWVzcGFjZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgc2VsZWN0ZWQgYnkgdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIGxpc3RlZCBpbiB0aGUgbmFtZXNwYWNlcyBmaWVsZC5cbm51bGwgc2VsZWN0b3IgYW5kIG51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi5cbkFuIGVtcHR5IHNlbGVjdG9yICh7fSkgbWF0Y2hlcyBhbGwgbmFtZXNwYWNlcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VzIjp7ImRlc2NyaXB0aW9uIjoibmFtZXNwYWNlcyBzcGVjaWZpZXMgYSBzdGF0aWMgbGlzdCBvZiBuYW1lc3BhY2UgbmFtZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgbGlzdGVkIGluIHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBzZWxlY3RlZCBieSBuYW1lc3BhY2VTZWxlY3Rvci5cbm51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IGFuZCBudWxsIG5hbWVzcGFjZVNlbGVjdG9yIG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJ0b3BvbG9neUtleSI6eyJkZXNjcmlwdGlvbiI6IlRoaXMgcG9kIHNob3VsZCBiZSBjby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGggdGhlIHBvZHMgbWF0Y2hpbmdcbnRoZSBsYWJlbFNlbGVjdG9yIGluIHRoZSBzcGVjaWZpZWQgbmFtZXNwYWNlcywgd2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlXG53aG9zZSB2YWx1ZSBvZiB0aGUgbGFiZWwgd2l0aCBrZXkgdG9wb2xvZ3lLZXkgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoIGFueSBvZiB0aGVcbnNlbGVjdGVkIHBvZHMgaXMgcnVubmluZy5cbkVtcHR5IHRvcG9sb2d5S2V5IGlzIG5vdCBhbGxvd2VkLiIsInR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInRvcG9sb2d5S2V5Il0sInR5cGUiOiJvYmplY3QifSwid2VpZ2h0Ijp7ImRlc2NyaXB0aW9uIjoid2VpZ2h0IGFzc29jaWF0ZWQgd2l0aCBtYXRjaGluZyB0aGUgY29ycmVzcG9uZGluZyBwb2RBZmZpbml0eVRlcm0sXG5pbiB0aGUgcmFuZ2UgMS0xMDAuIiwiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwicmVxdWlyZWQiOlsicG9kQWZmaW5pdHlUZXJtIiwid2VpZ2h0Il0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sInJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJJZiB0aGUgYWZmaW5pdHkgcmVxdWlyZW1lbnRzIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkIGFyZSBub3QgbWV0IGF0XG5zY2hlZHVsaW5nIHRpbWUsIHRoZSBwb2Qgd2lsbCBub3QgYmUgc2NoZWR1bGVkIG9udG8gdGhlIG5vZGUuXG5JZiB0aGUgYWZmaW5pdHkgcmVxdWlyZW1lbnRzIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkIGNlYXNlIHRvIGJlIG1ldFxuYXQgc29tZSBwb2ludCBkdXJpbmcgcG9kIGV4ZWN1dGlvbiAoZS5nLiBkdWUgdG8gYSBwb2QgbGFiZWwgdXBkYXRlKSwgdGhlXG5zeXN0ZW0gbWF5IG9yIG1heSBub3QgdHJ5IHRvIGV2ZW50dWFsbHkgZXZpY3QgdGhlIHBvZCBmcm9tIGl0cyBub2RlLlxuV2hlbiB0aGVyZSBhcmUgbXVsdGlwbGUgZWxlbWVudHMsIHRoZSBsaXN0cyBvZiBub2RlcyBjb3JyZXNwb25kaW5nIHRvIGVhY2hcbnBvZEFmZmluaXR5VGVybSBhcmUgaW50ZXJzZWN0ZWQsIGkuZS4gYWxsIHRlcm1zIG11c3QgYmUgc2F0aXNmaWVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiRGVmaW5lcyBhIHNldCBvZiBwb2RzIChuYW1lbHkgdGhvc2UgbWF0Y2hpbmcgdGhlIGxhYmVsU2VsZWN0b3JcbnJlbGF0aXZlIHRvIHRoZSBnaXZlbiBuYW1lc3BhY2UocykpIHRoYXQgdGhpcyBwb2Qgc2hvdWxkIGJlXG5jby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGgsXG53aGVyZSBjby1sb2NhdGVkIGlzIGRlZmluZWQgYXMgcnVubmluZyBvbiBhIG5vZGUgd2hvc2UgdmFsdWUgb2ZcbnRoZSBsYWJlbCB3aXRoIGtleSBcdTAwM2N0b3BvbG9neUtleVx1MDAzZSBtYXRjaGVzIHRoYXQgb2YgYW55IG5vZGUgb24gd2hpY2hcbmEgcG9kIG9mIHRoZSBzZXQgb2YgcG9kcyBpcyBydW5uaW5nIiwicHJvcGVydGllcyI6eyJsYWJlbFNlbGVjdG9yIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBxdWVyeSBvdmVyIGEgc2V0IG9mIHJlc291cmNlcywgaW4gdGhpcyBjYXNlIHBvZHMuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoibWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvciB0aGF0XG5yZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6ImtleSBpcyB0aGUgbGFiZWwga2V5IHRoYXQgdGhlIHNlbGVjdG9yIGFwcGxpZXMgdG8uIiwidHlwZSI6InN0cmluZyJ9LCJvcGVyYXRvciI6eyJkZXNjcmlwdGlvbiI6Im9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLlxuVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LiIsInR5cGUiOiJzdHJpbmcifSwidmFsdWVzIjp7ImRlc2NyaXB0aW9uIjoidmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpY1xubWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoTGFiZWxzIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjp7InR5cGUiOiJzdHJpbmcifSwiZGVzY3JpcHRpb24iOiJtYXRjaExhYmVscyBpcyBhIG1hcCBvZiB7a2V5LHZhbHVlfSBwYWlycy4gQSBzaW5nbGUge2tleSx2YWx1ZX0gaW4gdGhlIG1hdGNoTGFiZWxzXG5tYXAgaXMgZXF1aXZhbGVudCB0byBhbiBlbGVtZW50IG9mIG1hdGNoRXhwcmVzc2lvbnMsIHdob3NlIGtleSBmaWVsZCBpcyBcImtleVwiLCB0aGVcbm9wZXJhdG9yIGlzIFwiSW5cIiwgYW5kIHRoZSB2YWx1ZXMgYXJyYXkgY29udGFpbnMgb25seSBcInZhbHVlXCIuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwibmFtZXNwYWNlU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgdGhlIHNldCBvZiBuYW1lc3BhY2VzIHRoYXQgdGhlIHRlcm0gYXBwbGllcyB0by5cblRoZSB0ZXJtIGlzIGFwcGxpZWQgdG8gdGhlIHVuaW9uIG9mIHRoZSBuYW1lc3BhY2VzIHNlbGVjdGVkIGJ5IHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBsaXN0ZWQgaW4gdGhlIG5hbWVzcGFjZXMgZmllbGQuXG5udWxsIHNlbGVjdG9yIGFuZCBudWxsIG9yIGVtcHR5IG5hbWVzcGFjZXMgbGlzdCBtZWFucyBcInRoaXMgcG9kJ3MgbmFtZXNwYWNlXCIuXG5BbiBlbXB0eSBzZWxlY3RvciAoe30pIG1hdGNoZXMgYWxsIG5hbWVzcGFjZXMuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoibWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvciB0aGF0XG5yZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6ImtleSBpcyB0aGUgbGFiZWwga2V5IHRoYXQgdGhlIHNlbGVjdG9yIGFwcGxpZXMgdG8uIiwidHlwZSI6InN0cmluZyJ9LCJvcGVyYXRvciI6eyJkZXNjcmlwdGlvbiI6Im9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLlxuVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LiIsInR5cGUiOiJzdHJpbmcifSwidmFsdWVzIjp7ImRlc2NyaXB0aW9uIjoidmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpY1xubWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoTGFiZWxzIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjp7InR5cGUiOiJzdHJpbmcifSwiZGVzY3JpcHRpb24iOiJtYXRjaExhYmVscyBpcyBhIG1hcCBvZiB7a2V5LHZhbHVlfSBwYWlycy4gQSBzaW5nbGUge2tleSx2YWx1ZX0gaW4gdGhlIG1hdGNoTGFiZWxzXG5tYXAgaXMgZXF1aXZhbGVudCB0byBhbiBlbGVtZW50IG9mIG1hdGNoRXhwcmVzc2lvbnMsIHdob3NlIGtleSBmaWVsZCBpcyBcImtleVwiLCB0aGVcbm9wZXJhdG9yIGlzIFwiSW5cIiwgYW5kIHRoZSB2YWx1ZXMgYXJyYXkgY29udGFpbnMgb25seSBcInZhbHVlXCIuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwibmFtZXNwYWNlcyI6eyJkZXNjcmlwdGlvbiI6Im5hbWVzcGFjZXMgc3BlY2lmaWVzIGEgc3RhdGljIGxpc3Qgb2YgbmFtZXNwYWNlIG5hbWVzIHRoYXQgdGhlIHRlcm0gYXBwbGllcyB0by5cblRoZSB0ZXJtIGlzIGFwcGxpZWQgdG8gdGhlIHVuaW9uIG9mIHRoZSBuYW1lc3BhY2VzIGxpc3RlZCBpbiB0aGlzIGZpZWxkXG5hbmQgdGhlIG9uZXMgc2VsZWN0ZWQgYnkgbmFtZXNwYWNlU2VsZWN0b3IuXG5udWxsIG9yIGVtcHR5IG5hbWVzcGFjZXMgbGlzdCBhbmQgbnVsbCBuYW1lc3BhY2VTZWxlY3RvciBtZWFucyBcInRoaXMgcG9kJ3MgbmFtZXNwYWNlXCIuIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifSwidG9wb2xvZ3lLZXkiOnsiZGVzY3JpcHRpb24iOiJUaGlzIHBvZCBzaG91bGQgYmUgY28tbG9jYXRlZCAoYWZmaW5pdHkpIG9yIG5vdCBjby1sb2NhdGVkIChhbnRpLWFmZmluaXR5KSB3aXRoIHRoZSBwb2RzIG1hdGNoaW5nXG50aGUgbGFiZWxTZWxlY3RvciBpbiB0aGUgc3BlY2lmaWVkIG5hbWVzcGFjZXMsIHdoZXJlIGNvLWxvY2F0ZWQgaXMgZGVmaW5lZCBhcyBydW5uaW5nIG9uIGEgbm9kZVxud2hvc2UgdmFsdWUgb2YgdGhlIGxhYmVsIHdpdGgga2V5IHRvcG9sb2d5S2V5IG1hdGNoZXMgdGhhdCBvZiBhbnkgbm9kZSBvbiB3aGljaCBhbnkgb2YgdGhlXG5zZWxlY3RlZCBwb2RzIGlzIHJ1bm5pbmcuXG5FbXB0eSB0b3BvbG9neUtleSBpcyBub3QgYWxsb3dlZC4iLCJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJ0b3BvbG9neUtleSJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9fSwidHlwZSI6Im9iamVjdCJ9LCJwb2RBbnRpQWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJEZXNjcmliZXMgcG9kIGFudGktYWZmaW5pdHkgc2NoZWR1bGluZyBydWxlcyAoZS5nLiBhdm9pZCBwdXR0aW5nIHRoaXMgcG9kIGluIHRoZSBzYW1lIG5vZGUsIHpvbmUsIGV0Yy4gYXMgc29tZSBvdGhlciBwb2QocykpLiIsInByb3BlcnRpZXMiOnsicHJlZmVycmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJUaGUgc2NoZWR1bGVyIHdpbGwgcHJlZmVyIHRvIHNjaGVkdWxlIHBvZHMgdG8gbm9kZXMgdGhhdCBzYXRpc2Z5XG50aGUgYW50aS1hZmZpbml0eSBleHByZXNzaW9ucyBzcGVjaWZpZWQgYnkgdGhpcyBmaWVsZCwgYnV0IGl0IG1heSBjaG9vc2VcbmEgbm9kZSB0aGF0IHZpb2xhdGVzIG9uZSBvciBtb3JlIG9mIHRoZSBleHByZXNzaW9ucy4gVGhlIG5vZGUgdGhhdCBpc1xubW9zdCBwcmVmZXJyZWQgaXMgdGhlIG9uZSB3aXRoIHRoZSBncmVhdGVzdCBzdW0gb2Ygd2VpZ2h0cywgaS5lLlxuZm9yIGVhY2ggbm9kZSB0aGF0IG1lZXRzIGFsbCBvZiB0aGUgc2NoZWR1bGluZyByZXF1aXJlbWVudHMgKHJlc291cmNlXG5yZXF1ZXN0LCByZXF1aXJlZER1cmluZ1NjaGVkdWxpbmcgYW50aS1hZmZpbml0eSBleHByZXNzaW9ucywgZXRjLiksXG5jb21wdXRlIGEgc3VtIGJ5IGl0ZXJhdGluZyB0aHJvdWdoIHRoZSBlbGVtZW50cyBvZiB0aGlzIGZpZWxkIGFuZCBhZGRpbmdcblwid2VpZ2h0XCIgdG8gdGhlIHN1bSBpZiB0aGUgbm9kZSBoYXMgcG9kcyB3aGljaCBtYXRjaGVzIHRoZSBjb3JyZXNwb25kaW5nIHBvZEFmZmluaXR5VGVybTsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJUaGUgd2VpZ2h0cyBvZiBhbGwgb2YgdGhlIG1hdGNoZWQgV2VpZ2h0ZWRQb2RBZmZpbml0eVRlcm0gZmllbGRzIGFyZSBhZGRlZCBwZXItbm9kZSB0byBmaW5kIHRoZSBtb3N0IHByZWZlcnJlZCBub2RlKHMpIiwicHJvcGVydGllcyI6eyJwb2RBZmZpbml0eVRlcm0iOnsiZGVzY3JpcHRpb24iOiJSZXF1aXJlZC4gQSBwb2QgYWZmaW5pdHkgdGVybSwgYXNzb2NpYXRlZCB3aXRoIHRoZSBjb3JyZXNwb25kaW5nIHdlaWdodC4iLCJwcm9wZXJ0aWVzIjp7ImxhYmVsU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgYSBzZXQgb2YgcmVzb3VyY2VzLCBpbiB0aGlzIGNhc2UgcG9kcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciB0aGUgc2V0IG9mIG5hbWVzcGFjZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgc2VsZWN0ZWQgYnkgdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIGxpc3RlZCBpbiB0aGUgbmFtZXNwYWNlcyBmaWVsZC5cbm51bGwgc2VsZWN0b3IgYW5kIG51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi5cbkFuIGVtcHR5IHNlbGVjdG9yICh7fSkgbWF0Y2hlcyBhbGwgbmFtZXNwYWNlcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VzIjp7ImRlc2NyaXB0aW9uIjoibmFtZXNwYWNlcyBzcGVjaWZpZXMgYSBzdGF0aWMgbGlzdCBvZiBuYW1lc3BhY2UgbmFtZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgbGlzdGVkIGluIHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBzZWxlY3RlZCBieSBuYW1lc3BhY2VTZWxlY3Rvci5cbm51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IGFuZCBudWxsIG5hbWVzcGFjZVNlbGVjdG9yIG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJ0b3BvbG9neUtleSI6eyJkZXNjcmlwdGlvbiI6IlRoaXMgcG9kIHNob3VsZCBiZSBjby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGggdGhlIHBvZHMgbWF0Y2hpbmdcbnRoZSBsYWJlbFNlbGVjdG9yIGluIHRoZSBzcGVjaWZpZWQgbmFtZXNwYWNlcywgd2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlXG53aG9zZSB2YWx1ZSBvZiB0aGUgbGFiZWwgd2l0aCBrZXkgdG9wb2xvZ3lLZXkgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoIGFueSBvZiB0aGVcbnNlbGVjdGVkIHBvZHMgaXMgcnVubmluZy5cbkVtcHR5IHRvcG9sb2d5S2V5IGlzIG5vdCBhbGxvd2VkLiIsInR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInRvcG9sb2d5S2V5Il0sInR5cGUiOiJvYmplY3QifSwid2VpZ2h0Ijp7ImRlc2NyaXB0aW9uIjoid2VpZ2h0IGFzc29jaWF0ZWQgd2l0aCBtYXRjaGluZyB0aGUgY29ycmVzcG9uZGluZyBwb2RBZmZpbml0eVRlcm0sXG5pbiB0aGUgcmFuZ2UgMS0xMDAuIiwiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwicmVxdWlyZWQiOlsicG9kQWZmaW5pdHlUZXJtIiwid2VpZ2h0Il0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sInJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJJZiB0aGUgYW50aS1hZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgYXJlIG5vdCBtZXQgYXRcbnNjaGVkdWxpbmcgdGltZSwgdGhlIHBvZCB3aWxsIG5vdCBiZSBzY2hlZHVsZWQgb250byB0aGUgbm9kZS5cbklmIHRoZSBhbnRpLWFmZmluaXR5IHJlcXVpcmVtZW50cyBzcGVjaWZpZWQgYnkgdGhpcyBmaWVsZCBjZWFzZSB0byBiZSBtZXRcbmF0IHNvbWUgcG9pbnQgZHVyaW5nIHBvZCBleGVjdXRpb24gKGUuZy4gZHVlIHRvIGEgcG9kIGxhYmVsIHVwZGF0ZSksIHRoZVxuc3lzdGVtIG1heSBvciBtYXkgbm90IHRyeSB0byBldmVudHVhbGx5IGV2aWN0IHRoZSBwb2QgZnJvbSBpdHMgbm9kZS5cbldoZW4gdGhlcmUgYXJlIG11bHRpcGxlIGVsZW1lbnRzLCB0aGUgbGlzdHMgb2Ygbm9kZXMgY29ycmVzcG9uZGluZyB0byBlYWNoXG5wb2RBZmZpbml0eVRlcm0gYXJlIGludGVyc2VjdGVkLCBpLmUuIGFsbCB0ZXJtcyBtdXN0IGJlIHNhdGlzZmllZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkRlZmluZXMgYSBzZXQgb2YgcG9kcyAobmFtZWx5IHRob3NlIG1hdGNoaW5nIHRoZSBsYWJlbFNlbGVjdG9yXG5yZWxhdGl2ZSB0byB0aGUgZ2l2ZW4gbmFtZXNwYWNlKHMpKSB0aGF0IHRoaXMgcG9kIHNob3VsZCBiZVxuY28tbG9jYXRlZCAoYWZmaW5pdHkpIG9yIG5vdCBjby1sb2NhdGVkIChhbnRpLWFmZmluaXR5KSB3aXRoLFxud2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlIHdob3NlIHZhbHVlIG9mXG50aGUgbGFiZWwgd2l0aCBrZXkgXHUwMDNjdG9wb2xvZ3lLZXlcdTAwM2UgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoXG5hIHBvZCBvZiB0aGUgc2V0IG9mIHBvZHMgaXMgcnVubmluZyIsInByb3BlcnRpZXMiOnsibGFiZWxTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciBhIHNldCBvZiByZXNvdXJjZXMsIGluIHRoaXMgY2FzZSBwb2RzLiIsInByb3BlcnRpZXMiOnsibWF0Y2hFeHByZXNzaW9ucyI6eyJkZXNjcmlwdGlvbiI6Im1hdGNoRXhwcmVzc2lvbnMgaXMgYSBsaXN0IG9mIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50cy4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50IGlzIGEgc2VsZWN0b3IgdGhhdCBjb250YWlucyB2YWx1ZXMsIGEga2V5LCBhbmQgYW4gb3BlcmF0b3IgdGhhdFxucmVsYXRlcyB0aGUga2V5IGFuZCB2YWx1ZXMuIiwicHJvcGVydGllcyI6eyJrZXkiOnsiZGVzY3JpcHRpb24iOiJrZXkgaXMgdGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6InZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWNcbm1lcmdlIHBhdGNoLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJrZXkiLCJvcGVyYXRvciJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJtYXRjaExhYmVscyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJ0eXBlIjoic3RyaW5nIn0sImRlc2NyaXB0aW9uIjoibWF0Y2hMYWJlbHMgaXMgYSBtYXAgb2Yge2tleSx2YWx1ZX0gcGFpcnMuIEEgc2luZ2xlIHtrZXksdmFsdWV9IGluIHRoZSBtYXRjaExhYmVsc1xubWFwIGlzIGVxdWl2YWxlbnQgdG8gYW4gZWxlbWVudCBvZiBtYXRjaEV4cHJlc3Npb25zLCB3aG9zZSBrZXkgZmllbGQgaXMgXCJrZXlcIiwgdGhlXG5vcGVyYXRvciBpcyBcIkluXCIsIGFuZCB0aGUgdmFsdWVzIGFycmF5IGNvbnRhaW5zIG9ubHkgXCJ2YWx1ZVwiLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIm5hbWVzcGFjZVNlbGVjdG9yIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBxdWVyeSBvdmVyIHRoZSBzZXQgb2YgbmFtZXNwYWNlcyB0aGF0IHRoZSB0ZXJtIGFwcGxpZXMgdG8uXG5UaGUgdGVybSBpcyBhcHBsaWVkIHRvIHRoZSB1bmlvbiBvZiB0aGUgbmFtZXNwYWNlcyBzZWxlY3RlZCBieSB0aGlzIGZpZWxkXG5hbmQgdGhlIG9uZXMgbGlzdGVkIGluIHRoZSBuYW1lc3BhY2VzIGZpZWxkLlxubnVsbCBzZWxlY3RvciBhbmQgbnVsbCBvciBlbXB0eSBuYW1lc3BhY2VzIGxpc3QgbWVhbnMgXCJ0aGlzIHBvZCdzIG5hbWVzcGFjZVwiLlxuQW4gZW1wdHkgc2VsZWN0b3IgKHt9KSBtYXRjaGVzIGFsbCBuYW1lc3BhY2VzLiIsInByb3BlcnRpZXMiOnsibWF0Y2hFeHByZXNzaW9ucyI6eyJkZXNjcmlwdGlvbiI6Im1hdGNoRXhwcmVzc2lvbnMgaXMgYSBsaXN0IG9mIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50cy4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50IGlzIGEgc2VsZWN0b3IgdGhhdCBjb250YWlucyB2YWx1ZXMsIGEga2V5LCBhbmQgYW4gb3BlcmF0b3IgdGhhdFxucmVsYXRlcyB0aGUga2V5IGFuZCB2YWx1ZXMuIiwicHJvcGVydGllcyI6eyJrZXkiOnsiZGVzY3JpcHRpb24iOiJrZXkgaXMgdGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6InZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWNcbm1lcmdlIHBhdGNoLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJrZXkiLCJvcGVyYXRvciJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJtYXRjaExhYmVscyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJ0eXBlIjoic3RyaW5nIn0sImRlc2NyaXB0aW9uIjoibWF0Y2hMYWJlbHMgaXMgYSBtYXAgb2Yge2tleSx2YWx1ZX0gcGFpcnMuIEEgc2luZ2xlIHtrZXksdmFsdWV9IGluIHRoZSBtYXRjaExhYmVsc1xubWFwIGlzIGVxdWl2YWxlbnQgdG8gYW4gZWxlbWVudCBvZiBtYXRjaEV4cHJlc3Npb25zLCB3aG9zZSBrZXkgZmllbGQgaXMgXCJrZXlcIiwgdGhlXG5vcGVyYXRvciBpcyBcIkluXCIsIGFuZCB0aGUgdmFsdWVzIGFycmF5IGNvbnRhaW5zIG9ubHkgXCJ2YWx1ZVwiLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIm5hbWVzcGFjZXMiOnsiZGVzY3JpcHRpb24iOiJuYW1lc3BhY2VzIHNwZWNpZmllcyBhIHN0YXRpYyBsaXN0IG9mIG5hbWVzcGFjZSBuYW1lcyB0aGF0IHRoZSB0ZXJtIGFwcGxpZXMgdG8uXG5UaGUgdGVybSBpcyBhcHBsaWVkIHRvIHRoZSB1bmlvbiBvZiB0aGUgbmFtZXNwYWNlcyBsaXN0ZWQgaW4gdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIHNlbGVjdGVkIGJ5IG5hbWVzcGFjZVNlbGVjdG9yLlxubnVsbCBvciBlbXB0eSBuYW1lc3BhY2VzIGxpc3QgYW5kIG51bGwgbmFtZXNwYWNlU2VsZWN0b3IgbWVhbnMgXCJ0aGlzIHBvZCdzIG5hbWVzcGFjZVwiLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In0sInRvcG9sb2d5S2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhpcyBwb2Qgc2hvdWxkIGJlIGNvLWxvY2F0ZWQgKGFmZmluaXR5KSBvciBub3QgY28tbG9jYXRlZCAoYW50aS1hZmZpbml0eSkgd2l0aCB0aGUgcG9kcyBtYXRjaGluZ1xudGhlIGxhYmVsU2VsZWN0b3IgaW4gdGhlIHNwZWNpZmllZCBuYW1lc3BhY2VzLCB3aGVyZSBjby1sb2NhdGVkIGlzIGRlZmluZWQgYXMgcnVubmluZyBvbiBhIG5vZGVcbndob3NlIHZhbHVlIG9mIHRoZSBsYWJlbCB3aXRoIGtleSB0b3BvbG9neUtleSBtYXRjaGVzIHRoYXQgb2YgYW55IG5vZGUgb24gd2hpY2ggYW55IG9mIHRoZVxuc2VsZWN0ZWQgcG9kcyBpcyBydW5uaW5nLlxuRW1wdHkgdG9wb2xvZ3lLZXkgaXMgbm90IGFsbG93ZWQuIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsidG9wb2xvZ3lLZXkiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifX0sInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QifSwiaW1hZ2UiOnsidHlwZSI6InN0cmluZyJ9LCJpbWFnZVB1bGxTZWNyZXRzIjp7Iml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwidHlwZSI6ImFycmF5In0sImxpbWl0cyI6eyJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IlJhdGVMaW1pdCBkZWZpbmVzIHRoZSBkZXNpcmVkIExpbWl0YWRvciBsaW1pdCIsInByb3BlcnRpZXMiOnsiY29uZGl0aW9ucyI6eyJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJtYXhfdmFsdWUiOnsidHlwZSI6ImludGVnZXIifSwibmFtZSI6eyJ0eXBlIjoic3RyaW5nIn0sIm5hbWVzcGFjZSI6eyJ0eXBlIjoic3RyaW5nIn0sInNlY29uZHMiOnsidHlwZSI6ImludGVnZXIifSwidmFyaWFibGVzIjp7Iml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJjb25kaXRpb25zIiwibWF4X3ZhbHVlIiwibmFtZXNwYWNlIiwic2Vjb25kcyIsInZhcmlhYmxlcyJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJsaXN0ZW5lciI6eyJwcm9wZXJ0aWVzIjp7ImdycGMiOnsicHJvcGVydGllcyI6eyJwb3J0Ijp7ImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifX0sInR5cGUiOiJvYmplY3QifSwiaHR0cCI6eyJwcm9wZXJ0aWVzIjp7InBvcnQiOnsiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9LCJwZGIiOnsicHJvcGVydGllcyI6eyJtYXhVbmF2YWlsYWJsZSI6eyJhbnlPZiI6W3sidHlwZSI6ImludGVnZXIifSx7InR5cGUiOiJzdHJpbmcifV0sImRlc2NyaXB0aW9uIjoiQW4gZXZpY3Rpb24gaXMgYWxsb3dlZCBpZiBhdCBtb3N0IFwibWF4VW5hdmFpbGFibGVcIiBsaW1pdGFkb3IgcG9kc1xuYXJlIHVuYXZhaWxhYmxlIGFmdGVyIHRoZSBldmljdGlvbiwgaS5lLiBldmVuIGluIGFic2VuY2Ugb2ZcbnRoZSBldmljdGVkIHBvZC4gRm9yIGV4YW1wbGUsIG9uZSBjYW4gcHJldmVudCBhbGwgdm9sdW50YXJ5IGV2aWN0aW9uc1xuYnkgc3BlY2lmeWluZyAwLiBUaGlzIGlzIGEgbXV0dWFsbHkgZXhjbHVzaXZlIHNldHRpbmcgd2l0aCBcIm1pbkF2YWlsYWJsZVwiLiIsIngta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nIjp0cnVlfSwibWluQXZhaWxhYmxlIjp7ImFueU9mIjpbeyJ0eXBlIjoiaW50ZWdlciJ9LHsidHlwZSI6InN0cmluZyJ9XSwiZGVzY3JpcHRpb24iOiJBbiBldmljdGlvbiBpcyBhbGxvd2VkIGlmIGF0IGxlYXN0IFwibWluQXZhaWxhYmxlXCIgbGltaXRhZG9yIHBvZHMgd2lsbFxuc3RpbGwgYmUgYXZhaWxhYmxlIGFmdGVyIHRoZSBldmljdGlvbiwgaS5lLiBldmVuIGluIHRoZSBhYnNlbmNlIG9mXG50aGUgZXZpY3RlZCBwb2QuICBTbyBmb3IgZXhhbXBsZSB5b3UgY2FuIHByZXZlbnQgYWxsIHZvbHVudGFyeVxuZXZpY3Rpb25zIGJ5IHNwZWNpZnlpbmcgXCIxMDAlXCIuIiwieC1rdWJlcm5ldGVzLWludC1vci1zdHJpbmciOnRydWV9fSwidHlwZSI6Im9iamVjdCJ9LCJyYXRlTGltaXRIZWFkZXJzIjp7ImRlc2NyaXB0aW9uIjoiUmF0ZUxpbWl0SGVhZGVyc1R5cGUgZGVmaW5lcyB0aGUgdmFsaWQgb3B0aW9ucyBmb3IgdGhlIC0tcmF0ZS1saW1pdC1oZWFkZXJzIGFyZyIsImVudW0iOlsiTk9ORSIsIkRSQUZUX1ZFUlNJT05fMDMiXSwidHlwZSI6InN0cmluZyJ9LCJyZXBsaWNhcyI6eyJ0eXBlIjoiaW50ZWdlciJ9LCJyZXNvdXJjZVJlcXVpcmVtZW50cyI6eyJkZXNjcmlwdGlvbiI6IlJlc291cmNlUmVxdWlyZW1lbnRzIGRlc2NyaWJlcyB0aGUgY29tcHV0ZSByZXNvdXJjZSByZXF1aXJlbWVudHMuIiwicHJvcGVydGllcyI6eyJjbGFpbXMiOnsiZGVzY3JpcHRpb24iOiJDbGFpbXMgbGlzdHMgdGhlIG5hbWVzIG9mIHJlc291cmNlcywgZGVmaW5lZCBpbiBzcGVjLnJlc291cmNlQ2xhaW1zLFxudGhhdCBhcmUgdXNlZCBieSB0aGlzIGNvbnRhaW5lci5cblxuXG5UaGlzIGlzIGFuIGFscGhhIGZpZWxkIGFuZCByZXF1aXJlcyBlbmFibGluZyB0aGVcbkR5bmFtaWNSZXNvdXJjZUFsbG9jYXRpb24gZmVhdHVyZSBnYXRlLlxuXG5cblRoaXMgZmllbGQgaXMgaW1tdXRhYmxlLiBJdCBjYW4gb25seSBiZSBzZXQgZm9yIGNvbnRhaW5lcnMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJSZXNvdXJjZUNsYWltIHJlZmVyZW5jZXMgb25lIGVudHJ5IGluIFBvZFNwZWMuUmVzb3VyY2VDbGFpbXMuIiwicHJvcGVydGllcyI6eyJuYW1lIjp7ImRlc2NyaXB0aW9uIjoiTmFtZSBtdXN0IG1hdGNoIHRoZSBuYW1lIG9mIG9uZSBlbnRyeSBpbiBwb2Quc3BlYy5yZXNvdXJjZUNsYWltcyBvZlxudGhlIFBvZCB3aGVyZSB0aGlzIGZpZWxkIGlzIHVzZWQuIEl0IG1ha2VzIHRoYXQgcmVzb3VyY2UgYXZhaWxhYmxlXG5pbnNpZGUgYSBjb250YWluZXIuIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsibmFtZSJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSIsIngta3ViZXJuZXRlcy1saXN0LW1hcC1rZXlzIjpbIm5hbWUiXSwieC1rdWJlcm5ldGVzLWxpc3QtdHlwZSI6Im1hcCJ9LCJsaW1pdHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsiYW55T2YiOlt7InR5cGUiOiJpbnRlZ2VyIn0seyJ0eXBlIjoic3RyaW5nIn1dLCJwYXR0ZXJuIjoiXihcXCt8LSk/KChbMC05XSsoXFwuWzAtOV0qKT8pfChcXC5bMC05XSspKSgoW0tNR1RQRV1pKXxbbnVta01HVFBFXXwoW2VFXShcXCt8LSk/KChbMC05XSsoXFwuWzAtOV0qKT8pfChcXC5bMC05XSspKSkpPyQiLCJ4LWt1YmVybmV0ZXMtaW50LW9yLXN0cmluZyI6dHJ1ZX0sImRlc2NyaXB0aW9uIjoiTGltaXRzIGRlc2NyaWJlcyB0aGUgbWF4aW11bSBhbW91bnQgb2YgY29tcHV0ZSByZXNvdXJjZXMgYWxsb3dlZC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvY29uZmlndXJhdGlvbi9tYW5hZ2UtcmVzb3VyY2VzLWNvbnRhaW5lcnMvIiwidHlwZSI6Im9iamVjdCJ9LCJyZXF1ZXN0cyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJhbnlPZiI6W3sidHlwZSI6ImludGVnZXIifSx7InR5cGUiOiJzdHJpbmcifV0sInBhdHRlcm4iOiJeKFxcK3wtKT8oKFswLTldKyhcXC5bMC05XSopPyl8KFxcLlswLTldKykpKChbS01HVFBFXWkpfFtudW1rTUdUUEVdfChbZUVdKFxcK3wtKT8oKFswLTldKyhcXC5bMC05XSopPyl8KFxcLlswLTldKykpKSk/JCIsIngta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nIjp0cnVlfSwiZGVzY3JpcHRpb24iOiJSZXF1ZXN0cyBkZXNjcmliZXMgdGhlIG1pbmltdW0gYW1vdW50IG9mIGNvbXB1dGUgcmVzb3VyY2VzIHJlcXVpcmVkLlxuSWYgUmVxdWVzdHMgaXMgb21pdHRlZCBmb3IgYSBjb250YWluZXIsIGl0IGRlZmF1bHRzIHRvIExpbWl0cyBpZiB0aGF0IGlzIGV4cGxpY2l0bHkgc3BlY2lmaWVkLFxub3RoZXJ3aXNlIHRvIGFuIGltcGxlbWVudGF0aW9uLWRlZmluZWQgdmFsdWUuIFJlcXVlc3RzIGNhbm5vdCBleGNlZWQgTGltaXRzLlxuTW9yZSBpbmZvOiBodHRwczovL2t1YmVybmV0ZXMuaW8vZG9jcy9jb25jZXB0cy9jb25maWd1cmF0aW9uL21hbmFnZS1yZXNvdXJjZXMtY29udGFpbmVycy8iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In0sInN0b3JhZ2UiOnsiZGVzY3JpcHRpb24iOiJTdG9yYWdlIGNvbnRhaW5zIHRoZSBvcHRpb25zIGZvciBMaW1pdGFkb3IgY291bnRlcnMgZGF0YWJhc2Ugb3IgaW4tbWVtb3J5IGRhdGEgc3RvcmFnZSIsInByb3BlcnRpZXMiOnsiZGlzayI6eyJwcm9wZXJ0aWVzIjp7Im9wdGltaXplIjp7ImRlc2NyaXB0aW9uIjoiRGlza09wdGltaXplVHlwZSBkZWZpbmVzIHRoZSB2YWxpZCBvcHRpb25zIGZvciBcIm9wdGltaXplXCIgb3B0aW9uIG9mIHRoZSBkaXNrIHBlcnNpc3RlbmNlIHR5cGUiLCJlbnVtIjpbInRocm91Z2hwdXQiLCJkaXNrIl0sInR5cGUiOiJzdHJpbmcifSwicGVyc2lzdGVudFZvbHVtZUNsYWltIjp7InByb3BlcnRpZXMiOnsicmVzb3VyY2VzIjp7ImRlc2NyaXB0aW9uIjoiUmVzb3VyY2VzIHJlcHJlc2VudHMgdGhlIG1pbmltdW0gcmVzb3VyY2VzIHRoZSB2b2x1bWUgc2hvdWxkIGhhdmUuXG5JZ25vcmVkIHdoZW4gVm9sdW1lTmFtZSBmaWVsZCBpcyBzZXQiLCJwcm9wZXJ0aWVzIjp7InJlcXVlc3RzIjp7ImFueU9mIjpbeyJ0eXBlIjoiaW50ZWdlciJ9LHsidHlwZSI6InN0cmluZyJ9XSwiZGVzY3JpcHRpb24iOiJTdG9yYWdlIFJlc291cmNlIHJlcXVlc3RzIHRvIGJlIHVzZWQgb24gdGhlIFBlcnNpc3RlbnRWb2x1bWVDbGFpbS5cblRvIGxlYXJuIG1vcmUgYWJvdXQgcmVzb3VyY2UgcmVxdWVzdHMgc2VlOlxuaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvY29uZmlndXJhdGlvbi9tYW5hZ2UtcmVzb3VyY2VzLWNvbnRhaW5lcnMvIiwicGF0dGVybiI6Il4oXFwrfC0pPygoWzAtOV0rKFxcLlswLTldKik/KXwoXFwuWzAtOV0rKSkoKFtLTUdUUEVdaSl8W251bWtNR1RQRV18KFtlRV0oXFwrfC0pPygoWzAtOV0rKFxcLlswLTldKik/KXwoXFwuWzAtOV0rKSkpKT8kIiwieC1rdWJlcm5ldGVzLWludC1vci1zdHJpbmciOnRydWV9fSwicmVxdWlyZWQiOlsicmVxdWVzdHMiXSwidHlwZSI6Im9iamVjdCJ9LCJzdG9yYWdlQ2xhc3NOYW1lIjp7InR5cGUiOiJzdHJpbmcifSwidm9sdW1lTmFtZSI6eyJkZXNjcmlwdGlvbiI6IlZvbHVtZU5hbWUgaXMgdGhlIGJpbmRpbmcgcmVmZXJlbmNlIHRvIHRoZSBQZXJzaXN0ZW50Vm9sdW1lIGJhY2tpbmcgdGhpcyBjbGFpbS4iLCJ0eXBlIjoic3RyaW5nIn19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In0sInJlZGlzIjp7InByb3BlcnRpZXMiOnsiY29uZmlnU2VjcmV0UmVmIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifX0sInR5cGUiOiJvYmplY3QifSwicmVkaXMtY2FjaGVkIjp7InByb3BlcnRpZXMiOnsiY29uZmlnU2VjcmV0UmVmIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwib3B0aW9ucyI6eyJwcm9wZXJ0aWVzIjp7ImJhdGNoLXNpemUiOnsiZGVzY3JpcHRpb24iOiJCYXRjaFNpemUgZGVmaW5lcyB0aGUgc2l6ZSBvZiBlbnRyaWVzIHRvIGZsdXNoIGluIGFzIHNpbmdsZSBmbHVzaCBbZGVmYXVsdDogMTAwXSIsInR5cGUiOiJpbnRlZ2VyIn0sImZsdXNoLXBlcmlvZCI6eyJkZXNjcmlwdGlvbiI6IkZsdXNoUGVyaW9kIGZvciBjb3VudGVycyBpbiBtaWxsaXNlY29uZHMgW2RlZmF1bHQ6IDEwMDBdIiwidHlwZSI6ImludGVnZXIifSwibWF4LWNhY2hlZCI6eyJkZXNjcmlwdGlvbiI6Ik1heENhY2hlZCByZWZlcnMgdG8gdGhlIG1heGltdW0gYW1vdW50IG9mIGNvdW50ZXJzIGNhY2hlZCBbZGVmYXVsdDogMTAwMDBdIiwidHlwZSI6ImludGVnZXIifSwicmVzcG9uc2UtdGltZW91dCI6eyJkZXNjcmlwdGlvbiI6IlJlc3BvbnNlVGltZW91dCBkZWZpbmVzIHRoZSB0aW1lb3V0IGZvciBSZWRpcyBjb21tYW5kcyBpbiBtaWxsaXNlY29uZHMgW2RlZmF1bHQ6IDM1MF0iLCJ0eXBlIjoiaW50ZWdlciJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9LCJ0ZWxlbWV0cnkiOnsiZGVzY3JpcHRpb24iOiJUZWxlbWV0cnkgZGVmaW5lcyB0aGUgbGV2ZWwgb2YgbWV0cmljcyBMaW1pdGFkb3Igd2lsbCBleHBvc2UgdG8gdGhlIHVzZXIiLCJlbnVtIjpbImJhc2ljIiwiZXhoYXVzdGl2ZSJdLCJ0eXBlIjoic3RyaW5nIn0sInRyYWNpbmciOnsicHJvcGVydGllcyI6eyJlbmRwb2ludCI6eyJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJlbmRwb2ludCJdLCJ0eXBlIjoib2JqZWN0In0sInZlcmJvc2l0eSI6eyJkZXNjcmlwdGlvbiI6IlNldHMgdGhlIGxldmVsIG9mIHZlcmJvc2l0eSIsIm1heGltdW0iOjQsIm1pbmltdW0iOjEsInR5cGUiOiJpbnRlZ2VyIn0sInZlcnNpb24iOnsiZGVzY3JpcHRpb24iOiJbRGVwcmVjYXRlZF0gVXNlIHNwZWMuaW1hZ2UgaW5zdGVhZC5cbiBEb2NrZXIgdGFnIHVzZWQgYXMgbGltaXRhZG9yIGltYWdlLiBUaGUgcmVwbyBpcyBoYXJkY29kZWQgdG8gcXVheS5pby9rdWFkcmFudC9saW1pdGFkb3IiLCJ0eXBlIjoic3RyaW5nIn19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLXZhbGlkYXRpb25zIjpbeyJtZXNzYWdlIjoiZGlzayBzdG9yYWdlIGRvZXMgbm90IGFsbG93IG11bHRpcGxlIHJlcGxpY2FzIiwicnVsZSI6IighaGFzKHNlbGYuc3RvcmFnZSkgfHwgIWhhcyhzZWxmLnN0b3JhZ2UuZGlzaykpIHx8ICghaGFzKHNlbGYucmVwbGljYXMpIHx8IHNlbGYucmVwbGljYXMgXHUwMDNjIDIpIn1dfSwic3RhdHVzIjp7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yU3RhdHVzIGRlZmluZXMgdGhlIG9ic2VydmVkIHN0YXRlIG9mIExpbWl0YWRvciIsInByb3BlcnRpZXMiOnsiY29uZGl0aW9ucyI6eyJkZXNjcmlwdGlvbiI6IlJlcHJlc2VudHMgdGhlIG9ic2VydmF0aW9ucyBvZiBhIGZvbydzIGN1cnJlbnQgc3RhdGUuXG5Lbm93biAuc3RhdHVzLmNvbmRpdGlvbnMudHlwZSBhcmU6IFwiUmVhZHlcIiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQ29uZGl0aW9uIGNvbnRhaW5zIGRldGFpbHMgZm9yIG9uZSBhc3BlY3Qgb2YgdGhlIGN1cnJlbnQgc3RhdGUgb2YgdGhpcyBBUEkgUmVzb3VyY2UuXG4tLS1cblRoaXMgc3RydWN0IGlzIGludGVuZGVkIGZvciBkaXJlY3QgdXNlIGFzIGFuIGFycmF5IGF0IHRoZSBmaWVsZCBwYXRoIC5zdGF0dXMuY29uZGl0aW9ucy4gIEZvciBleGFtcGxlLFxuXG5cblx0dHlwZSBGb29TdGF0dXMgc3RydWN0e1xuXHQgICAgLy8gUmVwcmVzZW50cyB0aGUgb2JzZXJ2YXRpb25zIG9mIGEgZm9vJ3MgY3VycmVudCBzdGF0ZS5cblx0ICAgIC8vIEtub3duIC5zdGF0dXMuY29uZGl0aW9ucy50eXBlIGFyZTogXCJBdmFpbGFibGVcIiwgXCJQcm9ncmVzc2luZ1wiLCBhbmQgXCJEZWdyYWRlZFwiXG5cdCAgICAvLyArcGF0Y2hNZXJnZUtleT10eXBlXG5cdCAgICAvLyArcGF0Y2hTdHJhdGVneT1tZXJnZVxuXHQgICAgLy8gK2xpc3RUeXBlPW1hcFxuXHQgICAgLy8gK2xpc3RNYXBLZXk9dHlwZVxuXHQgICAgQ29uZGl0aW9ucyBbXW1ldGF2MS5Db25kaXRpb24gYGpzb246XCJjb25kaXRpb25zLG9taXRlbXB0eVwiIHBhdGNoU3RyYXRlZ3k6XCJtZXJnZVwiIHBhdGNoTWVyZ2VLZXk6XCJ0eXBlXCIgcHJvdG9idWY6XCJieXRlcywxLHJlcCxuYW1lPWNvbmRpdGlvbnNcImBcblxuXG5cdCAgICAvLyBvdGhlciBmaWVsZHNcblx0fSIsInByb3BlcnRpZXMiOnsibGFzdFRyYW5zaXRpb25UaW1lIjp7ImRlc2NyaXB0aW9uIjoibGFzdFRyYW5zaXRpb25UaW1lIGlzIHRoZSBsYXN0IHRpbWUgdGhlIGNvbmRpdGlvbiB0cmFuc2l0aW9uZWQgZnJvbSBvbmUgc3RhdHVzIHRvIGFub3RoZXIuXG5UaGlzIHNob3VsZCBiZSB3aGVuIHRoZSB1bmRlcmx5aW5nIGNvbmRpdGlvbiBjaGFuZ2VkLiAgSWYgdGhhdCBpcyBub3Qga25vd24sIHRoZW4gdXNpbmcgdGhlIHRpbWUgd2hlbiB0aGUgQVBJIGZpZWxkIGNoYW5nZWQgaXMgYWNjZXB0YWJsZS4iLCJmb3JtYXQiOiJkYXRlLXRpbWUiLCJ0eXBlIjoic3RyaW5nIn0sIm1lc3NhZ2UiOnsiZGVzY3JpcHRpb24iOiJtZXNzYWdlIGlzIGEgaHVtYW4gcmVhZGFibGUgbWVzc2FnZSBpbmRpY2F0aW5nIGRldGFpbHMgYWJvdXQgdGhlIHRyYW5zaXRpb24uXG5UaGlzIG1heSBiZSBhbiBlbXB0eSBzdHJpbmcuIiwibWF4TGVuZ3RoIjozMjc2OCwidHlwZSI6InN0cmluZyJ9LCJvYnNlcnZlZEdlbmVyYXRpb24iOnsiZGVzY3JpcHRpb24iOiJvYnNlcnZlZEdlbmVyYXRpb24gcmVwcmVzZW50cyB0aGUgLm1ldGFkYXRhLmdlbmVyYXRpb24gdGhhdCB0aGUgY29uZGl0aW9uIHdhcyBzZXQgYmFzZWQgdXBvbi5cbkZvciBpbnN0YW5jZSwgaWYgLm1ldGFkYXRhLmdlbmVyYXRpb24gaXMgY3VycmVudGx5IDEyLCBidXQgdGhlIC5zdGF0dXMuY29uZGl0aW9uc1t4XS5vYnNlcnZlZEdlbmVyYXRpb24gaXMgOSwgdGhlIGNvbmRpdGlvbiBpcyBvdXQgb2YgZGF0ZVxud2l0aCByZXNwZWN0IHRvIHRoZSBjdXJyZW50IHN0YXRlIG9mIHRoZSBpbnN0YW5jZS4iLCJmb3JtYXQiOiJpbnQ2NCIsIm1pbmltdW0iOjAsInR5cGUiOiJpbnRlZ2VyIn0sInJlYXNvbiI6eyJkZXNjcmlwdGlvbiI6InJlYXNvbiBjb250YWlucyBhIHByb2dyYW1tYXRpYyBpZGVudGlmaWVyIGluZGljYXRpbmcgdGhlIHJlYXNvbiBmb3IgdGhlIGNvbmRpdGlvbidzIGxhc3QgdHJhbnNpdGlvbi5cblByb2R1Y2VycyBvZiBzcGVjaWZpYyBjb25kaXRpb24gdHlwZXMgbWF5IGRlZmluZSBleHBlY3RlZCB2YWx1ZXMgYW5kIG1lYW5pbmdzIGZvciB0aGlzIGZpZWxkLFxuYW5kIHdoZXRoZXIgdGhlIHZhbHVlcyBhcmUgY29uc2lkZXJlZCBhIGd1YXJhbnRlZWQgQVBJLlxuVGhlIHZhbHVlIHNob3VsZCBiZSBhIENhbWVsQ2FzZSBzdHJpbmcuXG5UaGlzIGZpZWxkIG1heSBub3QgYmUgZW1wdHkuIiwibWF4TGVuZ3RoIjoxMDI0LCJtaW5MZW5ndGgiOjEsInBhdHRlcm4iOiJeW0EtWmEtel0oW0EtWmEtejAtOV8sOl0qW0EtWmEtejAtOV9dKT8kIiwidHlwZSI6InN0cmluZyJ9LCJzdGF0dXMiOnsiZGVzY3JpcHRpb24iOiJzdGF0dXMgb2YgdGhlIGNvbmRpdGlvbiwgb25lIG9mIFRydWUsIEZhbHNlLCBVbmtub3duLiIsImVudW0iOlsiVHJ1ZSIsIkZhbHNlIiwiVW5rbm93biJdLCJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOnsiZGVzY3JpcHRpb24iOiJ0eXBlIG9mIGNvbmRpdGlvbiBpbiBDYW1lbENhc2Ugb3IgaW4gZm9vLmV4YW1wbGUuY29tL0NhbWVsQ2FzZS5cbi0tLVxuTWFueSAuY29uZGl0aW9uLnR5cGUgdmFsdWVzIGFyZSBjb25zaXN0ZW50IGFjcm9zcyByZXNvdXJjZXMgbGlrZSBBdmFpbGFibGUsIGJ1dCBiZWNhdXNlIGFyYml0cmFyeSBjb25kaXRpb25zIGNhbiBiZVxudXNlZnVsIChzZWUgLm5vZGUuc3RhdHVzLmNvbmRpdGlvbnMpLCB0aGUgYWJpbGl0eSB0byBkZWNvbmZsaWN0IGlzIGltcG9ydGFudC5cblRoZSByZWdleCBpdCBtYXRjaGVzIGlzIChkbnMxMTIzU3ViZG9tYWluRm10Lyk/KHF1YWxpZmllZE5hbWVGbXQpIiwibWF4TGVuZ3RoIjozMTYsInBhdHRlcm4iOiJeKFthLXowLTldKFstYS16MC05XSpbYS16MC05XSk/KFxcLlthLXowLTldKFstYS16MC05XSpbYS16MC05XSk/KSovKT8oKFtBLVphLXowLTldWy1BLVphLXowLTlfLl0qKT9bQS1aYS16MC05XSkkIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsibGFzdFRyYW5zaXRpb25UaW1lIiwibWVzc2FnZSIsInJlYXNvbiIsInN0YXR1cyIsInR5cGUiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkiLCJ4LWt1YmVybmV0ZXMtbGlzdC1tYXAta2V5cyI6WyJ0eXBlIl0sIngta3ViZXJuZXRlcy1saXN0LXR5cGUiOiJtYXAifSwib2JzZXJ2ZWRHZW5lcmF0aW9uIjp7ImRlc2NyaXB0aW9uIjoiT2JzZXJ2ZWRHZW5lcmF0aW9uIHJlZmxlY3RzIHRoZSBnZW5lcmF0aW9uIG9mIHRoZSBtb3N0IHJlY2VudGx5IG9ic2VydmVkIHNwZWMuIiwiZm9ybWF0IjoiaW50NjQiLCJ0eXBlIjoiaW50ZWdlciJ9LCJzZXJ2aWNlIjp7ImRlc2NyaXB0aW9uIjoiU2VydmljZSBwcm92aWRlcyBpbmZvcm1hdGlvbiBhYm91dCB0aGUgc2VydmljZSBleHBvc2luZyBsaW1pdGFkb3IgQVBJIiwicHJvcGVydGllcyI6eyJob3N0Ijp7InR5cGUiOiJzdHJpbmcifSwicG9ydHMiOnsicHJvcGVydGllcyI6eyJncnBjIjp7ImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifSwiaHR0cCI6eyJmb3JtYXQiOiJpbnQzMiIsInR5cGUiOiJpbnRlZ2VyIn19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJzZXJ2ZWQiOnRydWUsInN0b3JhZ2UiOnRydWUsInN1YnJlc291cmNlcyI6eyJzdGF0dXMiOnt9fX1dfSwic3RhdHVzIjp7ImFjY2VwdGVkTmFtZXMiOnsia2luZCI6IiIsInBsdXJhbCI6IiJ9LCJjb25kaXRpb25zIjpudWxsLCJzdG9yZWRWZXJzaW9ucyI6bnVsbH19
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsiYWxtLWV4YW1wbGVzIjoiW1xuICB7XG4gICAgXCJhcGlWZXJzaW9uXCI6IFwibGltaXRhZG9yLmt1YWRyYW50LmlvL3YxYWxwaGExXCIsXG4gICAgXCJraW5kXCI6IFwiTGltaXRhZG9yXCIsXG4gICAgXCJtZXRhZGF0YVwiOiB7XG4gICAgICBcIm5hbWVcIjogXCJsaW1pdGFkb3Itc2FtcGxlXCJcbiAgICB9LFxuICAgIFwic3BlY1wiOiB7XG4gICAgICBcImxpbWl0c1wiOiBbXG4gICAgICAgIHtcbiAgICAgICAgICBcImNvbmRpdGlvbnNcIjogW1xuICAgICAgICAgICAgXCJnZXRfdG95ID09ICd5ZXMnXCJcbiAgICAgICAgICBdLFxuICAgICAgICAgIFwibWF4X3ZhbHVlXCI6IDIsXG4gICAgICAgICAgXCJuYW1lXCI6IFwidG95X2dldF9yb3V0ZVwiLFxuICAgICAgICAgIFwibmFtZXNwYWNlXCI6IFwidG95c3RvcmUtYXBwXCIsXG4gICAgICAgICAgXCJzZWNvbmRzXCI6IDMwLFxuICAgICAgICAgIFwidmFyaWFibGVzXCI6IFtdXG4gICAgICAgIH1cbiAgICAgIF0sXG4gICAgICBcImxpc3RlbmVyXCI6IHtcbiAgICAgICAgXCJncnBjXCI6IHtcbiAgICAgICAgICBcInBvcnRcIjogODA4MVxuICAgICAgICB9LFxuICAgICAgICBcImh0dHBcIjoge1xuICAgICAgICAgIFwicG9ydFwiOiA4MDgwXG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9XG4gIH1cbl0iLCJjYXBhYmlsaXRpZXMiOiJCYXNpYyBJbnN0YWxsIiwiY2F0ZWdvcmllcyI6IkludGVncmF0aW9uIFx1MDAyNiBEZWxpdmVyeSIsImNvbnRhaW5lckltYWdlIjoicmVnaXN0cnkucmVkaGF0LmlvL3JoY2wtMS9saW1pdGFkb3ItcmhlbDktb3BlcmF0b3JAc2hhMjU2OmIzMWJhMjkzODEyNzg4ZGM3ZTIxYzE0NzAzYWM2MWZkZDViZmYwMTA5NDhhZGEzMzcxNTU0NGJhNTA3ODUxZjciLCJjcmVhdGVkQXQiOiIyMyBTZXAgMjAyNSwgMTI6MTkiLCJkZXNjcmlwdGlvbiI6IkVuYWJsZXMgcmF0ZSBsaW1pdGluZyBmb3IgR2F0ZXdheXMgYW5kIGFwcGxpY2F0aW9ucyBpbiBhIEdhdGV3YXkgQVBJIG5ldHdvcmsiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2NuZiI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby9jbmkiOiJmYWxzZSIsImZlYXR1cmVzLm9wZXJhdG9ycy5vcGVuc2hpZnQuaW8vY3NpIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2Rpc2Nvbm5lY3RlZCI6InRydWUiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2ZpcHMtY29tcGxpYW50IjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Byb3h5LWF3YXJlIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Rscy1wcm9maWxlcyI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby90b2tlbi1hdXRoLWF3cyI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby90b2tlbi1hdXRoLWF6dXJlIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Rva2VuLWF1dGgtZ2NwIjoiZmFsc2UiLCJvcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3ZhbGlkLXN1YnNjcmlwdGlvbiI6IltcIlJlZCBIYXQgQ29ubmVjdGl2aXR5IExpbmtcIl0iLCJvcGVyYXRvcnMub3BlcmF0b3JmcmFtZXdvcmsuaW8vYnVpbGRlciI6Im9wZXJhdG9yLXNkay12MS4zMi4wIiwib3BlcmF0b3JzLm9wZXJhdG9yZnJhbWV3b3JrLmlvL3Byb2plY3RfbGF5b3V0IjoiZ28ua3ViZWJ1aWxkZXIuaW8vdjMiLCJyZXBvc2l0b3J5IjoiaHR0cHM6Ly9naXRodWIuY29tL2t1YWRyYW50L2xpbWl0YWRvci1vcGVyYXRvciIsInN1cHBvcnQiOiJrdWFkcmFudCJ9LCJsYWJlbHMiOnsib3BlcmF0b3JmcmFtZXdvcmsuaW8vb3MubGludXgiOiJzdXBwb3J0ZWQifSwibmFtZSI6ImxpbWl0YWRvci1vcGVyYXRvci52MS4xLjEiLCJuYW1lc3BhY2UiOiJwbGFjZWhvbGRlciJ9LCJzcGVjIjp7ImFwaXNlcnZpY2VkZWZpbml0aW9ucyI6e30sImN1c3RvbXJlc291cmNlZGVmaW5pdGlvbnMiOnsib3duZWQiOlt7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yIGlzIHRoZSBTY2hlbWEgZm9yIHRoZSBsaW1pdGFkb3JzIEFQSSIsImRpc3BsYXlOYW1lIjoiTGltaXRhZG9yIiwia2luZCI6IkxpbWl0YWRvciIsIm5hbWUiOiJsaW1pdGFkb3JzLmxpbWl0YWRvci5rdWFkcmFudC5pbyIsInZlcnNpb24iOiJ2MWFscGhhMSJ9XX0sImRlc2NyaXB0aW9uIjoiVGhlIExpbWl0YWRvciBvcGVyYXRvciBpbnN0YWxscyBhbmQgbWFpbnRhaW5zIGxpbWl0YWRvciBpbnN0YW5jZXMiLCJkaXNwbGF5TmFtZSI6IkxpbWl0YWRvciIsImljb24iOlt7ImJhc2U2NGRhdGEiOiJpVkJPUncwS0dnb0FBQUFOU1VoRVVnQUFBWHdBQUFGOENBWUFBQURNNXdES0FBQUFDWEJJV1hNQUFHNjZBQUJ1dWdIVzNyRVhBQUFnQUVsRVFWUjRuTzNkZjJ6VDE3My84VGNRbDhRRTI4T0FETVVrc0lrb0lWbmNhRlNEUmpmNWE1cGEzWkpxZjFTcjdsZGswdjRvdXQ4Sjc0K3BXeldKSU8xMlEvc25hSnJhUHlZVmRMOXF0VCttaG43VmFkby9KVmZRVG1OcUhTV0FFcTJRa0FJV0VHb2JFNXZhbFB1SEU2QWRGSC9PT1o5Zi9qd2ZValhwWG81OVZLa3ZIODU1bi9kWmNmZnVYUUVBTkw2VmJrOEFBT0FNQWg4QUFvTEFCNENBSVBBQklDQUlmQUFJQ0FJZkFBS0N3QWVBZ0NEd0FTQWdDSHdBQ0lnbXR5ZlFxTHE2dXZwWHJWcjFuVkFvTkxCeTVjcHZORGMzZDZ4YXRhcFpSQ1FhamNiY25oL2d0bncrbnhNUnVYUG5UcmxjTGs5LzhjVVhuMVVxbGZFN2QrNzg0K3pac3lmZG5sOGpXa0ZyQlgwOVBUM3BWYXRXZmIrbHBlVmJMUzB0bTF0YlcxdmNuaFBnZDhWaXNWUXFsUzdmdm4xN3NsS3BqRTlPVG82NlBTZS9JL0F0NnV6c2JIdmlpU2RlWHIxNjlmZGJXMXM3Q0hmQU9jVmlzVlFzRnFkdjM3NzlsODgvLy95TmMrZk96Yms5Sno4aDhPdlEzZDM5WW5OejgvNUlKUEkwQVE5NFI3RllMQlVLaGIrWHkrWFhwNmFtL3VqMmZMeU93SCtFN3U3dUY4UGg4TTlqc1ZoM2MzTXpaeDJBeDVYTDVXb3VsNXRhWEZ6OERlSC9jQVQrQTdxNnV2ckQ0ZkN2MXExYjl3d2hEL2hYdVZ5dTNyaHg0OVRpNHVJdk9RQytqOEFYa1ZRcTlZZG9OUG9EcW1lQXhwUFA1M1A1ZlA1UG1Vem14MjdQeFcyQkRmek96czYyTld2V0hHTTFEd1REOHFyLzFxMWIrNEo2MkJ1NHdPL3E2dXB2YlczOTNmcjE2M3VibXBwV3VEMGZBTTZxVnF0M3IxKy9QbEVzRm44U3RPMmV3QVIrVjFkWGZ6UWFQYnBodzRadnVqMFhBTjV3N2RxMVQvTDUvSEJRZ3IvaEEzOTU2MmJ6NXMwRGJzOEZnRGRkdm54NVBBaGJQUTBkK0gxOWZlOGtFb205Yk4wQWVKeHF0WG8zbTgwZS8raWpqMTV3ZXk1MmFjakE3K25wU1cvYXRPbTNYajJNclZRcVVpZ1VIdnIvVzFoWWNIZzJnSDNpOGZoRC8rK1JTRVJDb1pERHM2bFB1Vnl1WHJseTVXZU4yTXFob1FLL3M3T3pMUjZQLzIzZHVuVUp0K2RTS0JSa2NYRlJDb1dDNVBQNWV5RmZxVlRjbmhyZ0dhRlE2Rjc0UjZOUmlVUWlFZzZISlJLSnVEMDF1WEhqUm5aaFllRzdqYlROMHpDQjcrYjJUYWxVa3V2WHI5OExkMWJwZ0w1NFBIN3ZSMkQ5K3ZYUzB1SjhWNU5HMitieGZlQjNkbmEyYmR5NE1lUDBwYWxzTmlzTEN3dVN6V1psY1hIUnlhOEdBaWtjRGtzaWtaQjRQQzZKaExOL2ljL244N21yVjYrbS9MN2E5M1hnOS9iMi92ckpKNTk4eFlsVmZhVlNrV3cyZSs4ZkFPNUtKQkwzL25IaVBLQmFyZDY5ZE9uUzRZbUppVi9ZL21VMjhXWGdkM1oydHExZHUzWXNrVWlrN1A2dTVZQ2ZuNSszKzZzQUtFb21rL2ZDMzI3WmJEWno4K2JOSVQrdTluMFgrRjFkWGYySlJPS3ZkcllwcmxRcWN1SENCWm1mbjJlN0J2Q1JjRGdzeVdSU3RtM2JadXVxdjFnc2xyTFo3UGY4ZG1ITFY0RnY5eFpPcVZTUzZlbHBWdk5BQTBnbWs5TFIwV0hiWWE4ZnQzaDhFL2g5ZlgzdmJObXlaY2lPejE1WVdKRHo1OCt6Tnc4MG9FUWlJZHUzYjMva25RQmRuMzc2NlpoZnFuaDhFZmk3ZCsvK3B4MDljRXFsa256ODhjZVVVUUlCRUkvSDVhbW5uckpseFgvdDJyVlBQdnp3dzI4Wi8yRERQQjM0ZHBWY1Zpb1ZPWFBtREZzM1FBQWxrMG5adVhPbjhUMStQNVJ1ZWpid096czcyelp0Mm5UTzlPSHN6TXlNbkQ5L25odXZRSUNGUWlIWnZuMjc3Tml4dytqbkZvdkYwcFVyVnpxOUd2cWVEUHlubjM3NjI2MnRyWDh6R2ZZTEN3c3lOVFgxeUI0MkFJSW5Fb2xJZDNlMzBmMTlMNGUrNXdLL3U3djd4YTFidDc1dHFoS25VcW5jVzlVRHdNTXNyL1pOYmZOVXE5VzdGeTllL0tIWEhsUDNWT0NiRHZ0Q29TQ25UNSttbGg3QVk0WERZZG0xYTVleHhtMWVESDNQQlA2V0xWdSsvZTF2Znp0akt1eG5abVprZW5yYXhFY0JDSkNPamc1amUvdlZhdlh1aFFzWHRubGxlOGNUZ1cveWdMWlNxY2pwMDZjcHRRU2dMQjZQeTY1ZHU0eHM4WGhwVDkvMXdEY1o5b1ZDUVQ3NDRBTXFjQUJvQzRWQ3NtZlBIaU5iUEY0Si9aVnVmcm1JeU1hTkd6TW13bjUrZmw3R3g4Y0pld0JHVkNvVkdSOGZOM0pmcDdXMXRXWGp4bzBaQTlQUzRtcmc3OTY5KzU4bUxsWE56TXhJSnVQNnYwc0FEU2lUeWNqTXpJejI1MFNqMGRqdTNidi9hV0JLeWx3TC9MNit2bmRNdEV2SVpESWN6Z0t3MWZUMHRKRkY1WVlORzc3WjE5ZjNqb0VwS1hFbDhIdDdlMyt0MndpdFVxbElKcE9oUFFJQVI4elB6MHNtazlIZU50NnlaY3RRYjIvdnJ3MU55eExIRDIyN3VycjYyOXZiLzBlbi9MSlNxY2dISDN6QXJWa0Fqb3RFSXJKbnp4NnRDcDVxdFhwM2RuYjIzNXp1cCsvb0NyK3pzN010a1VqOGxiQUg0RmNtcWdHYm1wcFdKQktKdjNaMmRyWVpuTnBqT1JyNGE5ZXVIZE9weUNIc0FYaUJpZEJ2YlcxdFdidDI3WmpCYVQyV1k0SGYyOXY3YTkwM2FNK2NPVVBZQS9DRVFxRWdaODZjMGZxTVJDS1JjbkkvMzVFOS9NN096clp0MjdaZDBObks0WUFXZ0JjbGswbEpwZFRYc2s2MlgzQmtoYjl4NDBhdEhqa3pNek9FUFFCUG1wK2YxNnJUYjJwcVd1SFVwU3piQTcrdnIrOGRuY3RWOC9QejFOa0Q4TFRwNldtdFJXazBHbzA1VVo5dmErQXZWZVhzVlIxZktCUzRRUXZBRnpLWmpOWVpZeUtSMkd0MzFZNnRnUitQeC8rbXVwV3pYSkVEQUg2aFU3blQxTlMwSWg2UC84M3dsTDdFdHNEdjZlbEpyMXUzTHFFNi92VHAwelJDQStBcnkrM1pWYTFidHk3UjA5T1ROamlsTDdFdDhEZHQydlJiMWJFek16UDBzd2ZnU3dzTEMxcUh1RHJaK1RpMkJINWZYOTg3emMzTlRTcGpDNFVDaDdRQWZHMTZlbHA1UDcrNXVibkpyZ05jNDRHdmMxQ3IrOWNoQVBBS25XMXB1dzV3alFmK21qVnJqcWtlMU03TXpQRGdPSUNHc0xpNHFMeTEwOVRVdEdMTm1qWEhERS9KYk9CM2RYWDFiOTY4ZVVCbDdNTENncHcvZjk3a2RBREFWZWZQbjFjK2o5eThlZk5BVjFkWHY4bjVHQTM4YURSNlZIWHMxTlNVd1prQWdEZm9aSnRPcGo2TXNjRHY2dXJxVjMzQmFtWm1ocVpvQUJwU29WQlEzdHJac0dIRE4wMnU4bzBGZm10cjYrOVV4bFVxRmJaeUFEUzA4K2ZQS3gvZ3FtYnJ3eGdKL003T3pyYjE2OWYzcW93OWMrWU1GNndBTkxSS3BhTGNTbm45K3ZXOXBpcDJqQVMrYW1WT3FWU2lDeWFBUUppZm41ZFNxV1I1bk1tS0hTT0J2MjdkdW1kVXhuMzg4Y2Ntdmg0QWZFRTE4MVF6OXF1MEF6K1ZTdjFCNVZidHdzSUM3Uk1BQklwcTdqVTNOemVsVXFrLzZINi9kdUJIbzlFZnFJempvQlpBRUtsbW4ycldQa2dyOEx1NnV2cFZIamNwbFVxU3pXWjF2aG9BZkNtYnpTcnQ1VWVqMFpodWlhWlc0SWZENFYrcGpLTTVHb0FnVTgxQTFjeGRwaFg0S2djSmxVcUZ5aHdBZ1RZL1A2OVVqcTU3ZUtzYytOM2QzUytxSE5aZXVIQkI5U3NCb0dHb1pHRnpjM05UZDNmM2k2cmZxUno0NFhENDV5cmpXTjBEZ0hvV3FtYXZpRWJneDJLeGJxdGpzdGtzN1k4QlFHcnRrMVdLVjFTeWQ1bFM0S3R1NTFDWkF3RDNxV1NpenJhT1V1QTNOemZ2dHpxR3cxb0ErRExWdzF1VkRCWlJEUHhJSlBLMDFUR3M3Z0hnWDZsa28wb0dpeWdFZm1kbloxdHJhMnVMMVhFRVBnRDhLNVZzYkcxdGJWSHBvR2s1OEo5NDRvbVhyWTRSSWZBQjRHRlVzMUVsaXkwSC91clZxNzl2ZFF4aER3Q1BwcEtSS2xsc09mQmJXMXM3ckk2aEt5WUFQSnBLUnFwa3NVcmdzMzhQQUFhcDd1TmJIV01wOEh0NmV0Sld2NkJVS25IWkNnQyt4dUxpb2xJSFRhdVpiQ253VzFwYUxPOFpYYjkrM2VvUUFBZ2NsYXdNaFVJRFZ2NjhwY0JmdFdyVnQ2eE5SNlJRS0ZnZEFnQ0JvNUtWcTFldjdySHk1NjJ1OERkYm00NUlQcCszT2dRQUFrY2xLNjFtc3FYQVZ6a2tvRUlIQUI1UHNWTEhVaWJYSGZncVQydXhuUU1BOVZQSlRDdlpYSGZncjFxMTZqdFdKMEoxRGdEVVR5VXpyV1J6M1lGdjlUUlloQlUrQUZpaGtwbFdzcm51d0YrNWN1VTNyRTZFQTFzQXFKOUtabHJKNXJvRHY3bTUyZkkxWHBVK3p3QVFWSXE5OGV2T1ppdDcrTTFXSjhLV0RnRFVUeVV6cldTejhwdTI5V0NGRHdEMXN6c3o2dzc4YURRYXMvTEJoRDBBV0djMU82MWtzMjByZkxaekFNQTZPN1BUMWkwZEFJQjNFUGdBRUJBRVBnQUVCSUVQQUFGUlYrQS8vL3p6N1ZZL21Db2RBSERHaWhVcjJ1djVjM1VGL3J2dnZqdHJkUUpVNlFDQWRTcnRGZTdldlR0Yno1OWpTd2NBUEtSYXJkcjIyUVErQUFRRWdROEFBVUhnQTBCQUVQZ0FFQkFFUGdBRUJJRVBBQUZCNEFOQVFCRDRBQkFRQkQ0QUJBU0JEd0FCUWVBRFFFQVErQUFRRUFRK0FBUUVnUThBQVVIZ0EwQkFFUGdBRUJBRVBnQUVCSUVQQUFGQjRBTkFRQkQ0QUJBUUJENEFCRVNUMnhPQW5sZ3NKcWxVeXUxcGFEdHg0b1NyMzk4aklsRlhaK0I5a3lLU2Qzc1MwRUxnKzFRc0ZwUFIwVkhadDIrZjIxTXhZbTV1VGtaR1J1VG8wYU9PZnU5ekl2S2FpQ1FkL1ZiL2VsdEVYaFdDMzYvWTB2R2hXQ3dtSjA2Y2FKaXdGeEZwYTJ1VE45OTgwOUhBZjBWRS9sc0lleXQrS0NML1gvamJrRjhSK0Q0ME5qWW12YjI5YmsvREZ2djI3Wk9ob1NIYnYrYzVxUVUrck9zV2tmL245aVNnaE1EM21hR2hJUmtZR0hCN0dyWWFIUjIxL1R0ZXMvMGJHdHN6VXZ2UmhMOFErRDZ5dkcvZjZOcmEybVJ3Y05DMnozOUYyTVl4Z1I5Ti95SHdmU1NkVGt0Ylc1dmIwL0MxcUlqc2Qzc1NEU0lwYkl2NURZSHZFKzN0N1pKT3A5MmVodSs5SmlJUnR5ZlJRUGFMeUZhM0o0RzZFZmcrTVRJeUl0RW90UkU2K3FWV1pRSnpJc0lxMzA4SWZCOFlIQnhzcUJMTXg1bWJtN1BsSWhiQlpJOGZTdTNIRk41SDRQdkF5TWlJMjFOd2xCMWJWeTlKcmJJRTl1REgxQjhJZkk4YkhoNXUrRExNQngwN2Rrekd4c2FNZm1aVUNDUzdQU08xSDFWNEc0SHZZVUVwd3hTcGJlTzg4TUlMTWp3OGJQeXpYeGJLTUozd21uQUQxK3ZvcGVOaDZYUmErYUQyUnovNmtjek96cHFka0kzc2FwNjJWZFRMTUUrSnlHR0RjL0dMSGhINUw0VnhFYW45dUFieDM1bGZFUGdlMWQ3ZUxnY1BIbFFhT3o0KzduZ1RNcS9TS2NOOFZXb2RJb1BtcElnOEsycG5IcTlJcmNIYVJhTXpnaWxzNlhpVXpsYU9IZHNpZnRRdnRlQlM4WVlFTSt5WC9hZkdXRzdnZWhlQjcwR0RnNE95ZCs5ZXBiRkhqaHp4MVZhT25WU0RweUJzUzF5VTJvK2VpbWVGTWsydkl2QTlTSFYxbjgvbkExZkMrU2d2U2Eycm80ckRRcjkza2RxL2g0TGlXRmI1M2tUZ2UwdzZuVlp1ZlR3eU1pSzVYTTd3alB3bkt1cUJNeThpcnh1Y2k1L2xSZjF2T3QxQ3p5SXZJdkE5SkJhTEthL1FKeVltQWxQQytUaXZpUHBCcmM3ZWRTTjZYVVNtRk1lK0lwUnBlZzJCN3lFNi9YSm9yRmF6VldxbGdTcE9TYTFDQlYvMnF1STQrdXg0RDRIdkVlM3Q3WExnd0FHbHNjZVBIM2Y5RVhDditMM0dXRmIzRDNkU1JQNnNPUFpsb1p1bWx4RDRIcUZUTjgvcXZxWmYxUHZsSEJacXg3K082aXBmUk85SEdHWVIrQjZnODJ6aG9VT0hLTU5jb2hvc0JWRXZRUXlLaTZKK2dQdU1VS2JwRlFTK0IraVVZWEpRVzdOZjFQdmx2Q3FVWWRiakRWRXYwMlNWN3cwRXZzdEdSa2FVbnkxTXA5T1VZWXBlTjh3cEVYbkw0RndhV1Y3VXQzWjREdEViQ0h3WHhXSXg1ZjEzK3VYY3A5c3ZCL1Y3UzJyVlRDcjJDMldhYmlQd1hUUTZPcXBjaHNtTjJwb2VVWCsyOEcyaERGT0Y2bDUrUkxpQjZ6WUMzeVdwVkVyNTJjSmp4NDVSaHJtRWZqbk9PeW0xSDBzVlA1VGFqelRjUWVDN2hINDUrcDRUOVRMTTE0VXlUQjMwMmZFbkF0OEZPczhXam82T1VvYTVSS2RmRG1XWWVpNktlcytoWjZUMll3M25FZmdPMCttWE16YzN4K3AreVN1aVhvWkpOMHd6M3BEYWo2Y0tua04wQjRIdnNIUTZyVldHQ2YxbkN5bkRORU8zVEZPMTV4SFVFZmdPYW05djF5ckRIQnNiTXp3amY5THBoa2tacGxudmlWNlpKbjEybkVYZ080aHVtUHI2UmE4TU04alBGdHFGYnByK1FlQTdaSEJ3VUtzTU01UEpHSjZSUDZrR1JFRlkzZHRsVXZUS05PbXo0eHdDM3lFNlpaaXM3bXRlRXIweVRBNXE3Zk9xVUticEJ3UytBNGFIaDNtMlVKUHVzNFZjc3JKWFh0VExOTHVsOW1NTyt4SDROb3ZGWXNxcis3bTVPYnBoTG5sWk9LajF1c05DbWFiWEVmZzJTNmZUeWdlMXc4UERaaWZqVTF0RmZlLytsTlFxU2VBTTFWZkRJa0tacGhNSWZCdTF0N2ZMd1lNSGxjYU9qNC9UTDJlSnpoNHZ6eFk2NjZTb2wybStJcFJwMm8zQXQ1SE9kZ3lyKzVwK0VYbFdjZXdiUXI4Y04rajh5SEtBYXk4QzN5YURnNE95ZCs5ZXBiRkhqaHloWDg0U3VtSDZ6MFZSNzFYMHJGQ21hU2NDM3lhcWo1UFFEZk8rL1ZLcjRGQkJ2eHgzNlhUVDVEbEUreEQ0TnREdGwwTVpwdDZ6aGZPaVhpSUlNM1Q3N0tqMlNzTFhJL0FOMCttR09URXh3Yk9GUzNUNjVYQlE2dzF2U2UzTllCV3ZDR1dhZGlEd0RhTmZqcjZ0b2w2aTkyZmgyVUl2b2MrT3R4RDRCcVZTS1RsdzRJRFMyT1BIajFPR3VVUm5ENWRMVnQ1eVVtby93aXBlRnNvMFRTUHdEZElwdzJSMVg5TXY2djF5RGd0bG1GNms4eVBNQWE1WkJMNGhRME5EeXM4V0hqcDBpRExNSmFyL2dSZUVad3U5NnFLb2w4anlIS0paQkw0aDlNdlJwL05zNGF0Q0dhYVg2VDZIQ0RNSWZBTkdSa2FVeXpEcGhsa1RGWjR0YkdSNVVWL2xKNFVEWEZNSWZFMnhXRXpyMlVMS01HdGVFL1V5VEc3VStzTmJvdmNjSW1XYStnaDhUYU9qbzhwbG1OeW9yZWtSdldjTEtjUDBEOVVmNTRpd3RXTUNnYTlCOTlsQ3lqQnI2SmNUSENkRjd6bkVIb056Q1NJQ1g0UHFDcDErT2ZjOUozclBGbEtHNlQ4NmZYWlk1ZXNoOEJVTkR3OHJsMkdPam81U2hpbjZ6eFpTaHVsUEYwVzkxOUV6d25PSU9naDhCVHI5Y3VibTVsamRMM2xaS01NTUtwM25FT216bzQ3QVY2RGJEUk8xSy9NNlpaZzhXK2gvT3QwMGVRNVJEWUZ2VVh0N3UxWVo1dGpZbU9FWitaTk9OMHo2NVRTRzkwU3ZUSk0rTzlZUitCYnBsR0d5dXEvcEY3MHl6RW1EYzdGYkxCYVR3Y0ZCR1JrWmtjSEJRV2x2YjNkN1NwNmkwMDJUQTF6ckNId0xkSjh0ekdReWhtZmtUenBsbUg1WjNjZGlNVGw2OUtoODl0bG44djc3Nzh2Qmd3ZmwvZmZmbHdzWExzaUpFeWNJL2lXVHduT0lUaUx3TFZEdGVVTVo1bjB2aWZxemhhK0xQdzVxMjl2YlpYWjI5cEYzTkFZR0JpU1R5VWdxbFhKNFp0NUVtYVp6Q1B3NkRROFBTMjl2cjlKWSt1WFU2SlpoK3VXUzFkalkyR08zL2FMUnFJeU5qVWtzRm5Ob1Z0NmwwMmVuV3lqVHRJTEFyNU5PR1NiZE1HdGVrc1ovdHRES3dxQ3RyVTJHaDRmdG5aQlB2QzU2Wlpxb0Q0RmZoOEhCUWVVeVRQNkR2dTlaeFhHbnhCLzljbUt4bU9VZjk2R2hJWnRtNHorcVArcEpZUysvWGdTK2pjYkh4K21YOHdEVkZncCtXZDJydkdlc2VsdTdFWjBVOVRKTkxtTFZoOENIcDcwaC91aVgwOTdlcnZ5ZU1lQVVBcjhPcWdldUF3TURNamc0YUhZeVBtWjE5ZWFuYnBpcTd4cU1qNCtibllpUDZieG43SWRGZ1JjUStIWElaREl5Tnplbk5KWUhUdTc3czhVL2YxajhVWVk1T0Rpb3ZEWER6ZXY3Vk44em5oZC9YY1p6RTRGZko5VXFuYmEyTm03WUxubEw2cS9FbUJMMWpvcE9VLzFSeitmekxBaVc3QmYxUm5wKytWdWdGeEQ0ZFRwNjlLaE1URXdvalIwWkdhSGVXbXFyOWYrUXgxK3lLU3o5T1QvUWJhVEgvWXphZ2F0cWFlV1U4SjZ4RlFTK0Jhb3I5V2cweWszYkpaTWk4bS95NlAzOHQwV2tWL3l4SjZ2VEpwdjNqTytqa1o1ekNId0xUcHc0SWNlUEgxY2FlK0RBQWE3U0w3a29Jdjh1SWlrUmVWNUUvdS9TLzI2VFdnbW1IL2J0UlhqUDJJUWVVVzkxL0dmeHgvME1MeUh3TFVxbjA1TFBxMFVTTjI2LzdLTFUvb045YStsLy9STDBJaUtwVklyM2pBMElRaU05THlId0xacWRuVlVPN29HQkFXNVdOZ2dhNmVualBXUG5FZmdLUmtkSGxjczBXZVg3MzlEUUVPOFpHOEI3eHM0ajhCWGtjam10TWsxV2VQNmwwaTluR1kzMDdudEY5TW93L2JUOTV5VUV2cUtqUjQ4cTM1Sk1wOU04Z09GVGxHSHEwMzNQbURKTWRRUytCdFdWT21XYS9zUjd4bVpRaHVrZUFsL0RpUk1uNU5peFkwcGo5KzNiUjU4ZG4xSHBocm1NMjlZMVFYclAySXNJZkUwNlpacXM4djFqY0hCUXF3eVQ5NHhyVkcvVVVvWnBCb0d2S1pmTGFaVnA4a0NLUDZqK09PZnplVmIzUzE0U3ZUSk1EbXIxRWZnR2pJeU1LSmRwMG1mSCs0YUhoN1hLTURtbzFldVg0NmYzakwyT3dEZEVkUlZITjAxdjB5M0RaTnV1NW1WUkw4TmtLOGNjQXQrUXNiRXg1VExOZ3djUFVxYnBVZWwwV3ZtZ2x1MjZtcTJpdnJvL0pTTHZHWnhMMEJINEJ1bXMxTG1RNHozdDdlMXk4T0JCcGJHOFozeWY2bzFhRWYrOFord1hCTDVCbVV4R2podzVvalIyNzk2OWxHbDZqTTZQTUt2N21uNFJlVlp4ckYvZU0vWVRBdCt3a1pFUnVtazJnTUhCUWRtN2Q2L1MyQ05IanRBdlo0bE9OMHdPYXMwajhBM1Q2YlBUMjl2THl0QWo2SWFwN3lVUjZWWWNTNzhjZXhENE50RHRwa21acHJ2UzZiVDA5dllxajZVTXMxYUdxZE1OMHkvdkdmc05nVzhUMVpVNmZYYmNwZk5zNGNURUJNOFdMdEhwbDhOQnJYMElmSnZvUG9kSW1hWTc2SmVqYjZ2d2JLRlhFZmcyMGdrQVZvck9hMjl2bHdNSERpaU5QWDc4T0dXWVMzNnZNWlpMVnZZaThHMDBPenNyaHc0ZFVobzdNREJBbWFiRGRINWtXZDNYOUl0NnY1ekRRaG1tM1FoOG00Mk9qaXFYYWJMS2Q0N09zNFdIRGgyaURIT0o2dXErSUR4YjZBUUMzMmE1WEk0K096N0FzNFg2OW90ZXZ4ektNTzFINER2ZzZOR2pNakV4b1RTV2JwcjJHeGtaVVg2MmNHUmtoREpNMGV1R09TVThXK2dVQXQ4aHFpdjFhRFRLQ3RKR3NWaE02OWxDdHQxcVhoT2VMZlFEQXQ4aHVzOGhwbElwd3pPQ1NHMHJSN1VNay9zU05UMmk5MndoWlpqT0lmQWRSSjhkYjBtbFVsclBGbEtHV1VPL0hQOGc4QjAwT3p1cjlSemkwTkNRNFJrRkcvMXk5RDBuZXM4V1VvYnBMQUxmWWJwOWRtQ0c3ck9GbEdIcTk4dWhETk41Qkw3RGRMcHB0clcxc2JJMFFLZGZEczhXM3FmN2JDRmxtTTRqOEYxdzlPaFI1ZWNRMCtrMGZYWTBwZE5wNVRKTTdrWFViSlZhM2IwS25pMTBENEh2RXAweVRWYVk2dHJiMjdYS01NZkd4Z3pQeUo5MHVtRlNodWtlQXQ4bG1VeEdxMHlUUGp0cTZJYXByMS8weWpBbkRjNEYxaEQ0TGtxbjA4cGxtcXp5clJzY0hOUXF3OHhrTW9abjVFK3FOMm9Md3VyZWJRUytpM0s1bkZhWkpzOGhXcU5UaHNucXZ1WWwwU3ZENUtEV1hRUyt5MFpHUm5nTzBRSER3OFBLenhiU0w2ZEd0d3lUUzFidUkvQTlRT2NBbDVYbjQ4VmlNYnBoR3ZDeThHeWgzeEg0SGpBMk5xWmNwbm53NEVIS05COGpuVTRySDlTeWJWYXpWZFQzN2s4Si9YSzhnc0QzQ0oxZ1lRWDZhTzN0N1hMdzRFR2xzZVBqNC9UTFdhSzZsU1BDNnQ1TENIeVBtSjJkbFNOSGppaU4zYnQzTDJXYWo2RFR2cGpWZlUyL2lEeXJPUFlOb1YrT2x4RDRIa0kzVGJNR0J3ZDV0dEFBdW1FMkRnTGZRM1Q2N1BUMjluS0EreFdxcS90OFBzOFA2Skw5SXRLdE9QYXdVSWJwTlFTK3g0eU9qdkljb2dHNi9YSW93OVIvdHZCMWczT0JHUVMrQjlGblI0OU9OOHlKaVFtZUxWeEN2NXpHUStCNzBJa1RKK1Q0OGVOS1l3OGNPQkQ0TWszNjVlamJLclc2ZXhWL0Zzb3d2WXJBOXlpZDRBbnlDaldWU3NtQkF3ZVV4aDQvZnB3eXpDVy8xeGpMNnQ2N210eWVBQjV1ZG5aV0RoMDZwRlJEdnR4bko0aFZKcXBiT1hiM3krbTM3WlBONnhIMWZqbUhoVEpNTHlQd1BXeDBkRlQ1bHVpYmI3NXB3NHdhbDEzUEZqNG50YkpHMVplaC9LUWdQRnZvZFd6cGVGZ3VsMk5QMlFGMjljdjV2WWo4dHdRajdFVjR0dEFQQ0h5UDAza09FZld4b3h2bWM2TCtTSWdmblJLUnQ5eWVCQjZMd1BjQlNpM3RNejQrYnNzaHQwN3ZHVC9pUnEwL0VQZytjT0xFQ2VYbkVQSDE3UGd4N1pmZ2JPT0kxSjR0cEF6VEh3aDhuOURwczRPSE8zYnNHR1dZbXVpWDR5OEV2ay9NenM3UzM4VWduaTAwNDNXaEROTlBDSHdmR1IwZFZYNE9FVjgyT2pwS3Z4eE5QRnZvUHdTK2oxQ21hY2JjM0p5dEIrRW5wUmFHalk0YnRmNUQ0UHVNem5PSXFISGlSN1BSdy9DVWlMem45aVJnR1lIdlEwTkRROG90bElQdXB6LzlxWXlOamRuK1BlOUpyWHFsRVUySnlIKzRQUWtvSWZCOUtKZkx5ZURnb1BLVGlFRTBOemNuTDd6d2dxTUgzLzhwSXY5SEdtdDc1MjBSK1hmaFJxMWYwVXZIcDViMzgwZEdSaVNWU3JrOUhVL0w1WEtTeVdSYytlNzNsdjdwa2RxREluNDJLUVM5M3hINFBwZkw1YWdsOTRGSnR5Y0FDRnM2QUJBWUJENEFCQVNCRHdBQlFlQURRRUFRK0FBUUVBUStBQVFFZ1E4QUFVSGdBMEJBRVBnQUVCQUVQZ0FFQklFUEFBRkI0QU5BUUJENEFCQVFCRDRBQkFTQkR3QUJRZUFEUUVBUStBQVFFQVErQUFRRWdROEFBVUhnQTBCQUVQZ0FFQkFFUGdBRWhHMkJINGxFN1Bwb0FHaFk4WGpjOHBqbm4zKyt2WjQvWjF2Z2gwSWh1ejRhQVBDQWQ5OTlkN2FlUDhlV0RnQUVCSUVQQUFGQjRBTkFRQkQ0QUJBUVZPa0FnSWZZbVoxMUIzNCtuODlaK1dDcWRBREFPcXZaYVNXYmJkM1NJZlFCb0g1MloyYmRnWC9uenAyeTFROW5Xd2NBNnFlU21WYXl1ZTdBTDVmTDAxWW53Z29mQU9xbmtwbFdzcm51d1AvaWl5OCtzenFSYURScWRRZ0FCSlpLWmxySjVyb0R2MUtwakZ1ZENGczZBRkEvbGN5MGtzMVc5dkQvWVhVaTRYRFk2aEFBQ0N5VnpMU1N6WFVIL3RtelowOWFuUWdyZkFDb24wcG1Xc2xtUzJXWnhXS3haSFV5S3EwK0FTQm9WTExTYWlaYkN2eFNxWFRaMm5RNHVBV0FlcWhrcGRWTXRocjQvN1EySGJaMUFLQWVLbGw1Ky9idFNTdC8zbExnMzdsejV5L1dwaU95ZnYxNnEwTUFJSEJVc3RKcTlhU2x3SitjbkJ5MU5oMlJscFlXcW5VQTRHdUV3MkZwYVdteFBNNXFKbHZ1cGFOeWNKdElKS3dPQVlEQVVNbElsU3hXQ1h6TExSYW8xQUdBUjFPczBMR2N4WllELy9idDI1YjM4Vm5oQThDanFXU2tTaFpiRHZ6UFAvLzhEYXRqUkFoOUFIZ1kxV3hVeVdMTGdYL3UzTGs1OXZFQndBelYvZnR6NTg3TldSMm45QUJLb1ZENHU5VXhCRDRBL0N1VmJGVEpZQkhGd0MrWHk2OWJIUk1LaFNTWlRLcDhIUUEwcEdReXFkb0QzM0lHaXlnRy90VFUxQi9MNVhMVjZqaFcrUUJ3bjBvbWxzdmw2dFRVMUI5VnZrLzVUZHRjTGpkbGRVd2lrZUFTRmdCSTdiS1ZTdUNyWk84eTVjQmZYRno4amNvNHRuVUFRRDBMVmJOWFJDUHdWYmQxdG0zYnB2cVZBTkF3VkxKUVp6dEhSQ1B3UlVSdTNMaHh5dW9ZRG04QkJKM3FZYTFLNWo1SUsvQVhGeGQvcVRLdW82TkQ1MnNCd05kVU0xQTFjNWRwQmY3WnMyZFA1dlA1bk5WeExTMHRWT3dBQ0tSRUlxSFVHVE9meitkVW5wcDlrRmJnTDAzaVR5cmp0bS9mcnZ2VkFPQTdxdG1ubXJVUDBnNzhUQ2J6WTVYRDIzZzhUaGROQUlHaW1udmxjcm1heVdSK3JQdjkyb0V2b242UThOUlRUNW40ZWdEd0JkWE0wejJzWFdZazhHL2R1cld2V3EzZXRUcXVwYVdGaWgwQWdaQk1KcFgyN3F2VjZ0MWJ0Mjd0TXpFSEk0Ri83dHk1dWV2WHIwK29qTjI1YzZkU2VSSUErRVVvRkpLZE8zY3FqYjErL2ZxRVNtZk1oekVTK0NJaXhXTHhKeXJqUXFFUUI3Z0FHdHIyN2R1VkY3YXEyZEw3SzFRQUFBZ0dTVVJCVlBvd3hnTC83Tm16SjY5ZHUvYUp5dGdkTzNaSUpCSXhOUlVBOEl4SUpDSTdkdXhRR252dDJyVlBkRXN4SDJRczhFVkU4dm44c09yWTd1NXVnek1CQUcvUXlUYWRUSDBZbzRGLzl1elprNWN2WHg1WEdSdVB4OW5hQWRCUXRtL2ZybHgrZnZueTVYR1RxM3NSdzRFdm9sNnhJMUxiMnFGOU1vQkdFQTZIbGJkeVRGYm1QTWg0NEo4N2QyNHVtODBlVnhrYkNvVmsxNjVkcHFjRUFJN2J0V3VYOGtGdE5wczlicW95NTBIR0ExOUU1S09QUG5wQjVmYXRTTzJBZytacUFQeXNvNk5EdVJDbFhDNVhQL3Jvb3hjTVQwbEViQXA4RVpFclY2NzhUSFhzamgwN2FMc0F3SmZpOGJqeVZvNklYblkram0yQlB6azVPWHJqeG8yczZuaWR2dzRCZ0J0MHQ2VnYzTGlSblp5Y0hEVTRwUyt4TGZCRlJCWVdGcjZyZW9BYkNvVmt6NTQ5cHFjRUFMYlpzMmVQOGtLMVdxM2VYVmhZK0s3aEtYMkpyWUd2YzRBclV0dlBUNlZTSnFjRUFMWklwVkphRjBqdE9xaDlrSzJCTDFJN3dGVjVKR1ZaTXBua0VCZUFwM1YwZEdnMWdzem44em03RG1vZlpIdmdpNGhjdlhvMXBicTFJMUk3eEtXckpnQXZTaWFUV29lMDFXcjE3dFdyVngzWnluQWs4TStkT3pkMzZkS2x3enFma1VxbENIMEFucEpNSnJXM25TOWR1blRZN3EyY1pZNEV2b2pJeE1URUw3TFpiRWJuTTNidTNFbVROUUNlRUlsRWxGc2VMOHRtczVtSmlZbGZHSnJTWXprVytDSWlOMi9lSENvV2l5WFY4Y3VWTzRRK0FEZEZJaEd0aWh3UmtXS3hXTHA1OCthUXdXazlscU9CdjFTMTh6MmQvWHhDSDRDYlRJUjl0VnE5bTgxbXYrZlVWczR5UndOZnBOWlJVM2MvZnpuMDJkTUg0S1JrTXFrZDlpSzFmWHZUblREcnNlTHVYZVhGdHBhK3ZyNTN0bXpab3YzWG1Vd21JL1B6OHlhbUJBQ1BaT0tBVmtUazAwOC9IWE9pQlBOaFhBdDhFWkhkdTNmL2M4T0dEZC9VL1p5Wm1SbVpucDQyTVNVQStCY2RIUjFhcFpmTHJsMjc5c21ISDM3NExRTlRVdUpxNEl1SURBd01mQmFOUm1PNm56TS9QeStaakZZUkVBRDhDMU1sNGZsOFBqYytQdjROQTFOUzV2Z2UvbGRkdlhvMXBWTzVzeXlaVE1yQXdBQU4xd0FZRVFxRlpHQmd3RWpZRjR2RmtsT1hxNzZPNnl0OEVaSE96czYyVFpzMm5XdHRiVzNSL2F4S3BTS25UNStXaFlVRkUxTURFRUR4ZU54WXg5NWlzVmk2Y3VWS3A5TVZPUS9qaWNBWHFZWCt0bTNiTGpRMU5hMHc4WG5zNndOUVlXcS9YcVJXZm5uaHdvVnRYZ2g3RVE4RnZvaElkM2YzaTF1M2JuM2JWT2dYQ2dVNWZmcTBMQzR1bXZnNEFBMHNIQTdMcmwyN2pOM3hxVmFyZHk5ZXZQakRxYW1wUHhyNVFBTThGZmdpNWtPL1Vxbkl6TXlNbkQ5LzNzVEhBV2hBMjdkdmx4MDdkaGc3QS9SaTJJdDRNUEJGek83cEwxdFlXSkNwcVNrcEZBcW1QaEtBejBVaUVlbnU3amI2cEtxWDl1eS95cE9CTDJKUDZJdkl2ZFYrcFZJeCtiRUFmQ1FVQ3QxYjFadms1YkFYOFhEZ2k5UkNmK1BHalJrVGRmb1BxbFFxY3ViTUdXN29BZ0dVVENabDU4NmR4a3U0OC9sODd1clZxeW12aHIySXh3Ti9tYWtidVY5VktwWGs0NDgvcG9RVENJQjRQQzVQUGZXVXRMUVkzVFFRRWZkdjBOYkxGNEV2WXE3M3pzTXNMQ3pJK2ZQbkpadk4ydkh4QUZ5VVNDUmsrL2J0UnZmcEgrUm1ieHlyZkJQNElpSzl2YjIvZnZMSkoxOHhWY0h6VmFWU1NhYW5wOW5xQVJyQThudllkcXpvUldxVk9KY3VYVHJzNUFNbXVud1YrQ0lpWFYxZC9ZbEU0cSttRDNNZlZLbFU1TUtGQ3pJL1AwOE5QK0FqNFhCWWtzbWtiTnUyemRZMks4VmlzWlROWnIvblJvdGpIYjRMZkpIYVllN2F0V3ZIRW9tRTdiMHBzdG1zWkxOWlZ2MkFoeVdUU1Vra0VwSklKR3ovcm13Mm03bDU4K2FRbHc5bkg4V1hnYi9NN2kyZUIxVXFsWHZoejE0LzRMN2xnRThrRW80MFRmVGpGczVYK1Ryd1Jld3IzWHljYkRZckN3c0xrczFtMmZZQkhCQU9oeVdSU0VnOEhuZGtKZjhnUDVSYzFzUDNnYitzcjYvdm5VUWlzZGVKMWY1WGxVb2x1WDc5dWhRS0Jjbm44NVI1QWdiRTQzR0pScU1TaVVSay9mcjF0aDIrZnAybHQyZVArNlVLNTNFYUp2QkZhcXY5ZUR6K3QzWHIxam43OC84UWhVSkJGaGNYNy8wSVZDb1ZLUlFLM1BBRkhoQUtoU1FTaVVnb0ZMb1g3dUZ3MkZnRE14MDNidHpJTGl3c2ZOZnZxL29ITlZUZ0wrdnA2VWx2MnJUcHQ4M056VTF1eitWUkh2VzNBUDUyZ0VieXFOcjM1WkQzb25LNVhMMXk1Y3JQSmljblI5MmVpMmtOR2ZqTDNOem1BZUF2amJaOTh6QU5IZmdpdFcyZU5XdldITnU4ZWZPQTIzTUI0RTJYTDE4ZXYzWHIxcjVHMnI1NW1JWVAvR1ZkWFYzOTBXajBxQjA5ZVFENDA3VnIxejdKNS9QRGZydEFwU293Z2Irc3E2dXJ2N1cxOVhmcjE2L3ZaYXNIQ0o1cXRYcjMrdlhyRThWaThTZEJDZnBsZ1F2OFpjdGJQZXZXclh2R3k0ZTdBTXdvbDh2Vkd6ZHVuQXJDMXMyakJEYndINVJLcGY0UWpVWi80UFRsTFFEMnkrZnp1WHcrLzZkTUp2Tmp0K2ZpTmdML0FWMWRYZjNoY1BoWHJQb0JmMXRlelM4dUx2NHlhTnMyWDRmQWY0VHU3dTRYdytId3oyT3hXRGZoRDNoZnVWeXU1bks1cWNYRnhkOTQ3ZkZ3cnlEdzY5RGQzZjFpYzNQei9rZ2s4clNkYlprQldGTXNGa3VGUXVIdjVYTDVkVUwrOFFoOGl6bzdPOXVlZU9LSmwxZXZYdjM5MXRiV0RuNEFBT2NVaThWU3NWaWN2bjM3OWw4Ky8venpONEo2K0txS3dEZWdwNmNuSFFxRkJsYXZYdDNUMHRLeW1SOEJRRit4V0N5VlNxWEx0Mi9mbnF4VUt1T04yT3JBYVFTK1RicTZ1dnBYclZyMW5WQW9OTEJ5NWNwdk5EYzNkNnhhdGFwWlJJUnFJS0JXUFNNaWN1Zk9uWEs1WEo3KzRvc3ZQcXRVS3VOMzd0ejVCd2V0OWlEd0FTQWdWcm85QVFDQU13aDhBQWdJQWg4QUFvTEFCNENBSVBBQklDQUlmQUFJQ0FJZkFBS0N3QWVBZ0NEd0FTQWcvaGZuYUh3a3pmaTdnZ0FBQUFCSlJVNUVya0pnZ2c9PSIsIm1lZGlhdHlwZSI6ImltYWdlL3BuZyJ9XSwiaW5zdGFsbCI6eyJzcGVjIjp7ImNsdXN0ZXJQZXJtaXNzaW9ucyI6W3sicnVsZXMiOlt7ImFwaUdyb3VwcyI6WyIiXSwicmVzb3VyY2VzIjpbImNvbmZpZ21hcHMiLCJwZXJzaXN0ZW50dm9sdW1lY2xhaW1zIiwic2VjcmV0cyIsInNlcnZpY2VzIl0sInZlcmJzIjpbImNyZWF0ZSIsImRlbGV0ZSIsImdldCIsImxpc3QiLCJ1cGRhdGUiLCJ3YXRjaCJdfSx7ImFwaUdyb3VwcyI6WyIiXSwicmVzb3VyY2VzIjpbInBvZHMiXSwidmVyYnMiOlsibGlzdCIsInVwZGF0ZSIsIndhdGNoIl19LHsiYXBpR3JvdXBzIjpbImFwcHMiXSwicmVzb3VyY2VzIjpbImRlcGxveW1lbnRzIl0sInZlcmJzIjpbImNyZWF0ZSIsImRlbGV0ZSIsImdldCIsImxpc3QiLCJ1cGRhdGUiLCJ3YXRjaCJdfSx7ImFwaUdyb3VwcyI6WyJsaW1pdGFkb3Iua3VhZHJhbnQuaW8iXSwicmVzb3VyY2VzIjpbImxpbWl0YWRvcnMiXSwidmVyYnMiOlsiY3JlYXRlIiwiZGVsZXRlIiwiZ2V0IiwibGlzdCIsInBhdGNoIiwidXBkYXRlIiwid2F0Y2giXX0seyJhcGlHcm91cHMiOlsibGltaXRhZG9yLmt1YWRyYW50LmlvIl0sInJlc291cmNlcyI6WyJsaW1pdGFkb3JzL2ZpbmFsaXplcnMiXSwidmVyYnMiOlsidXBkYXRlIl19LHsiYXBpR3JvdXBzIjpbImxpbWl0YWRvci5rdWFkcmFudC5pbyJdLCJyZXNvdXJjZXMiOlsibGltaXRhZG9ycy9zdGF0dXMiXSwidmVyYnMiOlsiZ2V0IiwicGF0Y2giLCJ1cGRhdGUiXX0seyJhcGlHcm91cHMiOlsicG9saWN5Il0sInJlc291cmNlcyI6WyJwb2RkaXNydXB0aW9uYnVkZ2V0cyJdLCJ2ZXJicyI6WyJjcmVhdGUiLCJkZWxldGUiLCJnZXQiLCJsaXN0IiwidXBkYXRlIiwid2F0Y2giXX1dLCJzZXJ2aWNlQWNjb3VudE5hbWUiOiJsaW1pdGFkb3Itb3BlcmF0b3ItY29udHJvbGxlci1tYW5hZ2VyIn1dLCJkZXBsb3ltZW50cyI6W3sibGFiZWwiOnsiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9LCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciIsInNwZWMiOnsicmVwbGljYXMiOjEsInNlbGVjdG9yIjp7Im1hdGNoTGFiZWxzIjp7ImNvbnRyb2wtcGxhbmUiOiJjb250cm9sbGVyLW1hbmFnZXIifX0sInN0cmF0ZWd5Ijp7fSwidGVtcGxhdGUiOnsibWV0YWRhdGEiOnsibGFiZWxzIjp7ImFwcCI6ImxpbWl0YWRvci1vcGVyYXRvciIsImNvbnRyb2wtcGxhbmUiOiJjb250cm9sbGVyLW1hbmFnZXIifX0sInNwZWMiOnsiY29udGFpbmVycyI6W3siYXJncyI6WyItLWxlYWRlci1lbGVjdCJdLCJjb21tYW5kIjpbIi9tYW5hZ2VyIl0sImVudiI6W3sibmFtZSI6IlJFTEFURURfSU1BR0VfTElNSVRBRE9SIiwidmFsdWUiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOUBzaGEyNTY6OTQ3MWFhZGNlMWExN2FhY2IxYmY2NTNiNzVlMGQ3OTI0ZjhmOWUxNDQ5NTQ0NDBlMGQ5YzliZTZmZDQzMmU4YyJ9XSwiaW1hZ2UiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOS1vcGVyYXRvckBzaGEyNTY6YjMxYmEyOTM4MTI3ODhkYzdlMjFjMTQ3MDNhYzYxZmRkNWJmZjAxMDk0OGFkYTMzNzE1NTQ0YmE1MDc4NTFmNyIsImxpdmVuZXNzUHJvYmUiOnsiaHR0cEdldCI6eyJwYXRoIjoiL2hlYWx0aHoiLCJwb3J0Ijo4MDgxfSwiaW5pdGlhbERlbGF5U2Vjb25kcyI6MTUsInBlcmlvZFNlY29uZHMiOjIwfSwibmFtZSI6Im1hbmFnZXIiLCJwb3J0cyI6W3siY29udGFpbmVyUG9ydCI6ODA4MCwibmFtZSI6Im1ldHJpY3MifV0sInJlYWRpbmVzc1Byb2JlIjp7Imh0dHBHZXQiOnsicGF0aCI6Ii9yZWFkeXoiLCJwb3J0Ijo4MDgxfSwiaW5pdGlhbERlbGF5U2Vjb25kcyI6NSwicGVyaW9kU2Vjb25kcyI6MTB9LCJyZXNvdXJjZXMiOnsibGltaXRzIjp7ImNwdSI6IjIwMG0iLCJtZW1vcnkiOiIzMDBNaSJ9LCJyZXF1ZXN0cyI6eyJjcHUiOiIyMDBtIiwibWVtb3J5IjoiMjAwTWkifX0sInNlY3VyaXR5Q29udGV4dCI6eyJhbGxvd1ByaXZpbGVnZUVzY2FsYXRpb24iOmZhbHNlfX1dLCJzZWN1cml0eUNvbnRleHQiOnsicnVuQXNOb25Sb290Ijp0cnVlfSwic2VydmljZUFjY291bnROYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciIsInRlcm1pbmF0aW9uR3JhY2VQZXJpb2RTZWNvbmRzIjoxMH19fX1dLCJwZXJtaXNzaW9ucyI6W3sicnVsZXMiOlt7ImFwaUdyb3VwcyI6WyIiLCJjb29yZGluYXRpb24uazhzLmlvIl0sInJlc291cmNlcyI6WyJjb25maWdtYXBzIiwibGVhc2VzIl0sInZlcmJzIjpbImdldCIsImxpc3QiLCJ3YXRjaCIsImNyZWF0ZSIsInVwZGF0ZSIsInBhdGNoIiwiZGVsZXRlIl19LHsiYXBpR3JvdXBzIjpbIiJdLCJyZXNvdXJjZXMiOlsiZXZlbnRzIl0sInZlcmJzIjpbImNyZWF0ZSIsInBhdGNoIl19XSwic2VydmljZUFjY291bnROYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciJ9XX0sInN0cmF0ZWd5IjoiZGVwbG95bWVudCJ9LCJpbnN0YWxsTW9kZXMiOlt7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJPd25OYW1lc3BhY2UifSx7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJTaW5nbGVOYW1lc3BhY2UifSx7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJNdWx0aU5hbWVzcGFjZSJ9LHsic3VwcG9ydGVkIjp0cnVlLCJ0eXBlIjoiQWxsTmFtZXNwYWNlcyJ9XSwia2V5d29yZHMiOlsiYXBpIiwicmF0ZS1saW1pdCIsImt1YWRyYW50Il0sImxpbmtzIjpbeyJuYW1lIjoiTGltaXRhZG9yIE9wZXJhdG9yIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL0t1YWRyYW50L2xpbWl0YWRvci1vcGVyYXRvciJ9LHsibmFtZSI6Ikt1YWRyYW50IERvY3MiLCJ1cmwiOiJodHRwczovL2t1YWRyYW50LmlvIn1dLCJtYWludGFpbmVycyI6W3siZW1haWwiOiJlYXN0aXpsZUByZWRoYXQuY29tIiwibmFtZSI6IkVndXpraSBBc3RpeiBMZXphdW4ifSx7ImVtYWlsIjoiYXNuYXBzQHJlZGhhdC5jb20iLCJuYW1lIjoiQWxleCBTbmFwcyJ9LHsiZW1haWwiOiJkaWRpZXJAcmVkaGF0LmNvbSIsIm5hbWUiOiJEaWRpZXIgRGkgQ2VzYXJlIn1dLCJtYXR1cml0eSI6ImFscGhhIiwibWluS3ViZVZlcnNpb24iOiIxLjI1LjAiLCJwcm92aWRlciI6eyJuYW1lIjoiUmVkIEhhdCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9LdWFkcmFudC9saW1pdGFkb3Itb3BlcmF0b3IifSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOUBzaGEyNTY6OTQ3MWFhZGNlMWExN2FhY2IxYmY2NTNiNzVlMGQ3OTI0ZjhmOWUxNDQ5NTQ0NDBlMGQ5YzliZTZmZDQzMmU4YyIsIm5hbWUiOiJsaW1pdGFkb3IifV0sInZlcnNpb24iOiIxLjEuMSJ9fQ==
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoicmJhYy5hdXRob3JpemF0aW9uLms4cy5pby92MSIsImtpbmQiOiJDbHVzdGVyUm9sZSIsIm1ldGFkYXRhIjp7ImNyZWF0aW9uVGltZXN0YW1wIjpudWxsLCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLW1ldHJpY3MtcmVhZGVyIn0sInJ1bGVzIjpbeyJub25SZXNvdXJjZVVSTHMiOlsiL21ldHJpY3MiXSwidmVyYnMiOlsiZ2V0Il19XX0=
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoidjEiLCJkYXRhIjp7ImNvbnRyb2xsZXJfbWFuYWdlcl9jb25maWcueWFtbCI6ImFwaVZlcnNpb246IGNvbnRyb2xsZXItcnVudGltZS5zaWdzLms4cy5pby92MWFscGhhMVxua2luZDogQ29udHJvbGxlck1hbmFnZXJDb25maWdcbmhlYWx0aDpcbiAgaGVhbHRoUHJvYmVCaW5kQWRkcmVzczogOjgwODFcbm1ldHJpY3M6XG4gIGJpbmRBZGRyZXNzOiA6ODA4MFxud2ViaG9vazpcbiAgcG9ydDogOTQ0M1xubGVhZGVyRWxlY3Rpb246XG4gIGxlYWRlckVsZWN0OiB0cnVlXG4gIHJlc291cmNlTmFtZTogMzc0NWExNmUua3VhZHJhbnQuaW9cbiJ9LCJraW5kIjoiQ29uZmlnTWFwIiwibWV0YWRhdGEiOnsibmFtZSI6ImxpbWl0YWRvci1vcGVyYXRvci1tYW5hZ2VyLWNvbmZpZyJ9fQ==
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoidjEiLCJraW5kIjoiU2VydmljZSIsIm1ldGFkYXRhIjp7ImNyZWF0aW9uVGltZXN0YW1wIjpudWxsLCJsYWJlbHMiOnsiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9LCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLW1ldHJpY3MifSwic3BlYyI6eyJwb3J0cyI6W3sibmFtZSI6Im1ldHJpY3MiLCJwb3J0Ijo4MDgwLCJ0YXJnZXRQb3J0IjoibWV0cmljcyJ9XSwic2VsZWN0b3IiOnsiYXBwIjoibGltaXRhZG9yLW9wZXJhdG9yIiwiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9fSwic3RhdHVzIjp7ImxvYWRCYWxhbmNlciI6e319fQ==
+relatedImages:
+  - image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-1-limitador-operator-bundle@sha256:93c6f058da352883789f7db0150b1097a5f09e1268e24914ad964d5fdc83f6e1
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:b31ba293812788dc7e21c14703ac61fdd5bff010948ada33715544ba507851f7
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:9471aadce1a17aacb1bf653b75e0d7924f8f9e144954440e0d9c9be6fd432e8c
+    name: limitador
 schema: olm.bundle

--- a/catalog/4.18/limitador-operator/catalog.yaml
+++ b/catalog/4.18/limitador-operator/catalog.yaml
@@ -7,9 +7,11 @@ name: limitador-operator
 schema: olm.package
 ---
 entries:
-- name: limitador-operator.v1.0.2
-- name: limitador-operator.v1.1.0
-  replaces: limitador-operator.v1.0.2
+  - name: limitador-operator.v1.0.2
+  - name: limitador-operator.v1.1.0
+    replaces: limitador-operator.v1.0.2
+  - name: limitador-operator.v1.1.1
+    replaces: limitador-operator.v1.1.0
 name: stable
 package: limitador-operator
 schema: olm.channel
@@ -18,236 +20,269 @@ image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:1fa81c5cf9b184
 name: limitador-operator.v1.0.2
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 1.0.2
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.0.2
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
-      createdAt: "2024-10-18T10:24:00Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: Enables rate limiting for Gateways and applications in a Gateway
-      API network. - Part of Red Hat Connectivity Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
+        createdAt: "2024-10-18T10:24:00Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: Enables rate limiting for Gateways and applications in a Gateway API network. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
-  name: limitador-rhel9-operator-4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:0112e4478abe28486670bb1221b4039ca0b4bde314d72c28485008ea7d6f73c1
-  name: limitador
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:1fa81c5cf9b184da51cdf9ff17039e5ca9a0c4d6a40d5a536368219b6b3794a3
-  name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
+    name: limitador-rhel9-operator-4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:0112e4478abe28486670bb1221b4039ca0b4bde314d72c28485008ea7d6f73c1
+    name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:1fa81c5cf9b184da51cdf9ff17039e5ca9a0c4d6a40d5a536368219b6b3794a3
+    name: ""
 schema: olm.bundle
 ---
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
 name: limitador-operator.v1.1.0
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 1.1.0
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.1.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-      createdAt: "2025-04-07T15:52:04Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: Enables rate limiting for Gateways and applications in a Gateway
-      API network. - Part of Red Hat Connectivity Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+        createdAt: "2025-04-07T15:52:04Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: Enables rate limiting for Gateways and applications in a Gateway API network. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
-  name: ""
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-  name: limitador-rhel9-operator-edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:98f85a05da53fbf7f20845d1969441620407cc13a185fd52714308679f116425
-  name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+    name: limitador-rhel9-operator-edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:98f85a05da53fbf7f20845d1969441620407cc13a185fd52714308679f116425
+    name: limitador
+schema: olm.bundle
+---
+image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-1-limitador-operator-bundle@sha256:93c6f058da352883789f7db0150b1097a5f09e1268e24914ad964d5fdc83f6e1
+name: limitador-operator.v1.1.1
+package: limitador-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.1.1
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsiY29udHJvbGxlci1nZW4ua3ViZWJ1aWxkZXIuaW8vdmVyc2lvbiI6InYwLjE1LjAifSwiY3JlYXRpb25UaW1lc3RhbXAiOm51bGwsIm5hbWUiOiJsaW1pdGFkb3JzLmxpbWl0YWRvci5rdWFkcmFudC5pbyJ9LCJzcGVjIjp7Imdyb3VwIjoibGltaXRhZG9yLmt1YWRyYW50LmlvIiwibmFtZXMiOnsia2luZCI6IkxpbWl0YWRvciIsImxpc3RLaW5kIjoiTGltaXRhZG9yTGlzdCIsInBsdXJhbCI6ImxpbWl0YWRvcnMiLCJzaW5ndWxhciI6ImxpbWl0YWRvciJ9LCJzY29wZSI6Ik5hbWVzcGFjZWQiLCJ2ZXJzaW9ucyI6W3siYWRkaXRpb25hbFByaW50ZXJDb2x1bW5zIjpbeyJkZXNjcmlwdGlvbiI6IkxpbWl0YWRvciBSZWFkeSIsImpzb25QYXRoIjoiLnN0YXR1cy5jb25kaXRpb25zWz8oQC50eXBlPT1cIlJlYWR5XCIpXS5zdGF0dXMiLCJuYW1lIjoiUmVhZHkiLCJwcmlvcml0eSI6MiwidHlwZSI6InN0cmluZyJ9LHsianNvblBhdGgiOiIubWV0YWRhdGEuY3JlYXRpb25UaW1lc3RhbXAiLCJuYW1lIjoiQWdlIiwidHlwZSI6ImRhdGUifV0sIm5hbWUiOiJ2MWFscGhhMSIsInNjaGVtYSI6eyJvcGVuQVBJVjNTY2hlbWEiOnsiZGVzY3JpcHRpb24iOiJMaW1pdGFkb3IgaXMgdGhlIFNjaGVtYSBmb3IgdGhlIGxpbWl0YWRvcnMgQVBJIiwicHJvcGVydGllcyI6eyJhcGlWZXJzaW9uIjp7ImRlc2NyaXB0aW9uIjoiQVBJVmVyc2lvbiBkZWZpbmVzIHRoZSB2ZXJzaW9uZWQgc2NoZW1hIG9mIHRoaXMgcmVwcmVzZW50YXRpb24gb2YgYW4gb2JqZWN0LlxuU2VydmVycyBzaG91bGQgY29udmVydCByZWNvZ25pemVkIHNjaGVtYXMgdG8gdGhlIGxhdGVzdCBpbnRlcm5hbCB2YWx1ZSwgYW5kXG5tYXkgcmVqZWN0IHVucmVjb2duaXplZCB2YWx1ZXMuXG5Nb3JlIGluZm86IGh0dHBzOi8vZ2l0Lms4cy5pby9jb21tdW5pdHkvY29udHJpYnV0b3JzL2RldmVsL3NpZy1hcmNoaXRlY3R1cmUvYXBpLWNvbnZlbnRpb25zLm1kI3Jlc291cmNlcyIsInR5cGUiOiJzdHJpbmcifSwia2luZCI6eyJkZXNjcmlwdGlvbiI6IktpbmQgaXMgYSBzdHJpbmcgdmFsdWUgcmVwcmVzZW50aW5nIHRoZSBSRVNUIHJlc291cmNlIHRoaXMgb2JqZWN0IHJlcHJlc2VudHMuXG5TZXJ2ZXJzIG1heSBpbmZlciB0aGlzIGZyb20gdGhlIGVuZHBvaW50IHRoZSBjbGllbnQgc3VibWl0cyByZXF1ZXN0cyB0by5cbkNhbm5vdCBiZSB1cGRhdGVkLlxuSW4gQ2FtZWxDYXNlLlxuTW9yZSBpbmZvOiBodHRwczovL2dpdC5rOHMuaW8vY29tbXVuaXR5L2NvbnRyaWJ1dG9ycy9kZXZlbC9zaWctYXJjaGl0ZWN0dXJlL2FwaS1jb252ZW50aW9ucy5tZCN0eXBlcy1raW5kcyIsInR5cGUiOiJzdHJpbmcifSwibWV0YWRhdGEiOnsidHlwZSI6Im9iamVjdCJ9LCJzcGVjIjp7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yU3BlYyBkZWZpbmVzIHRoZSBkZXNpcmVkIHN0YXRlIG9mIExpbWl0YWRvciIsInByb3BlcnRpZXMiOnsiYWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJBZmZpbml0eSBpcyBhIGdyb3VwIG9mIGFmZmluaXR5IHNjaGVkdWxpbmcgcnVsZXMuIiwicHJvcGVydGllcyI6eyJub2RlQWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJEZXNjcmliZXMgbm9kZSBhZmZpbml0eSBzY2hlZHVsaW5nIHJ1bGVzIGZvciB0aGUgcG9kLiIsInByb3BlcnRpZXMiOnsicHJlZmVycmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJUaGUgc2NoZWR1bGVyIHdpbGwgcHJlZmVyIHRvIHNjaGVkdWxlIHBvZHMgdG8gbm9kZXMgdGhhdCBzYXRpc2Z5XG50aGUgYWZmaW5pdHkgZXhwcmVzc2lvbnMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQsIGJ1dCBpdCBtYXkgY2hvb3NlXG5hIG5vZGUgdGhhdCB2aW9sYXRlcyBvbmUgb3IgbW9yZSBvZiB0aGUgZXhwcmVzc2lvbnMuIFRoZSBub2RlIHRoYXQgaXNcbm1vc3QgcHJlZmVycmVkIGlzIHRoZSBvbmUgd2l0aCB0aGUgZ3JlYXRlc3Qgc3VtIG9mIHdlaWdodHMsIGkuZS5cbmZvciBlYWNoIG5vZGUgdGhhdCBtZWV0cyBhbGwgb2YgdGhlIHNjaGVkdWxpbmcgcmVxdWlyZW1lbnRzIChyZXNvdXJjZVxucmVxdWVzdCwgcmVxdWlyZWREdXJpbmdTY2hlZHVsaW5nIGFmZmluaXR5IGV4cHJlc3Npb25zLCBldGMuKSxcbmNvbXB1dGUgYSBzdW0gYnkgaXRlcmF0aW5nIHRocm91Z2ggdGhlIGVsZW1lbnRzIG9mIHRoaXMgZmllbGQgYW5kIGFkZGluZ1xuXCJ3ZWlnaHRcIiB0byB0aGUgc3VtIGlmIHRoZSBub2RlIG1hdGNoZXMgdGhlIGNvcnJlc3BvbmRpbmcgbWF0Y2hFeHByZXNzaW9uczsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBbiBlbXB0eSBwcmVmZXJyZWQgc2NoZWR1bGluZyB0ZXJtIG1hdGNoZXMgYWxsIG9iamVjdHMgd2l0aCBpbXBsaWNpdCB3ZWlnaHQgMFxuKGkuZS4gaXQncyBhIG5vLW9wKS4gQSBudWxsIHByZWZlcnJlZCBzY2hlZHVsaW5nIHRlcm0gbWF0Y2hlcyBubyBvYmplY3RzIChpLmUuIGlzIGFsc28gYSBuby1vcCkuIiwicHJvcGVydGllcyI6eyJwcmVmZXJlbmNlIjp7ImRlc2NyaXB0aW9uIjoiQSBub2RlIHNlbGVjdG9yIHRlcm0sIGFzc29jaWF0ZWQgd2l0aCB0aGUgY29ycmVzcG9uZGluZyB3ZWlnaHQuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoiQSBsaXN0IG9mIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnRzIGJ5IG5vZGUncyBsYWJlbHMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvclxudGhhdCByZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6IlRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoiUmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzLCBEb2VzTm90RXhpc3QuIEd0LCBhbmQgTHQuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJBbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEd0IG9yIEx0LCB0aGUgdmFsdWVzXG5hcnJheSBtdXN0IGhhdmUgYSBzaW5nbGUgZWxlbWVudCwgd2hpY2ggd2lsbCBiZSBpbnRlcnByZXRlZCBhcyBhbiBpbnRlZ2VyLlxuVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoRmllbGRzIjp7ImRlc2NyaXB0aW9uIjoiQSBsaXN0IG9mIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnRzIGJ5IG5vZGUncyBmaWVsZHMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvclxudGhhdCByZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6IlRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoiUmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzLCBEb2VzTm90RXhpc3QuIEd0LCBhbmQgTHQuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJBbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEd0IG9yIEx0LCB0aGUgdmFsdWVzXG5hcnJheSBtdXN0IGhhdmUgYSBzaW5nbGUgZWxlbWVudCwgd2hpY2ggd2lsbCBiZSBpbnRlcnByZXRlZCBhcyBhbiBpbnRlZ2VyLlxuVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIndlaWdodCI6eyJkZXNjcmlwdGlvbiI6IldlaWdodCBhc3NvY2lhdGVkIHdpdGggbWF0Y2hpbmcgdGhlIGNvcnJlc3BvbmRpbmcgbm9kZVNlbGVjdG9yVGVybSwgaW4gdGhlIHJhbmdlIDEtMTAwLiIsImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifX0sInJlcXVpcmVkIjpbInByZWZlcmVuY2UiLCJ3ZWlnaHQiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwicmVxdWlyZWREdXJpbmdTY2hlZHVsaW5nSWdub3JlZER1cmluZ0V4ZWN1dGlvbiI6eyJkZXNjcmlwdGlvbiI6IklmIHRoZSBhZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgYXJlIG5vdCBtZXQgYXRcbnNjaGVkdWxpbmcgdGltZSwgdGhlIHBvZCB3aWxsIG5vdCBiZSBzY2hlZHVsZWQgb250byB0aGUgbm9kZS5cbklmIHRoZSBhZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgY2Vhc2UgdG8gYmUgbWV0XG5hdCBzb21lIHBvaW50IGR1cmluZyBwb2QgZXhlY3V0aW9uIChlLmcuIGR1ZSB0byBhbiB1cGRhdGUpLCB0aGUgc3lzdGVtXG5tYXkgb3IgbWF5IG5vdCB0cnkgdG8gZXZlbnR1YWxseSBldmljdCB0aGUgcG9kIGZyb20gaXRzIG5vZGUuIiwicHJvcGVydGllcyI6eyJub2RlU2VsZWN0b3JUZXJtcyI6eyJkZXNjcmlwdGlvbiI6IlJlcXVpcmVkLiBBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciB0ZXJtcy4gVGhlIHRlcm1zIGFyZSBPUmVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBudWxsIG9yIGVtcHR5IG5vZGUgc2VsZWN0b3IgdGVybSBtYXRjaGVzIG5vIG9iamVjdHMuIFRoZSByZXF1aXJlbWVudHMgb2ZcbnRoZW0gYXJlIEFORGVkLlxuVGhlIFRvcG9sb2d5U2VsZWN0b3JUZXJtIHR5cGUgaW1wbGVtZW50cyBhIHN1YnNldCBvZiB0aGUgTm9kZVNlbGVjdG9yVGVybS4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudHMgYnkgbm9kZSdzIGxhYmVscy4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yXG50aGF0IHJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJSZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMsIERvZXNOb3RFeGlzdC4gR3QsIGFuZCBMdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6IkFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgR3Qgb3IgTHQsIHRoZSB2YWx1ZXNcbmFycmF5IG11c3QgaGF2ZSBhIHNpbmdsZSBlbGVtZW50LCB3aGljaCB3aWxsIGJlIGludGVycHJldGVkIGFzIGFuIGludGVnZXIuXG5UaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hGaWVsZHMiOnsiZGVzY3JpcHRpb24iOiJBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudHMgYnkgbm9kZSdzIGZpZWxkcy4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yXG50aGF0IHJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJSZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMsIERvZXNOb3RFeGlzdC4gR3QsIGFuZCBMdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6IkFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgR3Qgb3IgTHQsIHRoZSB2YWx1ZXNcbmFycmF5IG11c3QgaGF2ZSBhIHNpbmdsZSBlbGVtZW50LCB3aGljaCB3aWxsIGJlIGludGVycHJldGVkIGFzIGFuIGludGVnZXIuXG5UaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJub2RlU2VsZWN0b3JUZXJtcyJdLCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn19LCJ0eXBlIjoib2JqZWN0In0sInBvZEFmZmluaXR5Ijp7ImRlc2NyaXB0aW9uIjoiRGVzY3JpYmVzIHBvZCBhZmZpbml0eSBzY2hlZHVsaW5nIHJ1bGVzIChlLmcuIGNvLWxvY2F0ZSB0aGlzIHBvZCBpbiB0aGUgc2FtZSBub2RlLCB6b25lLCBldGMuIGFzIHNvbWUgb3RoZXIgcG9kKHMpKS4iLCJwcm9wZXJ0aWVzIjp7InByZWZlcnJlZER1cmluZ1NjaGVkdWxpbmdJZ25vcmVkRHVyaW5nRXhlY3V0aW9uIjp7ImRlc2NyaXB0aW9uIjoiVGhlIHNjaGVkdWxlciB3aWxsIHByZWZlciB0byBzY2hlZHVsZSBwb2RzIHRvIG5vZGVzIHRoYXQgc2F0aXNmeVxudGhlIGFmZmluaXR5IGV4cHJlc3Npb25zIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkLCBidXQgaXQgbWF5IGNob29zZVxuYSBub2RlIHRoYXQgdmlvbGF0ZXMgb25lIG9yIG1vcmUgb2YgdGhlIGV4cHJlc3Npb25zLiBUaGUgbm9kZSB0aGF0IGlzXG5tb3N0IHByZWZlcnJlZCBpcyB0aGUgb25lIHdpdGggdGhlIGdyZWF0ZXN0IHN1bSBvZiB3ZWlnaHRzLCBpLmUuXG5mb3IgZWFjaCBub2RlIHRoYXQgbWVldHMgYWxsIG9mIHRoZSBzY2hlZHVsaW5nIHJlcXVpcmVtZW50cyAocmVzb3VyY2VcbnJlcXVlc3QsIHJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZyBhZmZpbml0eSBleHByZXNzaW9ucywgZXRjLiksXG5jb21wdXRlIGEgc3VtIGJ5IGl0ZXJhdGluZyB0aHJvdWdoIHRoZSBlbGVtZW50cyBvZiB0aGlzIGZpZWxkIGFuZCBhZGRpbmdcblwid2VpZ2h0XCIgdG8gdGhlIHN1bSBpZiB0aGUgbm9kZSBoYXMgcG9kcyB3aGljaCBtYXRjaGVzIHRoZSBjb3JyZXNwb25kaW5nIHBvZEFmZmluaXR5VGVybTsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJUaGUgd2VpZ2h0cyBvZiBhbGwgb2YgdGhlIG1hdGNoZWQgV2VpZ2h0ZWRQb2RBZmZpbml0eVRlcm0gZmllbGRzIGFyZSBhZGRlZCBwZXItbm9kZSB0byBmaW5kIHRoZSBtb3N0IHByZWZlcnJlZCBub2RlKHMpIiwicHJvcGVydGllcyI6eyJwb2RBZmZpbml0eVRlcm0iOnsiZGVzY3JpcHRpb24iOiJSZXF1aXJlZC4gQSBwb2QgYWZmaW5pdHkgdGVybSwgYXNzb2NpYXRlZCB3aXRoIHRoZSBjb3JyZXNwb25kaW5nIHdlaWdodC4iLCJwcm9wZXJ0aWVzIjp7ImxhYmVsU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgYSBzZXQgb2YgcmVzb3VyY2VzLCBpbiB0aGlzIGNhc2UgcG9kcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciB0aGUgc2V0IG9mIG5hbWVzcGFjZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgc2VsZWN0ZWQgYnkgdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIGxpc3RlZCBpbiB0aGUgbmFtZXNwYWNlcyBmaWVsZC5cbm51bGwgc2VsZWN0b3IgYW5kIG51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi5cbkFuIGVtcHR5IHNlbGVjdG9yICh7fSkgbWF0Y2hlcyBhbGwgbmFtZXNwYWNlcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VzIjp7ImRlc2NyaXB0aW9uIjoibmFtZXNwYWNlcyBzcGVjaWZpZXMgYSBzdGF0aWMgbGlzdCBvZiBuYW1lc3BhY2UgbmFtZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgbGlzdGVkIGluIHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBzZWxlY3RlZCBieSBuYW1lc3BhY2VTZWxlY3Rvci5cbm51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IGFuZCBudWxsIG5hbWVzcGFjZVNlbGVjdG9yIG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJ0b3BvbG9neUtleSI6eyJkZXNjcmlwdGlvbiI6IlRoaXMgcG9kIHNob3VsZCBiZSBjby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGggdGhlIHBvZHMgbWF0Y2hpbmdcbnRoZSBsYWJlbFNlbGVjdG9yIGluIHRoZSBzcGVjaWZpZWQgbmFtZXNwYWNlcywgd2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlXG53aG9zZSB2YWx1ZSBvZiB0aGUgbGFiZWwgd2l0aCBrZXkgdG9wb2xvZ3lLZXkgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoIGFueSBvZiB0aGVcbnNlbGVjdGVkIHBvZHMgaXMgcnVubmluZy5cbkVtcHR5IHRvcG9sb2d5S2V5IGlzIG5vdCBhbGxvd2VkLiIsInR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInRvcG9sb2d5S2V5Il0sInR5cGUiOiJvYmplY3QifSwid2VpZ2h0Ijp7ImRlc2NyaXB0aW9uIjoid2VpZ2h0IGFzc29jaWF0ZWQgd2l0aCBtYXRjaGluZyB0aGUgY29ycmVzcG9uZGluZyBwb2RBZmZpbml0eVRlcm0sXG5pbiB0aGUgcmFuZ2UgMS0xMDAuIiwiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwicmVxdWlyZWQiOlsicG9kQWZmaW5pdHlUZXJtIiwid2VpZ2h0Il0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sInJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJJZiB0aGUgYWZmaW5pdHkgcmVxdWlyZW1lbnRzIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkIGFyZSBub3QgbWV0IGF0XG5zY2hlZHVsaW5nIHRpbWUsIHRoZSBwb2Qgd2lsbCBub3QgYmUgc2NoZWR1bGVkIG9udG8gdGhlIG5vZGUuXG5JZiB0aGUgYWZmaW5pdHkgcmVxdWlyZW1lbnRzIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkIGNlYXNlIHRvIGJlIG1ldFxuYXQgc29tZSBwb2ludCBkdXJpbmcgcG9kIGV4ZWN1dGlvbiAoZS5nLiBkdWUgdG8gYSBwb2QgbGFiZWwgdXBkYXRlKSwgdGhlXG5zeXN0ZW0gbWF5IG9yIG1heSBub3QgdHJ5IHRvIGV2ZW50dWFsbHkgZXZpY3QgdGhlIHBvZCBmcm9tIGl0cyBub2RlLlxuV2hlbiB0aGVyZSBhcmUgbXVsdGlwbGUgZWxlbWVudHMsIHRoZSBsaXN0cyBvZiBub2RlcyBjb3JyZXNwb25kaW5nIHRvIGVhY2hcbnBvZEFmZmluaXR5VGVybSBhcmUgaW50ZXJzZWN0ZWQsIGkuZS4gYWxsIHRlcm1zIG11c3QgYmUgc2F0aXNmaWVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiRGVmaW5lcyBhIHNldCBvZiBwb2RzIChuYW1lbHkgdGhvc2UgbWF0Y2hpbmcgdGhlIGxhYmVsU2VsZWN0b3JcbnJlbGF0aXZlIHRvIHRoZSBnaXZlbiBuYW1lc3BhY2UocykpIHRoYXQgdGhpcyBwb2Qgc2hvdWxkIGJlXG5jby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGgsXG53aGVyZSBjby1sb2NhdGVkIGlzIGRlZmluZWQgYXMgcnVubmluZyBvbiBhIG5vZGUgd2hvc2UgdmFsdWUgb2ZcbnRoZSBsYWJlbCB3aXRoIGtleSBcdTAwM2N0b3BvbG9neUtleVx1MDAzZSBtYXRjaGVzIHRoYXQgb2YgYW55IG5vZGUgb24gd2hpY2hcbmEgcG9kIG9mIHRoZSBzZXQgb2YgcG9kcyBpcyBydW5uaW5nIiwicHJvcGVydGllcyI6eyJsYWJlbFNlbGVjdG9yIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBxdWVyeSBvdmVyIGEgc2V0IG9mIHJlc291cmNlcywgaW4gdGhpcyBjYXNlIHBvZHMuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoibWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvciB0aGF0XG5yZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6ImtleSBpcyB0aGUgbGFiZWwga2V5IHRoYXQgdGhlIHNlbGVjdG9yIGFwcGxpZXMgdG8uIiwidHlwZSI6InN0cmluZyJ9LCJvcGVyYXRvciI6eyJkZXNjcmlwdGlvbiI6Im9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLlxuVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LiIsInR5cGUiOiJzdHJpbmcifSwidmFsdWVzIjp7ImRlc2NyaXB0aW9uIjoidmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpY1xubWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoTGFiZWxzIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjp7InR5cGUiOiJzdHJpbmcifSwiZGVzY3JpcHRpb24iOiJtYXRjaExhYmVscyBpcyBhIG1hcCBvZiB7a2V5LHZhbHVlfSBwYWlycy4gQSBzaW5nbGUge2tleSx2YWx1ZX0gaW4gdGhlIG1hdGNoTGFiZWxzXG5tYXAgaXMgZXF1aXZhbGVudCB0byBhbiBlbGVtZW50IG9mIG1hdGNoRXhwcmVzc2lvbnMsIHdob3NlIGtleSBmaWVsZCBpcyBcImtleVwiLCB0aGVcbm9wZXJhdG9yIGlzIFwiSW5cIiwgYW5kIHRoZSB2YWx1ZXMgYXJyYXkgY29udGFpbnMgb25seSBcInZhbHVlXCIuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwibmFtZXNwYWNlU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgdGhlIHNldCBvZiBuYW1lc3BhY2VzIHRoYXQgdGhlIHRlcm0gYXBwbGllcyB0by5cblRoZSB0ZXJtIGlzIGFwcGxpZWQgdG8gdGhlIHVuaW9uIG9mIHRoZSBuYW1lc3BhY2VzIHNlbGVjdGVkIGJ5IHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBsaXN0ZWQgaW4gdGhlIG5hbWVzcGFjZXMgZmllbGQuXG5udWxsIHNlbGVjdG9yIGFuZCBudWxsIG9yIGVtcHR5IG5hbWVzcGFjZXMgbGlzdCBtZWFucyBcInRoaXMgcG9kJ3MgbmFtZXNwYWNlXCIuXG5BbiBlbXB0eSBzZWxlY3RvciAoe30pIG1hdGNoZXMgYWxsIG5hbWVzcGFjZXMuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoibWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvciB0aGF0XG5yZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6ImtleSBpcyB0aGUgbGFiZWwga2V5IHRoYXQgdGhlIHNlbGVjdG9yIGFwcGxpZXMgdG8uIiwidHlwZSI6InN0cmluZyJ9LCJvcGVyYXRvciI6eyJkZXNjcmlwdGlvbiI6Im9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLlxuVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LiIsInR5cGUiOiJzdHJpbmcifSwidmFsdWVzIjp7ImRlc2NyaXB0aW9uIjoidmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpY1xubWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoTGFiZWxzIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjp7InR5cGUiOiJzdHJpbmcifSwiZGVzY3JpcHRpb24iOiJtYXRjaExhYmVscyBpcyBhIG1hcCBvZiB7a2V5LHZhbHVlfSBwYWlycy4gQSBzaW5nbGUge2tleSx2YWx1ZX0gaW4gdGhlIG1hdGNoTGFiZWxzXG5tYXAgaXMgZXF1aXZhbGVudCB0byBhbiBlbGVtZW50IG9mIG1hdGNoRXhwcmVzc2lvbnMsIHdob3NlIGtleSBmaWVsZCBpcyBcImtleVwiLCB0aGVcbm9wZXJhdG9yIGlzIFwiSW5cIiwgYW5kIHRoZSB2YWx1ZXMgYXJyYXkgY29udGFpbnMgb25seSBcInZhbHVlXCIuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwibmFtZXNwYWNlcyI6eyJkZXNjcmlwdGlvbiI6Im5hbWVzcGFjZXMgc3BlY2lmaWVzIGEgc3RhdGljIGxpc3Qgb2YgbmFtZXNwYWNlIG5hbWVzIHRoYXQgdGhlIHRlcm0gYXBwbGllcyB0by5cblRoZSB0ZXJtIGlzIGFwcGxpZWQgdG8gdGhlIHVuaW9uIG9mIHRoZSBuYW1lc3BhY2VzIGxpc3RlZCBpbiB0aGlzIGZpZWxkXG5hbmQgdGhlIG9uZXMgc2VsZWN0ZWQgYnkgbmFtZXNwYWNlU2VsZWN0b3IuXG5udWxsIG9yIGVtcHR5IG5hbWVzcGFjZXMgbGlzdCBhbmQgbnVsbCBuYW1lc3BhY2VTZWxlY3RvciBtZWFucyBcInRoaXMgcG9kJ3MgbmFtZXNwYWNlXCIuIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifSwidG9wb2xvZ3lLZXkiOnsiZGVzY3JpcHRpb24iOiJUaGlzIHBvZCBzaG91bGQgYmUgY28tbG9jYXRlZCAoYWZmaW5pdHkpIG9yIG5vdCBjby1sb2NhdGVkIChhbnRpLWFmZmluaXR5KSB3aXRoIHRoZSBwb2RzIG1hdGNoaW5nXG50aGUgbGFiZWxTZWxlY3RvciBpbiB0aGUgc3BlY2lmaWVkIG5hbWVzcGFjZXMsIHdoZXJlIGNvLWxvY2F0ZWQgaXMgZGVmaW5lZCBhcyBydW5uaW5nIG9uIGEgbm9kZVxud2hvc2UgdmFsdWUgb2YgdGhlIGxhYmVsIHdpdGgga2V5IHRvcG9sb2d5S2V5IG1hdGNoZXMgdGhhdCBvZiBhbnkgbm9kZSBvbiB3aGljaCBhbnkgb2YgdGhlXG5zZWxlY3RlZCBwb2RzIGlzIHJ1bm5pbmcuXG5FbXB0eSB0b3BvbG9neUtleSBpcyBub3QgYWxsb3dlZC4iLCJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJ0b3BvbG9neUtleSJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9fSwidHlwZSI6Im9iamVjdCJ9LCJwb2RBbnRpQWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJEZXNjcmliZXMgcG9kIGFudGktYWZmaW5pdHkgc2NoZWR1bGluZyBydWxlcyAoZS5nLiBhdm9pZCBwdXR0aW5nIHRoaXMgcG9kIGluIHRoZSBzYW1lIG5vZGUsIHpvbmUsIGV0Yy4gYXMgc29tZSBvdGhlciBwb2QocykpLiIsInByb3BlcnRpZXMiOnsicHJlZmVycmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJUaGUgc2NoZWR1bGVyIHdpbGwgcHJlZmVyIHRvIHNjaGVkdWxlIHBvZHMgdG8gbm9kZXMgdGhhdCBzYXRpc2Z5XG50aGUgYW50aS1hZmZpbml0eSBleHByZXNzaW9ucyBzcGVjaWZpZWQgYnkgdGhpcyBmaWVsZCwgYnV0IGl0IG1heSBjaG9vc2VcbmEgbm9kZSB0aGF0IHZpb2xhdGVzIG9uZSBvciBtb3JlIG9mIHRoZSBleHByZXNzaW9ucy4gVGhlIG5vZGUgdGhhdCBpc1xubW9zdCBwcmVmZXJyZWQgaXMgdGhlIG9uZSB3aXRoIHRoZSBncmVhdGVzdCBzdW0gb2Ygd2VpZ2h0cywgaS5lLlxuZm9yIGVhY2ggbm9kZSB0aGF0IG1lZXRzIGFsbCBvZiB0aGUgc2NoZWR1bGluZyByZXF1aXJlbWVudHMgKHJlc291cmNlXG5yZXF1ZXN0LCByZXF1aXJlZER1cmluZ1NjaGVkdWxpbmcgYW50aS1hZmZpbml0eSBleHByZXNzaW9ucywgZXRjLiksXG5jb21wdXRlIGEgc3VtIGJ5IGl0ZXJhdGluZyB0aHJvdWdoIHRoZSBlbGVtZW50cyBvZiB0aGlzIGZpZWxkIGFuZCBhZGRpbmdcblwid2VpZ2h0XCIgdG8gdGhlIHN1bSBpZiB0aGUgbm9kZSBoYXMgcG9kcyB3aGljaCBtYXRjaGVzIHRoZSBjb3JyZXNwb25kaW5nIHBvZEFmZmluaXR5VGVybTsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJUaGUgd2VpZ2h0cyBvZiBhbGwgb2YgdGhlIG1hdGNoZWQgV2VpZ2h0ZWRQb2RBZmZpbml0eVRlcm0gZmllbGRzIGFyZSBhZGRlZCBwZXItbm9kZSB0byBmaW5kIHRoZSBtb3N0IHByZWZlcnJlZCBub2RlKHMpIiwicHJvcGVydGllcyI6eyJwb2RBZmZpbml0eVRlcm0iOnsiZGVzY3JpcHRpb24iOiJSZXF1aXJlZC4gQSBwb2QgYWZmaW5pdHkgdGVybSwgYXNzb2NpYXRlZCB3aXRoIHRoZSBjb3JyZXNwb25kaW5nIHdlaWdodC4iLCJwcm9wZXJ0aWVzIjp7ImxhYmVsU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgYSBzZXQgb2YgcmVzb3VyY2VzLCBpbiB0aGlzIGNhc2UgcG9kcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciB0aGUgc2V0IG9mIG5hbWVzcGFjZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgc2VsZWN0ZWQgYnkgdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIGxpc3RlZCBpbiB0aGUgbmFtZXNwYWNlcyBmaWVsZC5cbm51bGwgc2VsZWN0b3IgYW5kIG51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi5cbkFuIGVtcHR5IHNlbGVjdG9yICh7fSkgbWF0Y2hlcyBhbGwgbmFtZXNwYWNlcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VzIjp7ImRlc2NyaXB0aW9uIjoibmFtZXNwYWNlcyBzcGVjaWZpZXMgYSBzdGF0aWMgbGlzdCBvZiBuYW1lc3BhY2UgbmFtZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgbGlzdGVkIGluIHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBzZWxlY3RlZCBieSBuYW1lc3BhY2VTZWxlY3Rvci5cbm51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IGFuZCBudWxsIG5hbWVzcGFjZVNlbGVjdG9yIG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJ0b3BvbG9neUtleSI6eyJkZXNjcmlwdGlvbiI6IlRoaXMgcG9kIHNob3VsZCBiZSBjby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGggdGhlIHBvZHMgbWF0Y2hpbmdcbnRoZSBsYWJlbFNlbGVjdG9yIGluIHRoZSBzcGVjaWZpZWQgbmFtZXNwYWNlcywgd2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlXG53aG9zZSB2YWx1ZSBvZiB0aGUgbGFiZWwgd2l0aCBrZXkgdG9wb2xvZ3lLZXkgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoIGFueSBvZiB0aGVcbnNlbGVjdGVkIHBvZHMgaXMgcnVubmluZy5cbkVtcHR5IHRvcG9sb2d5S2V5IGlzIG5vdCBhbGxvd2VkLiIsInR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInRvcG9sb2d5S2V5Il0sInR5cGUiOiJvYmplY3QifSwid2VpZ2h0Ijp7ImRlc2NyaXB0aW9uIjoid2VpZ2h0IGFzc29jaWF0ZWQgd2l0aCBtYXRjaGluZyB0aGUgY29ycmVzcG9uZGluZyBwb2RBZmZpbml0eVRlcm0sXG5pbiB0aGUgcmFuZ2UgMS0xMDAuIiwiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwicmVxdWlyZWQiOlsicG9kQWZmaW5pdHlUZXJtIiwid2VpZ2h0Il0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sInJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJJZiB0aGUgYW50aS1hZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgYXJlIG5vdCBtZXQgYXRcbnNjaGVkdWxpbmcgdGltZSwgdGhlIHBvZCB3aWxsIG5vdCBiZSBzY2hlZHVsZWQgb250byB0aGUgbm9kZS5cbklmIHRoZSBhbnRpLWFmZmluaXR5IHJlcXVpcmVtZW50cyBzcGVjaWZpZWQgYnkgdGhpcyBmaWVsZCBjZWFzZSB0byBiZSBtZXRcbmF0IHNvbWUgcG9pbnQgZHVyaW5nIHBvZCBleGVjdXRpb24gKGUuZy4gZHVlIHRvIGEgcG9kIGxhYmVsIHVwZGF0ZSksIHRoZVxuc3lzdGVtIG1heSBvciBtYXkgbm90IHRyeSB0byBldmVudHVhbGx5IGV2aWN0IHRoZSBwb2QgZnJvbSBpdHMgbm9kZS5cbldoZW4gdGhlcmUgYXJlIG11bHRpcGxlIGVsZW1lbnRzLCB0aGUgbGlzdHMgb2Ygbm9kZXMgY29ycmVzcG9uZGluZyB0byBlYWNoXG5wb2RBZmZpbml0eVRlcm0gYXJlIGludGVyc2VjdGVkLCBpLmUuIGFsbCB0ZXJtcyBtdXN0IGJlIHNhdGlzZmllZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkRlZmluZXMgYSBzZXQgb2YgcG9kcyAobmFtZWx5IHRob3NlIG1hdGNoaW5nIHRoZSBsYWJlbFNlbGVjdG9yXG5yZWxhdGl2ZSB0byB0aGUgZ2l2ZW4gbmFtZXNwYWNlKHMpKSB0aGF0IHRoaXMgcG9kIHNob3VsZCBiZVxuY28tbG9jYXRlZCAoYWZmaW5pdHkpIG9yIG5vdCBjby1sb2NhdGVkIChhbnRpLWFmZmluaXR5KSB3aXRoLFxud2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlIHdob3NlIHZhbHVlIG9mXG50aGUgbGFiZWwgd2l0aCBrZXkgXHUwMDNjdG9wb2xvZ3lLZXlcdTAwM2UgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoXG5hIHBvZCBvZiB0aGUgc2V0IG9mIHBvZHMgaXMgcnVubmluZyIsInByb3BlcnRpZXMiOnsibGFiZWxTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciBhIHNldCBvZiByZXNvdXJjZXMsIGluIHRoaXMgY2FzZSBwb2RzLiIsInByb3BlcnRpZXMiOnsibWF0Y2hFeHByZXNzaW9ucyI6eyJkZXNjcmlwdGlvbiI6Im1hdGNoRXhwcmVzc2lvbnMgaXMgYSBsaXN0IG9mIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50cy4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50IGlzIGEgc2VsZWN0b3IgdGhhdCBjb250YWlucyB2YWx1ZXMsIGEga2V5LCBhbmQgYW4gb3BlcmF0b3IgdGhhdFxucmVsYXRlcyB0aGUga2V5IGFuZCB2YWx1ZXMuIiwicHJvcGVydGllcyI6eyJrZXkiOnsiZGVzY3JpcHRpb24iOiJrZXkgaXMgdGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6InZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWNcbm1lcmdlIHBhdGNoLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJrZXkiLCJvcGVyYXRvciJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJtYXRjaExhYmVscyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJ0eXBlIjoic3RyaW5nIn0sImRlc2NyaXB0aW9uIjoibWF0Y2hMYWJlbHMgaXMgYSBtYXAgb2Yge2tleSx2YWx1ZX0gcGFpcnMuIEEgc2luZ2xlIHtrZXksdmFsdWV9IGluIHRoZSBtYXRjaExhYmVsc1xubWFwIGlzIGVxdWl2YWxlbnQgdG8gYW4gZWxlbWVudCBvZiBtYXRjaEV4cHJlc3Npb25zLCB3aG9zZSBrZXkgZmllbGQgaXMgXCJrZXlcIiwgdGhlXG5vcGVyYXRvciBpcyBcIkluXCIsIGFuZCB0aGUgdmFsdWVzIGFycmF5IGNvbnRhaW5zIG9ubHkgXCJ2YWx1ZVwiLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIm5hbWVzcGFjZVNlbGVjdG9yIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBxdWVyeSBvdmVyIHRoZSBzZXQgb2YgbmFtZXNwYWNlcyB0aGF0IHRoZSB0ZXJtIGFwcGxpZXMgdG8uXG5UaGUgdGVybSBpcyBhcHBsaWVkIHRvIHRoZSB1bmlvbiBvZiB0aGUgbmFtZXNwYWNlcyBzZWxlY3RlZCBieSB0aGlzIGZpZWxkXG5hbmQgdGhlIG9uZXMgbGlzdGVkIGluIHRoZSBuYW1lc3BhY2VzIGZpZWxkLlxubnVsbCBzZWxlY3RvciBhbmQgbnVsbCBvciBlbXB0eSBuYW1lc3BhY2VzIGxpc3QgbWVhbnMgXCJ0aGlzIHBvZCdzIG5hbWVzcGFjZVwiLlxuQW4gZW1wdHkgc2VsZWN0b3IgKHt9KSBtYXRjaGVzIGFsbCBuYW1lc3BhY2VzLiIsInByb3BlcnRpZXMiOnsibWF0Y2hFeHByZXNzaW9ucyI6eyJkZXNjcmlwdGlvbiI6Im1hdGNoRXhwcmVzc2lvbnMgaXMgYSBsaXN0IG9mIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50cy4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50IGlzIGEgc2VsZWN0b3IgdGhhdCBjb250YWlucyB2YWx1ZXMsIGEga2V5LCBhbmQgYW4gb3BlcmF0b3IgdGhhdFxucmVsYXRlcyB0aGUga2V5IGFuZCB2YWx1ZXMuIiwicHJvcGVydGllcyI6eyJrZXkiOnsiZGVzY3JpcHRpb24iOiJrZXkgaXMgdGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6InZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWNcbm1lcmdlIHBhdGNoLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJrZXkiLCJvcGVyYXRvciJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJtYXRjaExhYmVscyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJ0eXBlIjoic3RyaW5nIn0sImRlc2NyaXB0aW9uIjoibWF0Y2hMYWJlbHMgaXMgYSBtYXAgb2Yge2tleSx2YWx1ZX0gcGFpcnMuIEEgc2luZ2xlIHtrZXksdmFsdWV9IGluIHRoZSBtYXRjaExhYmVsc1xubWFwIGlzIGVxdWl2YWxlbnQgdG8gYW4gZWxlbWVudCBvZiBtYXRjaEV4cHJlc3Npb25zLCB3aG9zZSBrZXkgZmllbGQgaXMgXCJrZXlcIiwgdGhlXG5vcGVyYXRvciBpcyBcIkluXCIsIGFuZCB0aGUgdmFsdWVzIGFycmF5IGNvbnRhaW5zIG9ubHkgXCJ2YWx1ZVwiLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIm5hbWVzcGFjZXMiOnsiZGVzY3JpcHRpb24iOiJuYW1lc3BhY2VzIHNwZWNpZmllcyBhIHN0YXRpYyBsaXN0IG9mIG5hbWVzcGFjZSBuYW1lcyB0aGF0IHRoZSB0ZXJtIGFwcGxpZXMgdG8uXG5UaGUgdGVybSBpcyBhcHBsaWVkIHRvIHRoZSB1bmlvbiBvZiB0aGUgbmFtZXNwYWNlcyBsaXN0ZWQgaW4gdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIHNlbGVjdGVkIGJ5IG5hbWVzcGFjZVNlbGVjdG9yLlxubnVsbCBvciBlbXB0eSBuYW1lc3BhY2VzIGxpc3QgYW5kIG51bGwgbmFtZXNwYWNlU2VsZWN0b3IgbWVhbnMgXCJ0aGlzIHBvZCdzIG5hbWVzcGFjZVwiLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In0sInRvcG9sb2d5S2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhpcyBwb2Qgc2hvdWxkIGJlIGNvLWxvY2F0ZWQgKGFmZmluaXR5KSBvciBub3QgY28tbG9jYXRlZCAoYW50aS1hZmZpbml0eSkgd2l0aCB0aGUgcG9kcyBtYXRjaGluZ1xudGhlIGxhYmVsU2VsZWN0b3IgaW4gdGhlIHNwZWNpZmllZCBuYW1lc3BhY2VzLCB3aGVyZSBjby1sb2NhdGVkIGlzIGRlZmluZWQgYXMgcnVubmluZyBvbiBhIG5vZGVcbndob3NlIHZhbHVlIG9mIHRoZSBsYWJlbCB3aXRoIGtleSB0b3BvbG9neUtleSBtYXRjaGVzIHRoYXQgb2YgYW55IG5vZGUgb24gd2hpY2ggYW55IG9mIHRoZVxuc2VsZWN0ZWQgcG9kcyBpcyBydW5uaW5nLlxuRW1wdHkgdG9wb2xvZ3lLZXkgaXMgbm90IGFsbG93ZWQuIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsidG9wb2xvZ3lLZXkiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifX0sInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QifSwiaW1hZ2UiOnsidHlwZSI6InN0cmluZyJ9LCJpbWFnZVB1bGxTZWNyZXRzIjp7Iml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwidHlwZSI6ImFycmF5In0sImxpbWl0cyI6eyJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IlJhdGVMaW1pdCBkZWZpbmVzIHRoZSBkZXNpcmVkIExpbWl0YWRvciBsaW1pdCIsInByb3BlcnRpZXMiOnsiY29uZGl0aW9ucyI6eyJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJtYXhfdmFsdWUiOnsidHlwZSI6ImludGVnZXIifSwibmFtZSI6eyJ0eXBlIjoic3RyaW5nIn0sIm5hbWVzcGFjZSI6eyJ0eXBlIjoic3RyaW5nIn0sInNlY29uZHMiOnsidHlwZSI6ImludGVnZXIifSwidmFyaWFibGVzIjp7Iml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJjb25kaXRpb25zIiwibWF4X3ZhbHVlIiwibmFtZXNwYWNlIiwic2Vjb25kcyIsInZhcmlhYmxlcyJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJsaXN0ZW5lciI6eyJwcm9wZXJ0aWVzIjp7ImdycGMiOnsicHJvcGVydGllcyI6eyJwb3J0Ijp7ImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifX0sInR5cGUiOiJvYmplY3QifSwiaHR0cCI6eyJwcm9wZXJ0aWVzIjp7InBvcnQiOnsiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9LCJwZGIiOnsicHJvcGVydGllcyI6eyJtYXhVbmF2YWlsYWJsZSI6eyJhbnlPZiI6W3sidHlwZSI6ImludGVnZXIifSx7InR5cGUiOiJzdHJpbmcifV0sImRlc2NyaXB0aW9uIjoiQW4gZXZpY3Rpb24gaXMgYWxsb3dlZCBpZiBhdCBtb3N0IFwibWF4VW5hdmFpbGFibGVcIiBsaW1pdGFkb3IgcG9kc1xuYXJlIHVuYXZhaWxhYmxlIGFmdGVyIHRoZSBldmljdGlvbiwgaS5lLiBldmVuIGluIGFic2VuY2Ugb2ZcbnRoZSBldmljdGVkIHBvZC4gRm9yIGV4YW1wbGUsIG9uZSBjYW4gcHJldmVudCBhbGwgdm9sdW50YXJ5IGV2aWN0aW9uc1xuYnkgc3BlY2lmeWluZyAwLiBUaGlzIGlzIGEgbXV0dWFsbHkgZXhjbHVzaXZlIHNldHRpbmcgd2l0aCBcIm1pbkF2YWlsYWJsZVwiLiIsIngta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nIjp0cnVlfSwibWluQXZhaWxhYmxlIjp7ImFueU9mIjpbeyJ0eXBlIjoiaW50ZWdlciJ9LHsidHlwZSI6InN0cmluZyJ9XSwiZGVzY3JpcHRpb24iOiJBbiBldmljdGlvbiBpcyBhbGxvd2VkIGlmIGF0IGxlYXN0IFwibWluQXZhaWxhYmxlXCIgbGltaXRhZG9yIHBvZHMgd2lsbFxuc3RpbGwgYmUgYXZhaWxhYmxlIGFmdGVyIHRoZSBldmljdGlvbiwgaS5lLiBldmVuIGluIHRoZSBhYnNlbmNlIG9mXG50aGUgZXZpY3RlZCBwb2QuICBTbyBmb3IgZXhhbXBsZSB5b3UgY2FuIHByZXZlbnQgYWxsIHZvbHVudGFyeVxuZXZpY3Rpb25zIGJ5IHNwZWNpZnlpbmcgXCIxMDAlXCIuIiwieC1rdWJlcm5ldGVzLWludC1vci1zdHJpbmciOnRydWV9fSwidHlwZSI6Im9iamVjdCJ9LCJyYXRlTGltaXRIZWFkZXJzIjp7ImRlc2NyaXB0aW9uIjoiUmF0ZUxpbWl0SGVhZGVyc1R5cGUgZGVmaW5lcyB0aGUgdmFsaWQgb3B0aW9ucyBmb3IgdGhlIC0tcmF0ZS1saW1pdC1oZWFkZXJzIGFyZyIsImVudW0iOlsiTk9ORSIsIkRSQUZUX1ZFUlNJT05fMDMiXSwidHlwZSI6InN0cmluZyJ9LCJyZXBsaWNhcyI6eyJ0eXBlIjoiaW50ZWdlciJ9LCJyZXNvdXJjZVJlcXVpcmVtZW50cyI6eyJkZXNjcmlwdGlvbiI6IlJlc291cmNlUmVxdWlyZW1lbnRzIGRlc2NyaWJlcyB0aGUgY29tcHV0ZSByZXNvdXJjZSByZXF1aXJlbWVudHMuIiwicHJvcGVydGllcyI6eyJjbGFpbXMiOnsiZGVzY3JpcHRpb24iOiJDbGFpbXMgbGlzdHMgdGhlIG5hbWVzIG9mIHJlc291cmNlcywgZGVmaW5lZCBpbiBzcGVjLnJlc291cmNlQ2xhaW1zLFxudGhhdCBhcmUgdXNlZCBieSB0aGlzIGNvbnRhaW5lci5cblxuXG5UaGlzIGlzIGFuIGFscGhhIGZpZWxkIGFuZCByZXF1aXJlcyBlbmFibGluZyB0aGVcbkR5bmFtaWNSZXNvdXJjZUFsbG9jYXRpb24gZmVhdHVyZSBnYXRlLlxuXG5cblRoaXMgZmllbGQgaXMgaW1tdXRhYmxlLiBJdCBjYW4gb25seSBiZSBzZXQgZm9yIGNvbnRhaW5lcnMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJSZXNvdXJjZUNsYWltIHJlZmVyZW5jZXMgb25lIGVudHJ5IGluIFBvZFNwZWMuUmVzb3VyY2VDbGFpbXMuIiwicHJvcGVydGllcyI6eyJuYW1lIjp7ImRlc2NyaXB0aW9uIjoiTmFtZSBtdXN0IG1hdGNoIHRoZSBuYW1lIG9mIG9uZSBlbnRyeSBpbiBwb2Quc3BlYy5yZXNvdXJjZUNsYWltcyBvZlxudGhlIFBvZCB3aGVyZSB0aGlzIGZpZWxkIGlzIHVzZWQuIEl0IG1ha2VzIHRoYXQgcmVzb3VyY2UgYXZhaWxhYmxlXG5pbnNpZGUgYSBjb250YWluZXIuIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsibmFtZSJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSIsIngta3ViZXJuZXRlcy1saXN0LW1hcC1rZXlzIjpbIm5hbWUiXSwieC1rdWJlcm5ldGVzLWxpc3QtdHlwZSI6Im1hcCJ9LCJsaW1pdHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsiYW55T2YiOlt7InR5cGUiOiJpbnRlZ2VyIn0seyJ0eXBlIjoic3RyaW5nIn1dLCJwYXR0ZXJuIjoiXihcXCt8LSk/KChbMC05XSsoXFwuWzAtOV0qKT8pfChcXC5bMC05XSspKSgoW0tNR1RQRV1pKXxbbnVta01HVFBFXXwoW2VFXShcXCt8LSk/KChbMC05XSsoXFwuWzAtOV0qKT8pfChcXC5bMC05XSspKSkpPyQiLCJ4LWt1YmVybmV0ZXMtaW50LW9yLXN0cmluZyI6dHJ1ZX0sImRlc2NyaXB0aW9uIjoiTGltaXRzIGRlc2NyaWJlcyB0aGUgbWF4aW11bSBhbW91bnQgb2YgY29tcHV0ZSByZXNvdXJjZXMgYWxsb3dlZC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvY29uZmlndXJhdGlvbi9tYW5hZ2UtcmVzb3VyY2VzLWNvbnRhaW5lcnMvIiwidHlwZSI6Im9iamVjdCJ9LCJyZXF1ZXN0cyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJhbnlPZiI6W3sidHlwZSI6ImludGVnZXIifSx7InR5cGUiOiJzdHJpbmcifV0sInBhdHRlcm4iOiJeKFxcK3wtKT8oKFswLTldKyhcXC5bMC05XSopPyl8KFxcLlswLTldKykpKChbS01HVFBFXWkpfFtudW1rTUdUUEVdfChbZUVdKFxcK3wtKT8oKFswLTldKyhcXC5bMC05XSopPyl8KFxcLlswLTldKykpKSk/JCIsIngta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nIjp0cnVlfSwiZGVzY3JpcHRpb24iOiJSZXF1ZXN0cyBkZXNjcmliZXMgdGhlIG1pbmltdW0gYW1vdW50IG9mIGNvbXB1dGUgcmVzb3VyY2VzIHJlcXVpcmVkLlxuSWYgUmVxdWVzdHMgaXMgb21pdHRlZCBmb3IgYSBjb250YWluZXIsIGl0IGRlZmF1bHRzIHRvIExpbWl0cyBpZiB0aGF0IGlzIGV4cGxpY2l0bHkgc3BlY2lmaWVkLFxub3RoZXJ3aXNlIHRvIGFuIGltcGxlbWVudGF0aW9uLWRlZmluZWQgdmFsdWUuIFJlcXVlc3RzIGNhbm5vdCBleGNlZWQgTGltaXRzLlxuTW9yZSBpbmZvOiBodHRwczovL2t1YmVybmV0ZXMuaW8vZG9jcy9jb25jZXB0cy9jb25maWd1cmF0aW9uL21hbmFnZS1yZXNvdXJjZXMtY29udGFpbmVycy8iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In0sInN0b3JhZ2UiOnsiZGVzY3JpcHRpb24iOiJTdG9yYWdlIGNvbnRhaW5zIHRoZSBvcHRpb25zIGZvciBMaW1pdGFkb3IgY291bnRlcnMgZGF0YWJhc2Ugb3IgaW4tbWVtb3J5IGRhdGEgc3RvcmFnZSIsInByb3BlcnRpZXMiOnsiZGlzayI6eyJwcm9wZXJ0aWVzIjp7Im9wdGltaXplIjp7ImRlc2NyaXB0aW9uIjoiRGlza09wdGltaXplVHlwZSBkZWZpbmVzIHRoZSB2YWxpZCBvcHRpb25zIGZvciBcIm9wdGltaXplXCIgb3B0aW9uIG9mIHRoZSBkaXNrIHBlcnNpc3RlbmNlIHR5cGUiLCJlbnVtIjpbInRocm91Z2hwdXQiLCJkaXNrIl0sInR5cGUiOiJzdHJpbmcifSwicGVyc2lzdGVudFZvbHVtZUNsYWltIjp7InByb3BlcnRpZXMiOnsicmVzb3VyY2VzIjp7ImRlc2NyaXB0aW9uIjoiUmVzb3VyY2VzIHJlcHJlc2VudHMgdGhlIG1pbmltdW0gcmVzb3VyY2VzIHRoZSB2b2x1bWUgc2hvdWxkIGhhdmUuXG5JZ25vcmVkIHdoZW4gVm9sdW1lTmFtZSBmaWVsZCBpcyBzZXQiLCJwcm9wZXJ0aWVzIjp7InJlcXVlc3RzIjp7ImFueU9mIjpbeyJ0eXBlIjoiaW50ZWdlciJ9LHsidHlwZSI6InN0cmluZyJ9XSwiZGVzY3JpcHRpb24iOiJTdG9yYWdlIFJlc291cmNlIHJlcXVlc3RzIHRvIGJlIHVzZWQgb24gdGhlIFBlcnNpc3RlbnRWb2x1bWVDbGFpbS5cblRvIGxlYXJuIG1vcmUgYWJvdXQgcmVzb3VyY2UgcmVxdWVzdHMgc2VlOlxuaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvY29uZmlndXJhdGlvbi9tYW5hZ2UtcmVzb3VyY2VzLWNvbnRhaW5lcnMvIiwicGF0dGVybiI6Il4oXFwrfC0pPygoWzAtOV0rKFxcLlswLTldKik/KXwoXFwuWzAtOV0rKSkoKFtLTUdUUEVdaSl8W251bWtNR1RQRV18KFtlRV0oXFwrfC0pPygoWzAtOV0rKFxcLlswLTldKik/KXwoXFwuWzAtOV0rKSkpKT8kIiwieC1rdWJlcm5ldGVzLWludC1vci1zdHJpbmciOnRydWV9fSwicmVxdWlyZWQiOlsicmVxdWVzdHMiXSwidHlwZSI6Im9iamVjdCJ9LCJzdG9yYWdlQ2xhc3NOYW1lIjp7InR5cGUiOiJzdHJpbmcifSwidm9sdW1lTmFtZSI6eyJkZXNjcmlwdGlvbiI6IlZvbHVtZU5hbWUgaXMgdGhlIGJpbmRpbmcgcmVmZXJlbmNlIHRvIHRoZSBQZXJzaXN0ZW50Vm9sdW1lIGJhY2tpbmcgdGhpcyBjbGFpbS4iLCJ0eXBlIjoic3RyaW5nIn19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In0sInJlZGlzIjp7InByb3BlcnRpZXMiOnsiY29uZmlnU2VjcmV0UmVmIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifX0sInR5cGUiOiJvYmplY3QifSwicmVkaXMtY2FjaGVkIjp7InByb3BlcnRpZXMiOnsiY29uZmlnU2VjcmV0UmVmIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwib3B0aW9ucyI6eyJwcm9wZXJ0aWVzIjp7ImJhdGNoLXNpemUiOnsiZGVzY3JpcHRpb24iOiJCYXRjaFNpemUgZGVmaW5lcyB0aGUgc2l6ZSBvZiBlbnRyaWVzIHRvIGZsdXNoIGluIGFzIHNpbmdsZSBmbHVzaCBbZGVmYXVsdDogMTAwXSIsInR5cGUiOiJpbnRlZ2VyIn0sImZsdXNoLXBlcmlvZCI6eyJkZXNjcmlwdGlvbiI6IkZsdXNoUGVyaW9kIGZvciBjb3VudGVycyBpbiBtaWxsaXNlY29uZHMgW2RlZmF1bHQ6IDEwMDBdIiwidHlwZSI6ImludGVnZXIifSwibWF4LWNhY2hlZCI6eyJkZXNjcmlwdGlvbiI6Ik1heENhY2hlZCByZWZlcnMgdG8gdGhlIG1heGltdW0gYW1vdW50IG9mIGNvdW50ZXJzIGNhY2hlZCBbZGVmYXVsdDogMTAwMDBdIiwidHlwZSI6ImludGVnZXIifSwicmVzcG9uc2UtdGltZW91dCI6eyJkZXNjcmlwdGlvbiI6IlJlc3BvbnNlVGltZW91dCBkZWZpbmVzIHRoZSB0aW1lb3V0IGZvciBSZWRpcyBjb21tYW5kcyBpbiBtaWxsaXNlY29uZHMgW2RlZmF1bHQ6IDM1MF0iLCJ0eXBlIjoiaW50ZWdlciJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9LCJ0ZWxlbWV0cnkiOnsiZGVzY3JpcHRpb24iOiJUZWxlbWV0cnkgZGVmaW5lcyB0aGUgbGV2ZWwgb2YgbWV0cmljcyBMaW1pdGFkb3Igd2lsbCBleHBvc2UgdG8gdGhlIHVzZXIiLCJlbnVtIjpbImJhc2ljIiwiZXhoYXVzdGl2ZSJdLCJ0eXBlIjoic3RyaW5nIn0sInRyYWNpbmciOnsicHJvcGVydGllcyI6eyJlbmRwb2ludCI6eyJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJlbmRwb2ludCJdLCJ0eXBlIjoib2JqZWN0In0sInZlcmJvc2l0eSI6eyJkZXNjcmlwdGlvbiI6IlNldHMgdGhlIGxldmVsIG9mIHZlcmJvc2l0eSIsIm1heGltdW0iOjQsIm1pbmltdW0iOjEsInR5cGUiOiJpbnRlZ2VyIn0sInZlcnNpb24iOnsiZGVzY3JpcHRpb24iOiJbRGVwcmVjYXRlZF0gVXNlIHNwZWMuaW1hZ2UgaW5zdGVhZC5cbiBEb2NrZXIgdGFnIHVzZWQgYXMgbGltaXRhZG9yIGltYWdlLiBUaGUgcmVwbyBpcyBoYXJkY29kZWQgdG8gcXVheS5pby9rdWFkcmFudC9saW1pdGFkb3IiLCJ0eXBlIjoic3RyaW5nIn19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLXZhbGlkYXRpb25zIjpbeyJtZXNzYWdlIjoiZGlzayBzdG9yYWdlIGRvZXMgbm90IGFsbG93IG11bHRpcGxlIHJlcGxpY2FzIiwicnVsZSI6IighaGFzKHNlbGYuc3RvcmFnZSkgfHwgIWhhcyhzZWxmLnN0b3JhZ2UuZGlzaykpIHx8ICghaGFzKHNlbGYucmVwbGljYXMpIHx8IHNlbGYucmVwbGljYXMgXHUwMDNjIDIpIn1dfSwic3RhdHVzIjp7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yU3RhdHVzIGRlZmluZXMgdGhlIG9ic2VydmVkIHN0YXRlIG9mIExpbWl0YWRvciIsInByb3BlcnRpZXMiOnsiY29uZGl0aW9ucyI6eyJkZXNjcmlwdGlvbiI6IlJlcHJlc2VudHMgdGhlIG9ic2VydmF0aW9ucyBvZiBhIGZvbydzIGN1cnJlbnQgc3RhdGUuXG5Lbm93biAuc3RhdHVzLmNvbmRpdGlvbnMudHlwZSBhcmU6IFwiUmVhZHlcIiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQ29uZGl0aW9uIGNvbnRhaW5zIGRldGFpbHMgZm9yIG9uZSBhc3BlY3Qgb2YgdGhlIGN1cnJlbnQgc3RhdGUgb2YgdGhpcyBBUEkgUmVzb3VyY2UuXG4tLS1cblRoaXMgc3RydWN0IGlzIGludGVuZGVkIGZvciBkaXJlY3QgdXNlIGFzIGFuIGFycmF5IGF0IHRoZSBmaWVsZCBwYXRoIC5zdGF0dXMuY29uZGl0aW9ucy4gIEZvciBleGFtcGxlLFxuXG5cblx0dHlwZSBGb29TdGF0dXMgc3RydWN0e1xuXHQgICAgLy8gUmVwcmVzZW50cyB0aGUgb2JzZXJ2YXRpb25zIG9mIGEgZm9vJ3MgY3VycmVudCBzdGF0ZS5cblx0ICAgIC8vIEtub3duIC5zdGF0dXMuY29uZGl0aW9ucy50eXBlIGFyZTogXCJBdmFpbGFibGVcIiwgXCJQcm9ncmVzc2luZ1wiLCBhbmQgXCJEZWdyYWRlZFwiXG5cdCAgICAvLyArcGF0Y2hNZXJnZUtleT10eXBlXG5cdCAgICAvLyArcGF0Y2hTdHJhdGVneT1tZXJnZVxuXHQgICAgLy8gK2xpc3RUeXBlPW1hcFxuXHQgICAgLy8gK2xpc3RNYXBLZXk9dHlwZVxuXHQgICAgQ29uZGl0aW9ucyBbXW1ldGF2MS5Db25kaXRpb24gYGpzb246XCJjb25kaXRpb25zLG9taXRlbXB0eVwiIHBhdGNoU3RyYXRlZ3k6XCJtZXJnZVwiIHBhdGNoTWVyZ2VLZXk6XCJ0eXBlXCIgcHJvdG9idWY6XCJieXRlcywxLHJlcCxuYW1lPWNvbmRpdGlvbnNcImBcblxuXG5cdCAgICAvLyBvdGhlciBmaWVsZHNcblx0fSIsInByb3BlcnRpZXMiOnsibGFzdFRyYW5zaXRpb25UaW1lIjp7ImRlc2NyaXB0aW9uIjoibGFzdFRyYW5zaXRpb25UaW1lIGlzIHRoZSBsYXN0IHRpbWUgdGhlIGNvbmRpdGlvbiB0cmFuc2l0aW9uZWQgZnJvbSBvbmUgc3RhdHVzIHRvIGFub3RoZXIuXG5UaGlzIHNob3VsZCBiZSB3aGVuIHRoZSB1bmRlcmx5aW5nIGNvbmRpdGlvbiBjaGFuZ2VkLiAgSWYgdGhhdCBpcyBub3Qga25vd24sIHRoZW4gdXNpbmcgdGhlIHRpbWUgd2hlbiB0aGUgQVBJIGZpZWxkIGNoYW5nZWQgaXMgYWNjZXB0YWJsZS4iLCJmb3JtYXQiOiJkYXRlLXRpbWUiLCJ0eXBlIjoic3RyaW5nIn0sIm1lc3NhZ2UiOnsiZGVzY3JpcHRpb24iOiJtZXNzYWdlIGlzIGEgaHVtYW4gcmVhZGFibGUgbWVzc2FnZSBpbmRpY2F0aW5nIGRldGFpbHMgYWJvdXQgdGhlIHRyYW5zaXRpb24uXG5UaGlzIG1heSBiZSBhbiBlbXB0eSBzdHJpbmcuIiwibWF4TGVuZ3RoIjozMjc2OCwidHlwZSI6InN0cmluZyJ9LCJvYnNlcnZlZEdlbmVyYXRpb24iOnsiZGVzY3JpcHRpb24iOiJvYnNlcnZlZEdlbmVyYXRpb24gcmVwcmVzZW50cyB0aGUgLm1ldGFkYXRhLmdlbmVyYXRpb24gdGhhdCB0aGUgY29uZGl0aW9uIHdhcyBzZXQgYmFzZWQgdXBvbi5cbkZvciBpbnN0YW5jZSwgaWYgLm1ldGFkYXRhLmdlbmVyYXRpb24gaXMgY3VycmVudGx5IDEyLCBidXQgdGhlIC5zdGF0dXMuY29uZGl0aW9uc1t4XS5vYnNlcnZlZEdlbmVyYXRpb24gaXMgOSwgdGhlIGNvbmRpdGlvbiBpcyBvdXQgb2YgZGF0ZVxud2l0aCByZXNwZWN0IHRvIHRoZSBjdXJyZW50IHN0YXRlIG9mIHRoZSBpbnN0YW5jZS4iLCJmb3JtYXQiOiJpbnQ2NCIsIm1pbmltdW0iOjAsInR5cGUiOiJpbnRlZ2VyIn0sInJlYXNvbiI6eyJkZXNjcmlwdGlvbiI6InJlYXNvbiBjb250YWlucyBhIHByb2dyYW1tYXRpYyBpZGVudGlmaWVyIGluZGljYXRpbmcgdGhlIHJlYXNvbiBmb3IgdGhlIGNvbmRpdGlvbidzIGxhc3QgdHJhbnNpdGlvbi5cblByb2R1Y2VycyBvZiBzcGVjaWZpYyBjb25kaXRpb24gdHlwZXMgbWF5IGRlZmluZSBleHBlY3RlZCB2YWx1ZXMgYW5kIG1lYW5pbmdzIGZvciB0aGlzIGZpZWxkLFxuYW5kIHdoZXRoZXIgdGhlIHZhbHVlcyBhcmUgY29uc2lkZXJlZCBhIGd1YXJhbnRlZWQgQVBJLlxuVGhlIHZhbHVlIHNob3VsZCBiZSBhIENhbWVsQ2FzZSBzdHJpbmcuXG5UaGlzIGZpZWxkIG1heSBub3QgYmUgZW1wdHkuIiwibWF4TGVuZ3RoIjoxMDI0LCJtaW5MZW5ndGgiOjEsInBhdHRlcm4iOiJeW0EtWmEtel0oW0EtWmEtejAtOV8sOl0qW0EtWmEtejAtOV9dKT8kIiwidHlwZSI6InN0cmluZyJ9LCJzdGF0dXMiOnsiZGVzY3JpcHRpb24iOiJzdGF0dXMgb2YgdGhlIGNvbmRpdGlvbiwgb25lIG9mIFRydWUsIEZhbHNlLCBVbmtub3duLiIsImVudW0iOlsiVHJ1ZSIsIkZhbHNlIiwiVW5rbm93biJdLCJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOnsiZGVzY3JpcHRpb24iOiJ0eXBlIG9mIGNvbmRpdGlvbiBpbiBDYW1lbENhc2Ugb3IgaW4gZm9vLmV4YW1wbGUuY29tL0NhbWVsQ2FzZS5cbi0tLVxuTWFueSAuY29uZGl0aW9uLnR5cGUgdmFsdWVzIGFyZSBjb25zaXN0ZW50IGFjcm9zcyByZXNvdXJjZXMgbGlrZSBBdmFpbGFibGUsIGJ1dCBiZWNhdXNlIGFyYml0cmFyeSBjb25kaXRpb25zIGNhbiBiZVxudXNlZnVsIChzZWUgLm5vZGUuc3RhdHVzLmNvbmRpdGlvbnMpLCB0aGUgYWJpbGl0eSB0byBkZWNvbmZsaWN0IGlzIGltcG9ydGFudC5cblRoZSByZWdleCBpdCBtYXRjaGVzIGlzIChkbnMxMTIzU3ViZG9tYWluRm10Lyk/KHF1YWxpZmllZE5hbWVGbXQpIiwibWF4TGVuZ3RoIjozMTYsInBhdHRlcm4iOiJeKFthLXowLTldKFstYS16MC05XSpbYS16MC05XSk/KFxcLlthLXowLTldKFstYS16MC05XSpbYS16MC05XSk/KSovKT8oKFtBLVphLXowLTldWy1BLVphLXowLTlfLl0qKT9bQS1aYS16MC05XSkkIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsibGFzdFRyYW5zaXRpb25UaW1lIiwibWVzc2FnZSIsInJlYXNvbiIsInN0YXR1cyIsInR5cGUiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkiLCJ4LWt1YmVybmV0ZXMtbGlzdC1tYXAta2V5cyI6WyJ0eXBlIl0sIngta3ViZXJuZXRlcy1saXN0LXR5cGUiOiJtYXAifSwib2JzZXJ2ZWRHZW5lcmF0aW9uIjp7ImRlc2NyaXB0aW9uIjoiT2JzZXJ2ZWRHZW5lcmF0aW9uIHJlZmxlY3RzIHRoZSBnZW5lcmF0aW9uIG9mIHRoZSBtb3N0IHJlY2VudGx5IG9ic2VydmVkIHNwZWMuIiwiZm9ybWF0IjoiaW50NjQiLCJ0eXBlIjoiaW50ZWdlciJ9LCJzZXJ2aWNlIjp7ImRlc2NyaXB0aW9uIjoiU2VydmljZSBwcm92aWRlcyBpbmZvcm1hdGlvbiBhYm91dCB0aGUgc2VydmljZSBleHBvc2luZyBsaW1pdGFkb3IgQVBJIiwicHJvcGVydGllcyI6eyJob3N0Ijp7InR5cGUiOiJzdHJpbmcifSwicG9ydHMiOnsicHJvcGVydGllcyI6eyJncnBjIjp7ImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifSwiaHR0cCI6eyJmb3JtYXQiOiJpbnQzMiIsInR5cGUiOiJpbnRlZ2VyIn19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJzZXJ2ZWQiOnRydWUsInN0b3JhZ2UiOnRydWUsInN1YnJlc291cmNlcyI6eyJzdGF0dXMiOnt9fX1dfSwic3RhdHVzIjp7ImFjY2VwdGVkTmFtZXMiOnsia2luZCI6IiIsInBsdXJhbCI6IiJ9LCJjb25kaXRpb25zIjpudWxsLCJzdG9yZWRWZXJzaW9ucyI6bnVsbH19
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsiYWxtLWV4YW1wbGVzIjoiW1xuICB7XG4gICAgXCJhcGlWZXJzaW9uXCI6IFwibGltaXRhZG9yLmt1YWRyYW50LmlvL3YxYWxwaGExXCIsXG4gICAgXCJraW5kXCI6IFwiTGltaXRhZG9yXCIsXG4gICAgXCJtZXRhZGF0YVwiOiB7XG4gICAgICBcIm5hbWVcIjogXCJsaW1pdGFkb3Itc2FtcGxlXCJcbiAgICB9LFxuICAgIFwic3BlY1wiOiB7XG4gICAgICBcImxpbWl0c1wiOiBbXG4gICAgICAgIHtcbiAgICAgICAgICBcImNvbmRpdGlvbnNcIjogW1xuICAgICAgICAgICAgXCJnZXRfdG95ID09ICd5ZXMnXCJcbiAgICAgICAgICBdLFxuICAgICAgICAgIFwibWF4X3ZhbHVlXCI6IDIsXG4gICAgICAgICAgXCJuYW1lXCI6IFwidG95X2dldF9yb3V0ZVwiLFxuICAgICAgICAgIFwibmFtZXNwYWNlXCI6IFwidG95c3RvcmUtYXBwXCIsXG4gICAgICAgICAgXCJzZWNvbmRzXCI6IDMwLFxuICAgICAgICAgIFwidmFyaWFibGVzXCI6IFtdXG4gICAgICAgIH1cbiAgICAgIF0sXG4gICAgICBcImxpc3RlbmVyXCI6IHtcbiAgICAgICAgXCJncnBjXCI6IHtcbiAgICAgICAgICBcInBvcnRcIjogODA4MVxuICAgICAgICB9LFxuICAgICAgICBcImh0dHBcIjoge1xuICAgICAgICAgIFwicG9ydFwiOiA4MDgwXG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9XG4gIH1cbl0iLCJjYXBhYmlsaXRpZXMiOiJCYXNpYyBJbnN0YWxsIiwiY2F0ZWdvcmllcyI6IkludGVncmF0aW9uIFx1MDAyNiBEZWxpdmVyeSIsImNvbnRhaW5lckltYWdlIjoicmVnaXN0cnkucmVkaGF0LmlvL3JoY2wtMS9saW1pdGFkb3ItcmhlbDktb3BlcmF0b3JAc2hhMjU2OmIzMWJhMjkzODEyNzg4ZGM3ZTIxYzE0NzAzYWM2MWZkZDViZmYwMTA5NDhhZGEzMzcxNTU0NGJhNTA3ODUxZjciLCJjcmVhdGVkQXQiOiIyMyBTZXAgMjAyNSwgMTI6MTkiLCJkZXNjcmlwdGlvbiI6IkVuYWJsZXMgcmF0ZSBsaW1pdGluZyBmb3IgR2F0ZXdheXMgYW5kIGFwcGxpY2F0aW9ucyBpbiBhIEdhdGV3YXkgQVBJIG5ldHdvcmsiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2NuZiI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby9jbmkiOiJmYWxzZSIsImZlYXR1cmVzLm9wZXJhdG9ycy5vcGVuc2hpZnQuaW8vY3NpIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2Rpc2Nvbm5lY3RlZCI6InRydWUiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2ZpcHMtY29tcGxpYW50IjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Byb3h5LWF3YXJlIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Rscy1wcm9maWxlcyI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby90b2tlbi1hdXRoLWF3cyI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby90b2tlbi1hdXRoLWF6dXJlIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Rva2VuLWF1dGgtZ2NwIjoiZmFsc2UiLCJvcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3ZhbGlkLXN1YnNjcmlwdGlvbiI6IltcIlJlZCBIYXQgQ29ubmVjdGl2aXR5IExpbmtcIl0iLCJvcGVyYXRvcnMub3BlcmF0b3JmcmFtZXdvcmsuaW8vYnVpbGRlciI6Im9wZXJhdG9yLXNkay12MS4zMi4wIiwib3BlcmF0b3JzLm9wZXJhdG9yZnJhbWV3b3JrLmlvL3Byb2plY3RfbGF5b3V0IjoiZ28ua3ViZWJ1aWxkZXIuaW8vdjMiLCJyZXBvc2l0b3J5IjoiaHR0cHM6Ly9naXRodWIuY29tL2t1YWRyYW50L2xpbWl0YWRvci1vcGVyYXRvciIsInN1cHBvcnQiOiJrdWFkcmFudCJ9LCJsYWJlbHMiOnsib3BlcmF0b3JmcmFtZXdvcmsuaW8vb3MubGludXgiOiJzdXBwb3J0ZWQifSwibmFtZSI6ImxpbWl0YWRvci1vcGVyYXRvci52MS4xLjEiLCJuYW1lc3BhY2UiOiJwbGFjZWhvbGRlciJ9LCJzcGVjIjp7ImFwaXNlcnZpY2VkZWZpbml0aW9ucyI6e30sImN1c3RvbXJlc291cmNlZGVmaW5pdGlvbnMiOnsib3duZWQiOlt7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yIGlzIHRoZSBTY2hlbWEgZm9yIHRoZSBsaW1pdGFkb3JzIEFQSSIsImRpc3BsYXlOYW1lIjoiTGltaXRhZG9yIiwia2luZCI6IkxpbWl0YWRvciIsIm5hbWUiOiJsaW1pdGFkb3JzLmxpbWl0YWRvci5rdWFkcmFudC5pbyIsInZlcnNpb24iOiJ2MWFscGhhMSJ9XX0sImRlc2NyaXB0aW9uIjoiVGhlIExpbWl0YWRvciBvcGVyYXRvciBpbnN0YWxscyBhbmQgbWFpbnRhaW5zIGxpbWl0YWRvciBpbnN0YW5jZXMiLCJkaXNwbGF5TmFtZSI6IkxpbWl0YWRvciIsImljb24iOlt7ImJhc2U2NGRhdGEiOiJpVkJPUncwS0dnb0FBQUFOU1VoRVVnQUFBWHdBQUFGOENBWUFBQURNNXdES0FBQUFDWEJJV1hNQUFHNjZBQUJ1dWdIVzNyRVhBQUFnQUVsRVFWUjRuTzNkZjJ6VDE3My84VGNRbDhRRTI4T0FETVVrc0lrb0lWbmNhRlNEUmpmNWE1cGEzWkpxZjFTcjdsZGswdjRvdXQ4Sjc0K3BXeldKSU8xMlEvc25hSnJhUHlZVmRMOXF0VCttaG43VmFkby9KVmZRVG1OcUhTV0FFcTJRa0FJV0VHb2JFNXZhbFB1SEU2QWRGSC9PT1o5Zi9qd2ZValhwWG81OVZLa3ZIODU1bi9kWmNmZnVYUUVBTkw2VmJrOEFBT0FNQWg4QUFvTEFCNENBSVBBQklDQUlmQUFJQ0FJZkFBS0N3QWVBZ0NEd0FTQWdDSHdBQ0lnbXR5ZlFxTHE2dXZwWHJWcjFuVkFvTkxCeTVjcHZORGMzZDZ4YXRhcFpSQ1FhamNiY25oL2d0bncrbnhNUnVYUG5UcmxjTGs5LzhjVVhuMVVxbGZFN2QrNzg0K3pac3lmZG5sOGpXa0ZyQlgwOVBUM3BWYXRXZmIrbHBlVmJMUzB0bTF0YlcxdmNuaFBnZDhWaXNWUXFsUzdmdm4xN3NsS3BqRTlPVG82NlBTZS9JL0F0NnV6c2JIdmlpU2RlWHIxNjlmZGJXMXM3Q0hmQU9jVmlzVlFzRnFkdjM3NzlsODgvLy95TmMrZk96Yms5Sno4aDhPdlEzZDM5WW5OejgvNUlKUEkwQVE5NFI3RllMQlVLaGIrWHkrWFhwNmFtL3VqMmZMeU93SCtFN3U3dUY4UGg4TTlqc1ZoM2MzTXpaeDJBeDVYTDVXb3VsNXRhWEZ6OERlSC9jQVQrQTdxNnV2ckQ0ZkN2MXExYjl3d2hEL2hYdVZ5dTNyaHg0OVRpNHVJdk9RQytqOEFYa1ZRcTlZZG9OUG9EcW1lQXhwUFA1M1A1ZlA1UG1Vem14MjdQeFcyQkRmek96czYyTld2V0hHTTFEd1REOHFyLzFxMWIrNEo2MkJ1NHdPL3E2dXB2YlczOTNmcjE2M3VibXBwV3VEMGZBTTZxVnF0M3IxKy9QbEVzRm44U3RPMmV3QVIrVjFkWGZ6UWFQYnBodzRadnVqMFhBTjV3N2RxMVQvTDUvSEJRZ3IvaEEzOTU2MmJ6NXMwRGJzOEZnRGRkdm54NVBBaGJQUTBkK0gxOWZlOGtFb205Yk4wQWVKeHF0WG8zbTgwZS8raWpqMTV3ZXk1MmFjakE3K25wU1cvYXRPbTNYajJNclZRcVVpZ1VIdnIvVzFoWWNIZzJnSDNpOGZoRC8rK1JTRVJDb1pERHM2bFB1Vnl1WHJseTVXZU4yTXFob1FLL3M3T3pMUjZQLzIzZHVuVUp0K2RTS0JSa2NYRlJDb1dDNVBQNWV5RmZxVlRjbmhyZ0dhRlE2Rjc0UjZOUmlVUWlFZzZISlJLSnVEMDF1WEhqUm5aaFllRzdqYlROMHpDQjcrYjJUYWxVa3V2WHI5OExkMWJwZ0w1NFBIN3ZSMkQ5K3ZYUzB1SjhWNU5HMitieGZlQjNkbmEyYmR5NE1lUDBwYWxzTmlzTEN3dVN6V1psY1hIUnlhOEdBaWtjRGtzaWtaQjRQQzZKaExOL2ljL244N21yVjYrbS9MN2E5M1hnOS9iMi92ckpKNTk4eFlsVmZhVlNrV3cyZSs4ZkFPNUtKQkwzL25IaVBLQmFyZDY5ZE9uUzRZbUppVi9ZL21VMjhXWGdkM1oydHExZHUzWXNrVWlrN1A2dTVZQ2ZuNSszKzZzQUtFb21rL2ZDMzI3WmJEWno4K2JOSVQrdTluMFgrRjFkWGYySlJPS3ZkcllwcmxRcWN1SENCWm1mbjJlN0J2Q1JjRGdzeVdSU3RtM2JadXVxdjFnc2xyTFo3UGY4ZG1ITFY0RnY5eFpPcVZTUzZlbHBWdk5BQTBnbWs5TFIwV0hiWWE4ZnQzaDhFL2g5ZlgzdmJObXlaY2lPejE1WVdKRHo1OCt6Tnc4MG9FUWlJZHUzYjMva25RQmRuMzc2NlpoZnFuaDhFZmk3ZCsvK3B4MDljRXFsa256ODhjZVVVUUlCRUkvSDVhbW5uckpseFgvdDJyVlBQdnp3dzI4Wi8yRERQQjM0ZHBWY1Zpb1ZPWFBtREZzM1FBQWxrMG5adVhPbjhUMStQNVJ1ZWpid096czcyelp0Mm5UTzlPSHN6TXlNbkQ5L25odXZRSUNGUWlIWnZuMjc3Tml4dytqbkZvdkYwcFVyVnpxOUd2cWVEUHlubjM3NjI2MnRyWDh6R2ZZTEN3c3lOVFgxeUI0MkFJSW5Fb2xJZDNlMzBmMTlMNGUrNXdLL3U3djd4YTFidDc1dHFoS25VcW5jVzlVRHdNTXNyL1pOYmZOVXE5VzdGeTllL0tIWEhsUDNWT0NiRHZ0Q29TQ25UNSttbGg3QVk0WERZZG0xYTVleHhtMWVESDNQQlA2V0xWdSsvZTF2Znp0akt1eG5abVprZW5yYXhFY0JDSkNPamc1amUvdlZhdlh1aFFzWHRubGxlOGNUZ1cveWdMWlNxY2pwMDZjcHRRU2dMQjZQeTY1ZHU0eHM4WGhwVDkvMXdEY1o5b1ZDUVQ3NDRBTXFjQUJvQzRWQ3NtZlBIaU5iUEY0Si9aVnVmcm1JeU1hTkd6TW13bjUrZmw3R3g4Y0pld0JHVkNvVkdSOGZOM0pmcDdXMXRXWGp4bzBaQTlQUzRtcmc3OTY5KzU4bUxsWE56TXhJSnVQNnYwc0FEU2lUeWNqTXpJejI1MFNqMGRqdTNidi9hV0JLeWx3TC9MNit2bmRNdEV2SVpESWN6Z0t3MWZUMHRKRkY1WVlORzc3WjE5ZjNqb0VwS1hFbDhIdDdlMyt0MndpdFVxbElKcE9oUFFJQVI4elB6MHNtazlIZU50NnlaY3RRYjIvdnJ3MU55eExIRDIyN3VycjYyOXZiLzBlbi9MSlNxY2dISDN6QXJWa0Fqb3RFSXJKbnp4NnRDcDVxdFhwM2RuYjIzNXp1cCsvb0NyK3pzN010a1VqOGxiQUg0RmNtcWdHYm1wcFdKQktKdjNaMmRyWVpuTnBqT1JyNGE5ZXVIZE9weUNIc0FYaUJpZEJ2YlcxdFdidDI3WmpCYVQyV1k0SGYyOXY3YTkwM2FNK2NPVVBZQS9DRVFxRWdaODZjMGZxTVJDS1JjbkkvMzVFOS9NN096clp0MjdaZDBObks0WUFXZ0JjbGswbEpwZFRYc2s2MlgzQmtoYjl4NDBhdEhqa3pNek9FUFFCUG1wK2YxNnJUYjJwcVd1SFVwU3piQTcrdnIrOGRuY3RWOC9QejFOa0Q4TFRwNldtdFJXazBHbzA1VVo5dmErQXZWZVhzVlIxZktCUzRRUXZBRnpLWmpOWVpZeUtSMkd0MzFZNnRnUitQeC8rbXVwV3pYSkVEQUg2aFU3blQxTlMwSWg2UC84M3dsTDdFdHNEdjZlbEpyMXUzTHFFNi92VHAwelJDQStBcnkrM1pWYTFidHk3UjA5T1ROamlsTDdFdDhEZHQydlJiMWJFek16UDBzd2ZnU3dzTEMxcUh1RHJaK1RpMkJINWZYOTg3emMzTlRTcGpDNFVDaDdRQWZHMTZlbHA1UDcrNXVibkpyZ05jNDRHdmMxQ3IrOWNoQVBBS25XMXB1dzV3alFmK21qVnJqcWtlMU03TXpQRGdPSUNHc0xpNHFMeTEwOVRVdEdMTm1qWEhERS9KYk9CM2RYWDFiOTY4ZVVCbDdNTENncHcvZjk3a2RBREFWZWZQbjFjK2o5eThlZk5BVjFkWHY4bjVHQTM4YURSNlZIWHMxTlNVd1prQWdEZm9aSnRPcGo2TXNjRHY2dXJxVjMzQmFtWm1ocVpvQUJwU29WQlEzdHJac0dIRE4wMnU4bzBGZm10cjYrOVV4bFVxRmJaeUFEUzA4K2ZQS3gvZ3FtYnJ3eGdKL003T3pyYjE2OWYzcW93OWMrWU1GNndBTkxSS3BhTGNTbm45K3ZXOXBpcDJqQVMrYW1WT3FWU2lDeWFBUUppZm41ZFNxV1I1bk1tS0hTT0J2MjdkdW1kVXhuMzg4Y2Ntdmg0QWZFRTE4MVF6OXF1MEF6K1ZTdjFCNVZidHdzSUM3Uk1BQklwcTdqVTNOemVsVXFrLzZINi9kdUJIbzlFZnFJempvQlpBRUtsbW4ycldQa2dyOEx1NnV2cFZIamNwbFVxU3pXWjF2aG9BZkNtYnpTcnQ1VWVqMFpodWlhWlc0SWZENFYrcGpLTTVHb0FnVTgxQTFjeGRwaFg0S2djSmxVcUZ5aHdBZ1RZL1A2OVVqcTU3ZUtzYytOM2QzUytxSE5aZXVIQkI5U3NCb0dHb1pHRnpjM05UZDNmM2k2cmZxUno0NFhENDV5cmpXTjBEZ0hvV3FtYXZpRWJneDJLeGJxdGpzdGtzN1k4QlFHcnRrMVdLVjFTeWQ1bFM0S3R1NTFDWkF3RDNxV1NpenJhT1V1QTNOemZ2dHpxR3cxb0ErRExWdzF1VkRCWlJEUHhJSlBLMDFUR3M3Z0hnWDZsa28wb0dpeWdFZm1kbloxdHJhMnVMMVhFRVBnRDhLNVZzYkcxdGJWSHBvR2s1OEo5NDRvbVhyWTRSSWZBQjRHRlVzMUVsaXkwSC91clZxNzl2ZFF4aER3Q1BwcEtSS2xsc09mQmJXMXM3ckk2aEt5WUFQSnBLUnFwa3NVcmdzMzhQQUFhcDd1TmJIV01wOEh0NmV0Sld2NkJVS25IWkNnQyt4dUxpb2xJSFRhdVpiQ253VzFwYUxPOFpYYjkrM2VvUUFBZ2NsYXdNaFVJRFZ2NjhwY0JmdFdyVnQ2eE5SNlJRS0ZnZEFnQ0JvNUtWcTFldjdySHk1NjJ1OERkYm00NUlQcCszT2dRQUFrY2xLNjFtc3FYQVZ6a2tvRUlIQUI1UHNWTEhVaWJYSGZncVQydXhuUU1BOVZQSlRDdlpYSGZncjFxMTZqdFdKMEoxRGdEVVR5VXpyV1J6M1lGdjlUUlloQlUrQUZpaGtwbFdzcm51d0YrNWN1VTNyRTZFQTFzQXFKOUtabHJKNXJvRHY3bTUyZkkxWHBVK3p3QVFWSXE5OGV2T1ppdDcrTTFXSjhLV0RnRFVUeVV6cldTejhwdTI5V0NGRHdEMXN6c3o2dzc4YURRYXMvTEJoRDBBV0djMU82MWtzMjByZkxaekFNQTZPN1BUMWkwZEFJQjNFUGdBRUJBRVBnQUVCSUVQQUFGUlYrQS8vL3p6N1ZZL21Db2RBSERHaWhVcjJ1djVjM1VGL3J2dnZqdHJkUUpVNlFDQWRTcnRGZTdldlR0Yno1OWpTd2NBUEtSYXJkcjIyUVErQUFRRWdROEFBVUhnQTBCQUVQZ0FFQkFFUGdBRUJJRVBBQUZCNEFOQVFCRDRBQkFRQkQ0QUJBU0JEd0FCUWVBRFFFQVErQUFRRUFRK0FBUUVnUThBQVVIZ0EwQkFFUGdBRUJBRVBnQUVCSUVQQUFGQjRBTkFRQkQ0QUJBUUJENEFCRVNUMnhPQW5sZ3NKcWxVeXUxcGFEdHg0b1NyMzk4aklsRlhaK0I5a3lLU2Qzc1MwRUxnKzFRc0ZwUFIwVkhadDIrZjIxTXhZbTV1VGtaR1J1VG8wYU9PZnU5ekl2S2FpQ1FkL1ZiL2VsdEVYaFdDMzYvWTB2R2hXQ3dtSjA2Y2FKaXdGeEZwYTJ1VE45OTgwOUhBZjBWRS9sc0lleXQrS0NML1gvamJrRjhSK0Q0ME5qWW12YjI5YmsvREZ2djI3Wk9ob1NIYnYrYzVxUVUrck9zV2tmL245aVNnaE1EM21hR2hJUmtZR0hCN0dyWWFIUjIxL1R0ZXMvMGJHdHN6VXZ2UmhMOFErRDZ5dkcvZjZOcmEybVJ3Y05DMnozOUYyTVl4Z1I5Ti95SHdmU1NkVGt0Ylc1dmIwL0MxcUlqc2Qzc1NEU0lwYkl2NURZSHZFKzN0N1pKT3A5MmVodSs5SmlJUnR5ZlJRUGFMeUZhM0o0RzZFZmcrTVRJeUl0RW90UkU2K3FWV1pRSnpJc0lxMzA4SWZCOFlIQnhzcUJMTXg1bWJtN1BsSWhiQlpJOGZTdTNIRk41SDRQdkF5TWlJMjFOd2xCMWJWeTlKcmJJRTl1REgxQjhJZkk4YkhoNXUrRExNQngwN2Rrekd4c2FNZm1aVUNDUzdQU08xSDFWNEc0SHZZVUVwd3hTcGJlTzg4TUlMTWp3OGJQeXpYeGJLTUozd21uQUQxK3ZvcGVOaDZYUmErYUQyUnovNmtjek96cHFka0kzc2FwNjJWZFRMTUUrSnlHR0RjL0dMSGhINUw0VnhFYW45dUFieDM1bGZFUGdlMWQ3ZUxnY1BIbFFhT3o0KzduZ1RNcS9TS2NOOFZXb2RJb1BtcElnOEsycG5IcTlJcmNIYVJhTXpnaWxzNlhpVXpsYU9IZHNpZnRRdnRlQlM4WVlFTSt5WC9hZkdXRzdnZWhlQjcwR0RnNE95ZCs5ZXBiRkhqaHp4MVZhT25WU0RweUJzUzF5VTJvK2VpbWVGTWsydkl2QTlTSFYxbjgvbkExZkMrU2d2U2Eycm80ckRRcjkza2RxL2g0TGlXRmI1M2tUZ2UwdzZuVlp1ZlR3eU1pSzVYTTd3alB3bkt1cUJNeThpcnh1Y2k1L2xSZjF2T3QxQ3p5SXZJdkE5SkJhTEthL1FKeVltQWxQQytUaXZpUHBCcmM3ZWRTTjZYVVNtRk1lK0lwUnBlZzJCN3lFNi9YSm9yRmF6VldxbGdTcE9TYTFDQlYvMnF1STQrdXg0RDRIdkVlM3Q3WExnd0FHbHNjZVBIM2Y5RVhDditMM0dXRmIzRDNkU1JQNnNPUFpsb1p1bWx4RDRIcUZUTjgvcXZxWmYxUHZsSEJacXg3K082aXBmUk85SEdHWVIrQjZnODJ6aG9VT0hLTU5jb2hvc0JWRXZRUXlLaTZKK2dQdU1VS2JwRlFTK0IraVVZWEpRVzdOZjFQdmx2Q3FVWWRiakRWRXYwMlNWN3cwRXZzdEdSa2FVbnkxTXA5T1VZWXBlTjh3cEVYbkw0RndhV1Y3VXQzWjREdEViQ0h3WHhXSXg1ZjEzK3VYY3A5c3ZCL1Y3UzJyVlRDcjJDMldhYmlQd1hUUTZPcXBjaHNtTjJwb2VVWCsyOEcyaERGT0Y2bDUrUkxpQjZ6WUMzeVdwVkVyNTJjSmp4NDVSaHJtRWZqbk9PeW0xSDBzVlA1VGFqelRjUWVDN2hINDUrcDRUOVRMTTE0VXlUQjMwMmZFbkF0OEZPczhXam82T1VvYTVSS2RmRG1XWWVpNktlcytoWjZUMll3M25FZmdPMCttWE16YzN4K3AreVN1aVhvWkpOMHd6M3BEYWo2Y0tua04wQjRIdnNIUTZyVldHQ2YxbkN5bkRORU8zVEZPMTV4SFVFZmdPYW05djF5ckRIQnNiTXp3amY5THBoa2tacGxudmlWNlpKbjEybkVYZ080aHVtUHI2UmE4TU04alBGdHFGYnByK1FlQTdaSEJ3VUtzTU01UEpHSjZSUDZrR1JFRlkzZHRsVXZUS05PbXo0eHdDM3lFNlpaaXM3bXRlRXIweVRBNXE3Zk9xVUticEJ3UytBNGFIaDNtMlVKUHVzNFZjc3JKWFh0VExOTHVsOW1NTyt4SDROb3ZGWXNxcis3bTVPYnBoTG5sWk9LajF1c05DbWFiWEVmZzJTNmZUeWdlMXc4UERaaWZqVTF0RmZlLytsTlFxU2VBTTFWZkRJa0tacGhNSWZCdTF0N2ZMd1lNSGxjYU9qNC9UTDJlSnpoNHZ6eFk2NjZTb2wybStJcFJwMm8zQXQ1SE9kZ3lyKzVwK0VYbFdjZXdiUXI4Y04rajh5SEtBYXk4QzN5YURnNE95ZCs5ZXBiRkhqaHloWDg0U3VtSDZ6MFZSNzFYMHJGQ21hU2NDM3lhcWo1UFFEZk8rL1ZLcjRGQkJ2eHgzNlhUVDVEbEUreEQ0TnREdGwwTVpwdDZ6aGZPaVhpSUlNM1Q3N0tqMlNzTFhJL0FOMCttR09URXh3Yk9GUzNUNjVYQlE2dzF2U2UzTllCV3ZDR1dhZGlEd0RhTmZqcjZ0b2w2aTkyZmgyVUl2b2MrT3R4RDRCcVZTS1RsdzRJRFMyT1BIajFPR3VVUm5ENWRMVnQ1eVVtby93aXBlRnNvMFRTUHdEZElwdzJSMVg5TXY2djF5RGd0bG1GNms4eVBNQWE1WkJMNGhRME5EeXM4V0hqcDBpRExNSmFyL2dSZUVad3U5NnFLb2w4anlIS0paQkw0aDlNdlJwL05zNGF0Q0dhYVg2VDZIQ0RNSWZBTkdSa2FVeXpEcGhsa1RGWjR0YkdSNVVWL2xKNFVEWEZNSWZFMnhXRXpyMlVMS01HdGVFL1V5VEc3VStzTmJvdmNjSW1XYStnaDhUYU9qbzhwbG1OeW9yZWtSdldjTEtjUDBEOVVmNTRpd3RXTUNnYTlCOTlsQ3lqQnI2SmNUSENkRjd6bkVIb056Q1NJQ1g0UHFDcDErT2ZjOUozclBGbEtHNlQ4NmZYWlk1ZXNoOEJVTkR3OHJsMkdPam81U2hpbjZ6eFpTaHVsUEYwVzkxOUV6d25PSU9naDhCVHI5Y3VibTVsamRMM2xaS01NTUtwM25FT216bzQ3QVY2RGJEUk8xSy9NNlpaZzhXK2gvT3QwMGVRNVJEWUZ2VVh0N3UxWVo1dGpZbU9FWitaTk9OMHo2NVRTRzkwU3ZUSk0rTzlZUitCYnBsR0d5dXEvcEY3MHl6RW1EYzdGYkxCYVR3Y0ZCR1JrWmtjSEJRV2x2YjNkN1NwNmkwMDJUQTF6ckNId0xkSjh0ekdReWhtZmtUenBsbUg1WjNjZGlNVGw2OUtoODl0bG44djc3Nzh2Qmd3ZmwvZmZmbHdzWExzaUpFeWNJL2lXVHduT0lUaUx3TFZEdGVVTVo1bjB2aWZxemhhK0xQdzVxMjl2YlpYWjI5cEYzTkFZR0JpU1R5VWdxbFhKNFp0NUVtYVp6Q1B3NkRROFBTMjl2cjlKWSt1WFU2SlpoK3VXUzFkalkyR08zL2FMUnFJeU5qVWtzRm5Ob1Z0NmwwMmVuV3lqVHRJTEFyNU5PR1NiZE1HdGVrc1ovdHRES3dxQ3RyVTJHaDRmdG5aQlB2QzU2Wlpxb0Q0RmZoOEhCUWVVeVRQNkR2dTlaeFhHbnhCLzljbUt4bU9VZjk2R2hJWnRtNHorcVArcEpZUysvWGdTK2pjYkh4K21YOHdEVkZncCtXZDJydkdlc2VsdTdFWjBVOVRKTkxtTFZoOENIcDcwaC91aVgwOTdlcnZ5ZU1lQVVBcjhPcWdldUF3TURNamc0YUhZeVBtWjE5ZWFuYnBpcTd4cU1qNCtibllpUDZieG43SWRGZ1JjUStIWElaREl5Tnplbk5KWUhUdTc3czhVL2YxajhVWVk1T0Rpb3ZEWER6ZXY3Vk44em5oZC9YY1p6RTRGZko5VXFuYmEyTm03WUxubEw2cS9FbUJMMWpvcE9VLzFSeitmekxBaVc3QmYxUm5wKytWdWdGeEQ0ZFRwNjlLaE1URXdvalIwWkdhSGVXbXFyOWYrUXgxK3lLU3o5T1QvUWJhVEgvWXphZ2F0cWFlV1U4SjZ4RlFTK0Jhb3I5V2cweWszYkpaTWk4bS95NlAzOHQwV2tWL3l4SjZ2VEpwdjNqTytqa1o1ekNId0xUcHc0SWNlUEgxY2FlK0RBQWE3U0w3a29Jdjh1SWlrUmVWNUUvdS9TLzI2VFdnbW1IL2J0UlhqUDJJUWVVVzkxL0dmeHgvME1MeUh3TFVxbjA1TFBxMFVTTjI2LzdLTFUvb045YStsLy9STDBJaUtwVklyM2pBMElRaU05THlId0xacWRuVlVPN29HQkFXNVdOZ2dhNmVualBXUG5FZmdLUmtkSGxjczBXZVg3MzlEUUVPOFpHOEI3eHM0ajhCWGtjam10TWsxV2VQNmwwaTluR1kzMDdudEY5TW93L2JUOTV5VUV2cUtqUjQ4cTM1Sk1wOU04Z09GVGxHSHEwMzNQbURKTWRRUytCdFdWT21XYS9zUjd4bVpRaHVrZUFsL0RpUk1uNU5peFkwcGo5KzNiUjU4ZG4xSHBocm1NMjlZMVFYclAySXNJZkUwNlpacXM4djFqY0hCUXF3eVQ5NHhyVkcvVVVvWnBCb0d2S1pmTGFaVnA4a0NLUDZqK09PZnplVmIzUzE0U3ZUSk1EbXIxRWZnR2pJeU1LSmRwMG1mSCs0YUhoN1hLTURtbzFldVg0NmYzakwyT3dEZEVkUlZITjAxdjB5M0RaTnV1NW1WUkw4TmtLOGNjQXQrUXNiRXg1VExOZ3djUFVxYnBVZWwwV3ZtZ2x1MjZtcTJpdnJvL0pTTHZHWnhMMEJINEJ1bXMxTG1RNHozdDdlMXk4T0JCcGJHOFozeWY2bzFhRWYrOFord1hCTDVCbVV4R2podzVvalIyNzk2OWxHbDZqTTZQTUt2N21uNFJlVlp4ckYvZU0vWVRBdCt3a1pFUnVtazJnTUhCUWRtN2Q2L1MyQ05IanRBdlo0bE9OMHdPYXMwajhBM1Q2YlBUMjl2THl0QWo2SWFwN3lVUjZWWWNTNzhjZXhENE50RHRwa21acHJ2UzZiVDA5dllxajZVTXMxYUdxZE1OMHkvdkdmc05nVzhUMVpVNmZYYmNwZk5zNGNURUJNOFdMdEhwbDhOQnJYMElmSnZvUG9kSW1hWTc2SmVqYjZ2d2JLRlhFZmcyMGdrQVZvck9hMjl2bHdNSERpaU5QWDc4T0dXWVMzNnZNWlpMVnZZaThHMDBPenNyaHc0ZFVobzdNREJBbWFiRGRINWtXZDNYOUl0NnY1ekRRaG1tM1FoOG00Mk9qaXFYYWJMS2Q0N09zNFdIRGgyaURIT0o2dXErSUR4YjZBUUMzMmE1WEk0K096N0FzNFg2OW90ZXZ4ektNTzFINER2ZzZOR2pNakV4b1RTV2JwcjJHeGtaVVg2MmNHUmtoREpNMGV1R09TVThXK2dVQXQ4aHFpdjFhRFRLQ3RKR3NWaE02OWxDdHQxcVhoT2VMZlFEQXQ4aHVzOGhwbElwd3pPQ1NHMHJSN1VNay9zU05UMmk5MndoWlpqT0lmQWRSSjhkYjBtbFVsclBGbEtHV1VPL0hQOGc4QjAwT3p1cjlSemkwTkNRNFJrRkcvMXk5RDBuZXM4V1VvYnBMQUxmWWJwOWRtQ0c3ck9GbEdIcTk4dWhETk41Qkw3RGRMcHB0clcxc2JJMFFLZGZEczhXM3FmN2JDRmxtTTRqOEYxdzlPaFI1ZWNRMCtrMGZYWTBwZE5wNVRKTTdrWFViSlZhM2IwS25pMTBENEh2RXAweVRWYVk2dHJiMjdYS01NZkd4Z3pQeUo5MHVtRlNodWtlQXQ4bG1VeEdxMHlUUGp0cTZJYXByMS8weWpBbkRjNEYxaEQ0TGtxbjA4cGxtcXp5clJzY0hOUXF3OHhrTW9abjVFK3FOMm9Md3VyZWJRUytpM0s1bkZhWkpzOGhXcU5UaHNucXZ1WWwwU3ZENUtEV1hRUyt5MFpHUm5nTzBRSER3OFBLenhiU0w2ZEd0d3lUUzFidUkvQTlRT2NBbDVYbjQ4VmlNYnBoR3ZDeThHeWgzeEg0SGpBMk5xWmNwbm53NEVIS05COGpuVTRySDlTeWJWYXpWZFQzN2s4Si9YSzhnc0QzQ0oxZ1lRWDZhTzN0N1hMdzRFR2xzZVBqNC9UTFdhSzZsU1BDNnQ1TENIeVBtSjJkbFNOSGppaU4zYnQzTDJXYWo2RFR2cGpWZlUyL2lEeXJPUFlOb1YrT2x4RDRIa0kzVGJNR0J3ZDV0dEFBdW1FMkRnTGZRM1Q2N1BUMjluS0EreFdxcS90OFBzOFA2Skw5SXRLdE9QYXdVSWJwTlFTK3g0eU9qdkljb2dHNi9YSW93OVIvdHZCMWczT0JHUVMrQjlGblI0OU9OOHlKaVFtZUxWeEN2NXpHUStCNzBJa1RKK1Q0OGVOS1l3OGNPQkQ0TWszNjVlamJLclc2ZXhWL0Zzb3d2WXJBOXlpZDRBbnlDaldWU3NtQkF3ZVV4aDQvZnB3eXpDVy8xeGpMNnQ2N210eWVBQjV1ZG5aV0RoMDZwRlJEdnR4bko0aFZKcXBiT1hiM3krbTM3WlBONnhIMWZqbUhoVEpNTHlQd1BXeDBkRlQ1bHVpYmI3NXB3NHdhbDEzUEZqNG50YkpHMVplaC9LUWdQRnZvZFd6cGVGZ3VsMk5QMlFGMjljdjV2WWo4dHdRajdFVjR0dEFQQ0h5UDAza09FZld4b3h2bWM2TCtTSWdmblJLUnQ5eWVCQjZMd1BjQlNpM3RNejQrYnNzaHQwN3ZHVC9pUnEwL0VQZytjT0xFQ2VYbkVQSDE3UGd4N1pmZ2JPT0kxSjR0cEF6VEh3aDhuOURwczRPSE8zYnNHR1dZbXVpWDR5OEV2ay9NenM3UzM4VWduaTAwNDNXaEROTlBDSHdmR1IwZFZYNE9FVjgyT2pwS3Z4eE5QRnZvUHdTK2oxQ21hY2JjM0p5dEIrRW5wUmFHalk0YnRmNUQ0UHVNem5PSXFISGlSN1BSdy9DVWlMem45aVJnR1lIdlEwTkRROG90bElQdXB6LzlxWXlOamRuK1BlOUpyWHFsRVUySnlIKzRQUWtvSWZCOUtKZkx5ZURnb1BLVGlFRTBOemNuTDd6d2dxTUgzLzhwSXY5SEdtdDc1MjBSK1hmaFJxMWYwVXZIcDViMzgwZEdSaVNWU3JrOUhVL0w1WEtTeVdSYytlNzNsdjdwa2RxREluNDJLUVM5M3hINFBwZkw1YWdsOTRGSnR5Y0FDRnM2QUJBWUJENEFCQVNCRHdBQlFlQURRRUFRK0FBUUVBUStBQVFFZ1E4QUFVSGdBMEJBRVBnQUVCQUVQZ0FFQklFUEFBRkI0QU5BUUJENEFCQVFCRDRBQkFTQkR3QUJRZUFEUUVBUStBQVFFQVErQUFRRWdROEFBVUhnQTBCQUVQZ0FFQkFFUGdBRWhHMkJINGxFN1Bwb0FHaFk4WGpjOHBqbm4zKyt2WjQvWjF2Z2gwSWh1ejRhQVBDQWQ5OTlkN2FlUDhlV0RnQUVCSUVQQUFGQjRBTkFRQkQ0QUJBUVZPa0FnSWZZbVoxMUIzNCtuODlaK1dDcWRBREFPcXZaYVNXYmJkM1NJZlFCb0g1MloyYmRnWC9uenAyeTFROW5Xd2NBNnFlU21WYXl1ZTdBTDVmTDAxWW53Z29mQU9xbmtwbFdzcm51d1AvaWl5OCtzenFSYURScWRRZ0FCSlpLWmxySjVyb0R2MUtwakZ1ZENGczZBRkEvbGN5MGtzMVc5dkQvWVhVaTRYRFk2aEFBQ0N5VnpMU1N6WFVIL3RtelowOWFuUWdyZkFDb24wcG1Xc2xtUzJXWnhXS3haSFV5S3EwK0FTQm9WTExTYWlaYkN2eFNxWFRaMm5RNHVBV0FlcWhrcGRWTXRocjQvN1EySGJaMUFLQWVLbGw1Ky9idFNTdC8zbExnMzdsejV5L1dwaU95ZnYxNnEwTUFJSEJVc3RKcTlhU2x3SitjbkJ5MU5oMlJscFlXcW5VQTRHdUV3MkZwYVdteFBNNXFKbHZ1cGFOeWNKdElKS3dPQVlEQVVNbElsU3hXQ1h6TExSYW8xQUdBUjFPczBMR2N4WllELy9idDI1YjM4Vm5oQThDanFXU2tTaFpiRHZ6UFAvLzhEYXRqUkFoOUFIZ1kxV3hVeVdMTGdYL3UzTGs1OXZFQndBelYvZnR6NTg3TldSMm45QUJLb1ZENHU5VXhCRDRBL0N1VmJGVEpZQkhGd0MrWHk2OWJIUk1LaFNTWlRLcDhIUUEwcEdReXFkb0QzM0lHaXlnRy90VFUxQi9MNVhMVjZqaFcrUUJ3bjBvbWxzdmw2dFRVMUI5VnZrLzVUZHRjTGpkbGRVd2lrZUFTRmdCSTdiS1ZTdUNyWk84eTVjQmZYRno4amNvNHRuVUFRRDBMVmJOWFJDUHdWYmQxdG0zYnB2cVZBTkF3VkxKUVp6dEhSQ1B3UlVSdTNMaHh5dW9ZRG04QkJKM3FZYTFLNWo1SUsvQVhGeGQvcVRLdW82TkQ1MnNCd05kVU0xQTFjNWRwQmY3WnMyZFA1dlA1bk5WeExTMHRWT3dBQ0tSRUlxSFVHVE9meitkVW5wcDlrRmJnTDAzaVR5cmp0bS9mcnZ2VkFPQTdxdG1ubXJVUDBnNzhUQ2J6WTVYRDIzZzhUaGROQUlHaW1udmxjcm1heVdSK3JQdjkyb0V2b242UThOUlRUNW40ZWdEd0JkWE0wejJzWFdZazhHL2R1cld2V3EzZXRUcXVwYVdGaWgwQWdaQk1KcFgyN3F2VjZ0MWJ0Mjd0TXpFSEk0Ri83dHk1dWV2WHIwK29qTjI1YzZkU2VSSUErRVVvRkpLZE8zY3FqYjErL2ZxRVNtZk1oekVTK0NJaXhXTHhKeXJqUXFFUUI3Z0FHdHIyN2R1VkY3YXEyZEw3SzFRQUFBZ0dTVVJCVlBvd3hnTC83Tm16SjY5ZHUvYUp5dGdkTzNaSUpCSXhOUlVBOEl4SUpDSTdkdXhRR252dDJyVlBkRXN4SDJRczhFVkU4dm44c09yWTd1NXVnek1CQUcvUXlUYWRUSDBZbzRGLzl1elprNWN2WHg1WEdSdVB4OW5hQWRCUXRtL2ZybHgrZnZueTVYR1RxM3NSdzRFdm9sNnhJMUxiMnFGOU1vQkdFQTZIbGJkeVRGYm1QTWg0NEo4N2QyNHVtODBlVnhrYkNvVmsxNjVkcHFjRUFJN2J0V3VYOGtGdE5wczlicW95NTBIR0ExOUU1S09QUG5wQjVmYXRTTzJBZytacUFQeXNvNk5EdVJDbFhDNVhQL3Jvb3hjTVQwbEViQXA4RVpFclY2NzhUSFhzamgwN2FMc0F3SmZpOGJqeVZvNklYblkram0yQlB6azVPWHJqeG8yczZuaWR2dzRCZ0J0MHQ2VnYzTGlSblp5Y0hEVTRwUyt4TGZCRlJCWVdGcjZyZW9BYkNvVmt6NTQ5cHFjRUFMYlpzMmVQOGtLMVdxM2VYVmhZK0s3aEtYMkpyWUd2YzRBclV0dlBUNlZTSnFjRUFMWklwVkphRjBqdE9xaDlrSzJCTDFJN3dGVjVKR1ZaTXBua0VCZUFwM1YwZEdnMWdzem44em03RG1vZlpIdmdpNGhjdlhvMXBicTFJMUk3eEtXckpnQXZTaWFUV29lMDFXcjE3dFdyVngzWnluQWs4TStkT3pkMzZkS2x3enFma1VxbENIMEFucEpNSnJXM25TOWR1blRZN3EyY1pZNEV2b2pJeE1URUw3TFpiRWJuTTNidTNFbVROUUNlRUlsRWxGc2VMOHRtczVtSmlZbGZHSnJTWXprVytDSWlOMi9lSENvV2l5WFY4Y3VWTzRRK0FEZEZJaEd0aWh3UmtXS3hXTHA1OCthUXdXazlscU9CdjFTMTh6MmQvWHhDSDRDYlRJUjl0VnE5bTgxbXYrZlVWczR5UndOZnBOWlJVM2MvZnpuMDJkTUg0S1JrTXFrZDlpSzFmWHZUblREcnNlTHVYZVhGdHBhK3ZyNTN0bXpab3YzWG1Vd21JL1B6OHlhbUJBQ1BaT0tBVmtUazAwOC9IWE9pQlBOaFhBdDhFWkhkdTNmL2M4T0dEZC9VL1p5Wm1SbVpucDQyTVNVQStCY2RIUjFhcFpmTHJsMjc5c21ISDM3NExRTlRVdUpxNEl1SURBd01mQmFOUm1PNm56TS9QeStaakZZUkVBRDhDMU1sNGZsOFBqYytQdjROQTFOUzV2Z2UvbGRkdlhvMXBWTzVzeXlaVE1yQXdBQU4xd0FZRVFxRlpHQmd3RWpZRjR2RmtsT1hxNzZPNnl0OEVaSE96czYyVFpzMm5XdHRiVzNSL2F4S3BTS25UNStXaFlVRkUxTURFRUR4ZU54WXg5NWlzVmk2Y3VWS3A5TVZPUS9qaWNBWHFZWCt0bTNiTGpRMU5hMHc4WG5zNndOUVlXcS9YcVJXZm5uaHdvVnRYZ2g3RVE4RnZvaElkM2YzaTF1M2JuM2JWT2dYQ2dVNWZmcTBMQzR1bXZnNEFBMHNIQTdMcmwyN2pOM3hxVmFyZHk5ZXZQakRxYW1wUHhyNVFBTThGZmdpNWtPL1Vxbkl6TXlNbkQ5LzNzVEhBV2hBMjdkdmx4MDdkaGc3QS9SaTJJdDRNUEJGek83cEwxdFlXSkNwcVNrcEZBcW1QaEtBejBVaUVlbnU3amI2cEtxWDl1eS95cE9CTDJKUDZJdkl2ZFYrcFZJeCtiRUFmQ1FVQ3QxYjFadms1YkFYOFhEZ2k5UkNmK1BHalJrVGRmb1BxbFFxY3ViTUdXN29BZ0dVVENabDU4NmR4a3U0OC9sODd1clZxeW12aHIySXh3Ti9tYWtidVY5VktwWGs0NDgvcG9RVENJQjRQQzVQUGZXVXRMUVkzVFFRRWZkdjBOYkxGNEV2WXE3M3pzTXNMQ3pJK2ZQbkpadk4ydkh4QUZ5VVNDUmsrL2J0UnZmcEgrUm1ieHlyZkJQNElpSzl2YjIvZnZMSkoxOHhWY0h6VmFWU1NhYW5wOW5xQVJyQThudllkcXpvUldxVk9KY3VYVHJzNUFNbXVud1YrQ0lpWFYxZC9ZbEU0cSttRDNNZlZLbFU1TUtGQ3pJL1AwOE5QK0FqNFhCWWtzbWtiTnUyemRZMks4VmlzWlROWnIvblJvdGpIYjRMZkpIYVllN2F0V3ZIRW9tRTdiMHBzdG1zWkxOWlZ2MkFoeVdUU1Vra0VwSklKR3ovcm13Mm03bDU4K2FRbHc5bkg4V1hnYi9NN2kyZUIxVXFsWHZoejE0LzRMN2xnRThrRW80MFRmVGpGczVYK1Ryd1Jld3IzWHljYkRZckN3c0xrczFtMmZZQkhCQU9oeVdSU0VnOEhuZGtKZjhnUDVSYzFzUDNnYitzcjYvdm5VUWlzZGVKMWY1WGxVb2x1WDc5dWhRS0Jjbm44NVI1QWdiRTQzR0pScU1TaVVSay9mcjF0aDIrZnAybHQyZVArNlVLNTNFYUp2QkZhcXY5ZUR6K3QzWHIxam43OC84UWhVSkJGaGNYNy8wSVZDb1ZLUlFLM1BBRkhoQUtoU1FTaVVnb0ZMb1g3dUZ3MkZnRE14MDNidHpJTGl3c2ZOZnZxL29ITlZUZ0wrdnA2VWx2MnJUcHQ4M056VTF1eitWUkh2VzNBUDUyZ0VieXFOcjM1WkQzb25LNVhMMXk1Y3JQSmljblI5MmVpMmtOR2ZqTDNOem1BZUF2amJaOTh6QU5IZmdpdFcyZU5XdldITnU4ZWZPQTIzTUI0RTJYTDE4ZXYzWHIxcjVHMnI1NW1JWVAvR1ZkWFYzOTBXajBxQjA5ZVFENDA3VnIxejdKNS9QRGZydEFwU293Z2Irc3E2dXJ2N1cxOVhmcjE2L3ZaYXNIQ0o1cXRYcjMrdlhyRThWaThTZEJDZnBsZ1F2OFpjdGJQZXZXclh2R3k0ZTdBTXdvbDh2Vkd6ZHVuQXJDMXMyakJEYndINVJLcGY0UWpVWi80UFRsTFFEMnkrZnp1WHcrLzZkTUp2Tmp0K2ZpTmdML0FWMWRYZjNoY1BoWHJQb0JmMXRlelM4dUx2NHlhTnMyWDRmQWY0VHU3dTRYdytId3oyT3hXRGZoRDNoZnVWeXU1bks1cWNYRnhkOTQ3ZkZ3cnlEdzY5RGQzZjFpYzNQei9rZ2s4clNkYlprQldGTXNGa3VGUXVIdjVYTDVkVUwrOFFoOGl6bzdPOXVlZU9LSmwxZXZYdjM5MXRiV0RuNEFBT2NVaThWU3NWaWN2bjM3OWw4Ky8venpONEo2K0txS3dEZWdwNmNuSFFxRkJsYXZYdDNUMHRLeW1SOEJRRit4V0N5VlNxWEx0Mi9mbnF4VUt1T04yT3JBYVFTK1RicTZ1dnBYclZyMW5WQW9OTEJ5NWNwdk5EYzNkNnhhdGFwWlJJUnFJS0JXUFNNaWN1Zk9uWEs1WEo3KzRvc3ZQcXRVS3VOMzd0ejVCd2V0OWlEd0FTQWdWcm85QVFDQU13aDhBQWdJQWg4QUFvTEFCNENBSVBBQklDQUlmQUFJQ0FJZkFBS0N3QWVBZ0NEd0FTQWcvaGZuYUh3a3pmaTdnZ0FBQUFCSlJVNUVya0pnZ2c9PSIsIm1lZGlhdHlwZSI6ImltYWdlL3BuZyJ9XSwiaW5zdGFsbCI6eyJzcGVjIjp7ImNsdXN0ZXJQZXJtaXNzaW9ucyI6W3sicnVsZXMiOlt7ImFwaUdyb3VwcyI6WyIiXSwicmVzb3VyY2VzIjpbImNvbmZpZ21hcHMiLCJwZXJzaXN0ZW50dm9sdW1lY2xhaW1zIiwic2VjcmV0cyIsInNlcnZpY2VzIl0sInZlcmJzIjpbImNyZWF0ZSIsImRlbGV0ZSIsImdldCIsImxpc3QiLCJ1cGRhdGUiLCJ3YXRjaCJdfSx7ImFwaUdyb3VwcyI6WyIiXSwicmVzb3VyY2VzIjpbInBvZHMiXSwidmVyYnMiOlsibGlzdCIsInVwZGF0ZSIsIndhdGNoIl19LHsiYXBpR3JvdXBzIjpbImFwcHMiXSwicmVzb3VyY2VzIjpbImRlcGxveW1lbnRzIl0sInZlcmJzIjpbImNyZWF0ZSIsImRlbGV0ZSIsImdldCIsImxpc3QiLCJ1cGRhdGUiLCJ3YXRjaCJdfSx7ImFwaUdyb3VwcyI6WyJsaW1pdGFkb3Iua3VhZHJhbnQuaW8iXSwicmVzb3VyY2VzIjpbImxpbWl0YWRvcnMiXSwidmVyYnMiOlsiY3JlYXRlIiwiZGVsZXRlIiwiZ2V0IiwibGlzdCIsInBhdGNoIiwidXBkYXRlIiwid2F0Y2giXX0seyJhcGlHcm91cHMiOlsibGltaXRhZG9yLmt1YWRyYW50LmlvIl0sInJlc291cmNlcyI6WyJsaW1pdGFkb3JzL2ZpbmFsaXplcnMiXSwidmVyYnMiOlsidXBkYXRlIl19LHsiYXBpR3JvdXBzIjpbImxpbWl0YWRvci5rdWFkcmFudC5pbyJdLCJyZXNvdXJjZXMiOlsibGltaXRhZG9ycy9zdGF0dXMiXSwidmVyYnMiOlsiZ2V0IiwicGF0Y2giLCJ1cGRhdGUiXX0seyJhcGlHcm91cHMiOlsicG9saWN5Il0sInJlc291cmNlcyI6WyJwb2RkaXNydXB0aW9uYnVkZ2V0cyJdLCJ2ZXJicyI6WyJjcmVhdGUiLCJkZWxldGUiLCJnZXQiLCJsaXN0IiwidXBkYXRlIiwid2F0Y2giXX1dLCJzZXJ2aWNlQWNjb3VudE5hbWUiOiJsaW1pdGFkb3Itb3BlcmF0b3ItY29udHJvbGxlci1tYW5hZ2VyIn1dLCJkZXBsb3ltZW50cyI6W3sibGFiZWwiOnsiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9LCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciIsInNwZWMiOnsicmVwbGljYXMiOjEsInNlbGVjdG9yIjp7Im1hdGNoTGFiZWxzIjp7ImNvbnRyb2wtcGxhbmUiOiJjb250cm9sbGVyLW1hbmFnZXIifX0sInN0cmF0ZWd5Ijp7fSwidGVtcGxhdGUiOnsibWV0YWRhdGEiOnsibGFiZWxzIjp7ImFwcCI6ImxpbWl0YWRvci1vcGVyYXRvciIsImNvbnRyb2wtcGxhbmUiOiJjb250cm9sbGVyLW1hbmFnZXIifX0sInNwZWMiOnsiY29udGFpbmVycyI6W3siYXJncyI6WyItLWxlYWRlci1lbGVjdCJdLCJjb21tYW5kIjpbIi9tYW5hZ2VyIl0sImVudiI6W3sibmFtZSI6IlJFTEFURURfSU1BR0VfTElNSVRBRE9SIiwidmFsdWUiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOUBzaGEyNTY6OTQ3MWFhZGNlMWExN2FhY2IxYmY2NTNiNzVlMGQ3OTI0ZjhmOWUxNDQ5NTQ0NDBlMGQ5YzliZTZmZDQzMmU4YyJ9XSwiaW1hZ2UiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOS1vcGVyYXRvckBzaGEyNTY6YjMxYmEyOTM4MTI3ODhkYzdlMjFjMTQ3MDNhYzYxZmRkNWJmZjAxMDk0OGFkYTMzNzE1NTQ0YmE1MDc4NTFmNyIsImxpdmVuZXNzUHJvYmUiOnsiaHR0cEdldCI6eyJwYXRoIjoiL2hlYWx0aHoiLCJwb3J0Ijo4MDgxfSwiaW5pdGlhbERlbGF5U2Vjb25kcyI6MTUsInBlcmlvZFNlY29uZHMiOjIwfSwibmFtZSI6Im1hbmFnZXIiLCJwb3J0cyI6W3siY29udGFpbmVyUG9ydCI6ODA4MCwibmFtZSI6Im1ldHJpY3MifV0sInJlYWRpbmVzc1Byb2JlIjp7Imh0dHBHZXQiOnsicGF0aCI6Ii9yZWFkeXoiLCJwb3J0Ijo4MDgxfSwiaW5pdGlhbERlbGF5U2Vjb25kcyI6NSwicGVyaW9kU2Vjb25kcyI6MTB9LCJyZXNvdXJjZXMiOnsibGltaXRzIjp7ImNwdSI6IjIwMG0iLCJtZW1vcnkiOiIzMDBNaSJ9LCJyZXF1ZXN0cyI6eyJjcHUiOiIyMDBtIiwibWVtb3J5IjoiMjAwTWkifX0sInNlY3VyaXR5Q29udGV4dCI6eyJhbGxvd1ByaXZpbGVnZUVzY2FsYXRpb24iOmZhbHNlfX1dLCJzZWN1cml0eUNvbnRleHQiOnsicnVuQXNOb25Sb290Ijp0cnVlfSwic2VydmljZUFjY291bnROYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciIsInRlcm1pbmF0aW9uR3JhY2VQZXJpb2RTZWNvbmRzIjoxMH19fX1dLCJwZXJtaXNzaW9ucyI6W3sicnVsZXMiOlt7ImFwaUdyb3VwcyI6WyIiLCJjb29yZGluYXRpb24uazhzLmlvIl0sInJlc291cmNlcyI6WyJjb25maWdtYXBzIiwibGVhc2VzIl0sInZlcmJzIjpbImdldCIsImxpc3QiLCJ3YXRjaCIsImNyZWF0ZSIsInVwZGF0ZSIsInBhdGNoIiwiZGVsZXRlIl19LHsiYXBpR3JvdXBzIjpbIiJdLCJyZXNvdXJjZXMiOlsiZXZlbnRzIl0sInZlcmJzIjpbImNyZWF0ZSIsInBhdGNoIl19XSwic2VydmljZUFjY291bnROYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciJ9XX0sInN0cmF0ZWd5IjoiZGVwbG95bWVudCJ9LCJpbnN0YWxsTW9kZXMiOlt7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJPd25OYW1lc3BhY2UifSx7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJTaW5nbGVOYW1lc3BhY2UifSx7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJNdWx0aU5hbWVzcGFjZSJ9LHsic3VwcG9ydGVkIjp0cnVlLCJ0eXBlIjoiQWxsTmFtZXNwYWNlcyJ9XSwia2V5d29yZHMiOlsiYXBpIiwicmF0ZS1saW1pdCIsImt1YWRyYW50Il0sImxpbmtzIjpbeyJuYW1lIjoiTGltaXRhZG9yIE9wZXJhdG9yIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL0t1YWRyYW50L2xpbWl0YWRvci1vcGVyYXRvciJ9LHsibmFtZSI6Ikt1YWRyYW50IERvY3MiLCJ1cmwiOiJodHRwczovL2t1YWRyYW50LmlvIn1dLCJtYWludGFpbmVycyI6W3siZW1haWwiOiJlYXN0aXpsZUByZWRoYXQuY29tIiwibmFtZSI6IkVndXpraSBBc3RpeiBMZXphdW4ifSx7ImVtYWlsIjoiYXNuYXBzQHJlZGhhdC5jb20iLCJuYW1lIjoiQWxleCBTbmFwcyJ9LHsiZW1haWwiOiJkaWRpZXJAcmVkaGF0LmNvbSIsIm5hbWUiOiJEaWRpZXIgRGkgQ2VzYXJlIn1dLCJtYXR1cml0eSI6ImFscGhhIiwibWluS3ViZVZlcnNpb24iOiIxLjI1LjAiLCJwcm92aWRlciI6eyJuYW1lIjoiUmVkIEhhdCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9LdWFkcmFudC9saW1pdGFkb3Itb3BlcmF0b3IifSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOUBzaGEyNTY6OTQ3MWFhZGNlMWExN2FhY2IxYmY2NTNiNzVlMGQ3OTI0ZjhmOWUxNDQ5NTQ0NDBlMGQ5YzliZTZmZDQzMmU4YyIsIm5hbWUiOiJsaW1pdGFkb3IifV0sInZlcnNpb24iOiIxLjEuMSJ9fQ==
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoicmJhYy5hdXRob3JpemF0aW9uLms4cy5pby92MSIsImtpbmQiOiJDbHVzdGVyUm9sZSIsIm1ldGFkYXRhIjp7ImNyZWF0aW9uVGltZXN0YW1wIjpudWxsLCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLW1ldHJpY3MtcmVhZGVyIn0sInJ1bGVzIjpbeyJub25SZXNvdXJjZVVSTHMiOlsiL21ldHJpY3MiXSwidmVyYnMiOlsiZ2V0Il19XX0=
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoidjEiLCJkYXRhIjp7ImNvbnRyb2xsZXJfbWFuYWdlcl9jb25maWcueWFtbCI6ImFwaVZlcnNpb246IGNvbnRyb2xsZXItcnVudGltZS5zaWdzLms4cy5pby92MWFscGhhMVxua2luZDogQ29udHJvbGxlck1hbmFnZXJDb25maWdcbmhlYWx0aDpcbiAgaGVhbHRoUHJvYmVCaW5kQWRkcmVzczogOjgwODFcbm1ldHJpY3M6XG4gIGJpbmRBZGRyZXNzOiA6ODA4MFxud2ViaG9vazpcbiAgcG9ydDogOTQ0M1xubGVhZGVyRWxlY3Rpb246XG4gIGxlYWRlckVsZWN0OiB0cnVlXG4gIHJlc291cmNlTmFtZTogMzc0NWExNmUua3VhZHJhbnQuaW9cbiJ9LCJraW5kIjoiQ29uZmlnTWFwIiwibWV0YWRhdGEiOnsibmFtZSI6ImxpbWl0YWRvci1vcGVyYXRvci1tYW5hZ2VyLWNvbmZpZyJ9fQ==
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoidjEiLCJraW5kIjoiU2VydmljZSIsIm1ldGFkYXRhIjp7ImNyZWF0aW9uVGltZXN0YW1wIjpudWxsLCJsYWJlbHMiOnsiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9LCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLW1ldHJpY3MifSwic3BlYyI6eyJwb3J0cyI6W3sibmFtZSI6Im1ldHJpY3MiLCJwb3J0Ijo4MDgwLCJ0YXJnZXRQb3J0IjoibWV0cmljcyJ9XSwic2VsZWN0b3IiOnsiYXBwIjoibGltaXRhZG9yLW9wZXJhdG9yIiwiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9fSwic3RhdHVzIjp7ImxvYWRCYWxhbmNlciI6e319fQ==
+relatedImages:
+  - image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-1-limitador-operator-bundle@sha256:93c6f058da352883789f7db0150b1097a5f09e1268e24914ad964d5fdc83f6e1
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:b31ba293812788dc7e21c14703ac61fdd5bff010948ada33715544ba507851f7
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:9471aadce1a17aacb1bf653b75e0d7924f8f9e144954440e0d9c9be6fd432e8c
+    name: limitador
 schema: olm.bundle

--- a/catalog/4.19/limitador-operator/catalog.yaml
+++ b/catalog/4.19/limitador-operator/catalog.yaml
@@ -7,9 +7,11 @@ name: limitador-operator
 schema: olm.package
 ---
 entries:
-- name: limitador-operator.v1.0.2
-- name: limitador-operator.v1.1.0
-  replaces: limitador-operator.v1.0.2
+  - name: limitador-operator.v1.0.2
+  - name: limitador-operator.v1.1.0
+    replaces: limitador-operator.v1.0.2
+  - name: limitador-operator.v1.1.1
+    replaces: limitador-operator.v1.1.0
 name: stable
 package: limitador-operator
 schema: olm.channel
@@ -18,236 +20,269 @@ image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:21a579a5fd5c93
 name: limitador-operator.v1.0.2
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 1.0.2
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.0.2
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
-      createdAt: "2024-10-18T10:24:00Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: Enables rate limiting for Gateways and applications in a Gateway
-      API network. - Part of Red Hat Connectivity Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
+        createdAt: "2024-10-18T10:24:00Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: Enables rate limiting for Gateways and applications in a Gateway API network. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
-  name: limitador-rhel9-operator-4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:0112e4478abe28486670bb1221b4039ca0b4bde314d72c28485008ea7d6f73c1
-  name: limitador
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:21a579a5fd5c93677f68e5a79baaa9f9f77f2fd1310a4ce77532014844610630
-  name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
+    name: limitador-rhel9-operator-4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:0112e4478abe28486670bb1221b4039ca0b4bde314d72c28485008ea7d6f73c1
+    name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:21a579a5fd5c93677f68e5a79baaa9f9f77f2fd1310a4ce77532014844610630
+    name: ""
 schema: olm.bundle
 ---
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
 name: limitador-operator.v1.1.0
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 1.1.0
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.1.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-      createdAt: "2025-04-07T15:52:04Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: Enables rate limiting for Gateways and applications in a Gateway
-      API network. - Part of Red Hat Connectivity Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+        createdAt: "2025-04-07T15:52:04Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: Enables rate limiting for Gateways and applications in a Gateway API network. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
-  name: ""
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-  name: limitador-rhel9-operator-edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:98f85a05da53fbf7f20845d1969441620407cc13a185fd52714308679f116425
-  name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+    name: limitador-rhel9-operator-edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:98f85a05da53fbf7f20845d1969441620407cc13a185fd52714308679f116425
+    name: limitador
+schema: olm.bundle
+---
+image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-1-limitador-operator-bundle@sha256:93c6f058da352883789f7db0150b1097a5f09e1268e24914ad964d5fdc83f6e1
+name: limitador-operator.v1.1.1
+package: limitador-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.1.1
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsiY29udHJvbGxlci1nZW4ua3ViZWJ1aWxkZXIuaW8vdmVyc2lvbiI6InYwLjE1LjAifSwiY3JlYXRpb25UaW1lc3RhbXAiOm51bGwsIm5hbWUiOiJsaW1pdGFkb3JzLmxpbWl0YWRvci5rdWFkcmFudC5pbyJ9LCJzcGVjIjp7Imdyb3VwIjoibGltaXRhZG9yLmt1YWRyYW50LmlvIiwibmFtZXMiOnsia2luZCI6IkxpbWl0YWRvciIsImxpc3RLaW5kIjoiTGltaXRhZG9yTGlzdCIsInBsdXJhbCI6ImxpbWl0YWRvcnMiLCJzaW5ndWxhciI6ImxpbWl0YWRvciJ9LCJzY29wZSI6Ik5hbWVzcGFjZWQiLCJ2ZXJzaW9ucyI6W3siYWRkaXRpb25hbFByaW50ZXJDb2x1bW5zIjpbeyJkZXNjcmlwdGlvbiI6IkxpbWl0YWRvciBSZWFkeSIsImpzb25QYXRoIjoiLnN0YXR1cy5jb25kaXRpb25zWz8oQC50eXBlPT1cIlJlYWR5XCIpXS5zdGF0dXMiLCJuYW1lIjoiUmVhZHkiLCJwcmlvcml0eSI6MiwidHlwZSI6InN0cmluZyJ9LHsianNvblBhdGgiOiIubWV0YWRhdGEuY3JlYXRpb25UaW1lc3RhbXAiLCJuYW1lIjoiQWdlIiwidHlwZSI6ImRhdGUifV0sIm5hbWUiOiJ2MWFscGhhMSIsInNjaGVtYSI6eyJvcGVuQVBJVjNTY2hlbWEiOnsiZGVzY3JpcHRpb24iOiJMaW1pdGFkb3IgaXMgdGhlIFNjaGVtYSBmb3IgdGhlIGxpbWl0YWRvcnMgQVBJIiwicHJvcGVydGllcyI6eyJhcGlWZXJzaW9uIjp7ImRlc2NyaXB0aW9uIjoiQVBJVmVyc2lvbiBkZWZpbmVzIHRoZSB2ZXJzaW9uZWQgc2NoZW1hIG9mIHRoaXMgcmVwcmVzZW50YXRpb24gb2YgYW4gb2JqZWN0LlxuU2VydmVycyBzaG91bGQgY29udmVydCByZWNvZ25pemVkIHNjaGVtYXMgdG8gdGhlIGxhdGVzdCBpbnRlcm5hbCB2YWx1ZSwgYW5kXG5tYXkgcmVqZWN0IHVucmVjb2duaXplZCB2YWx1ZXMuXG5Nb3JlIGluZm86IGh0dHBzOi8vZ2l0Lms4cy5pby9jb21tdW5pdHkvY29udHJpYnV0b3JzL2RldmVsL3NpZy1hcmNoaXRlY3R1cmUvYXBpLWNvbnZlbnRpb25zLm1kI3Jlc291cmNlcyIsInR5cGUiOiJzdHJpbmcifSwia2luZCI6eyJkZXNjcmlwdGlvbiI6IktpbmQgaXMgYSBzdHJpbmcgdmFsdWUgcmVwcmVzZW50aW5nIHRoZSBSRVNUIHJlc291cmNlIHRoaXMgb2JqZWN0IHJlcHJlc2VudHMuXG5TZXJ2ZXJzIG1heSBpbmZlciB0aGlzIGZyb20gdGhlIGVuZHBvaW50IHRoZSBjbGllbnQgc3VibWl0cyByZXF1ZXN0cyB0by5cbkNhbm5vdCBiZSB1cGRhdGVkLlxuSW4gQ2FtZWxDYXNlLlxuTW9yZSBpbmZvOiBodHRwczovL2dpdC5rOHMuaW8vY29tbXVuaXR5L2NvbnRyaWJ1dG9ycy9kZXZlbC9zaWctYXJjaGl0ZWN0dXJlL2FwaS1jb252ZW50aW9ucy5tZCN0eXBlcy1raW5kcyIsInR5cGUiOiJzdHJpbmcifSwibWV0YWRhdGEiOnsidHlwZSI6Im9iamVjdCJ9LCJzcGVjIjp7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yU3BlYyBkZWZpbmVzIHRoZSBkZXNpcmVkIHN0YXRlIG9mIExpbWl0YWRvciIsInByb3BlcnRpZXMiOnsiYWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJBZmZpbml0eSBpcyBhIGdyb3VwIG9mIGFmZmluaXR5IHNjaGVkdWxpbmcgcnVsZXMuIiwicHJvcGVydGllcyI6eyJub2RlQWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJEZXNjcmliZXMgbm9kZSBhZmZpbml0eSBzY2hlZHVsaW5nIHJ1bGVzIGZvciB0aGUgcG9kLiIsInByb3BlcnRpZXMiOnsicHJlZmVycmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJUaGUgc2NoZWR1bGVyIHdpbGwgcHJlZmVyIHRvIHNjaGVkdWxlIHBvZHMgdG8gbm9kZXMgdGhhdCBzYXRpc2Z5XG50aGUgYWZmaW5pdHkgZXhwcmVzc2lvbnMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQsIGJ1dCBpdCBtYXkgY2hvb3NlXG5hIG5vZGUgdGhhdCB2aW9sYXRlcyBvbmUgb3IgbW9yZSBvZiB0aGUgZXhwcmVzc2lvbnMuIFRoZSBub2RlIHRoYXQgaXNcbm1vc3QgcHJlZmVycmVkIGlzIHRoZSBvbmUgd2l0aCB0aGUgZ3JlYXRlc3Qgc3VtIG9mIHdlaWdodHMsIGkuZS5cbmZvciBlYWNoIG5vZGUgdGhhdCBtZWV0cyBhbGwgb2YgdGhlIHNjaGVkdWxpbmcgcmVxdWlyZW1lbnRzIChyZXNvdXJjZVxucmVxdWVzdCwgcmVxdWlyZWREdXJpbmdTY2hlZHVsaW5nIGFmZmluaXR5IGV4cHJlc3Npb25zLCBldGMuKSxcbmNvbXB1dGUgYSBzdW0gYnkgaXRlcmF0aW5nIHRocm91Z2ggdGhlIGVsZW1lbnRzIG9mIHRoaXMgZmllbGQgYW5kIGFkZGluZ1xuXCJ3ZWlnaHRcIiB0byB0aGUgc3VtIGlmIHRoZSBub2RlIG1hdGNoZXMgdGhlIGNvcnJlc3BvbmRpbmcgbWF0Y2hFeHByZXNzaW9uczsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBbiBlbXB0eSBwcmVmZXJyZWQgc2NoZWR1bGluZyB0ZXJtIG1hdGNoZXMgYWxsIG9iamVjdHMgd2l0aCBpbXBsaWNpdCB3ZWlnaHQgMFxuKGkuZS4gaXQncyBhIG5vLW9wKS4gQSBudWxsIHByZWZlcnJlZCBzY2hlZHVsaW5nIHRlcm0gbWF0Y2hlcyBubyBvYmplY3RzIChpLmUuIGlzIGFsc28gYSBuby1vcCkuIiwicHJvcGVydGllcyI6eyJwcmVmZXJlbmNlIjp7ImRlc2NyaXB0aW9uIjoiQSBub2RlIHNlbGVjdG9yIHRlcm0sIGFzc29jaWF0ZWQgd2l0aCB0aGUgY29ycmVzcG9uZGluZyB3ZWlnaHQuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoiQSBsaXN0IG9mIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnRzIGJ5IG5vZGUncyBsYWJlbHMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvclxudGhhdCByZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6IlRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoiUmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzLCBEb2VzTm90RXhpc3QuIEd0LCBhbmQgTHQuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJBbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEd0IG9yIEx0LCB0aGUgdmFsdWVzXG5hcnJheSBtdXN0IGhhdmUgYSBzaW5nbGUgZWxlbWVudCwgd2hpY2ggd2lsbCBiZSBpbnRlcnByZXRlZCBhcyBhbiBpbnRlZ2VyLlxuVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoRmllbGRzIjp7ImRlc2NyaXB0aW9uIjoiQSBsaXN0IG9mIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnRzIGJ5IG5vZGUncyBmaWVsZHMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvclxudGhhdCByZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6IlRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoiUmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzLCBEb2VzTm90RXhpc3QuIEd0LCBhbmQgTHQuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJBbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEd0IG9yIEx0LCB0aGUgdmFsdWVzXG5hcnJheSBtdXN0IGhhdmUgYSBzaW5nbGUgZWxlbWVudCwgd2hpY2ggd2lsbCBiZSBpbnRlcnByZXRlZCBhcyBhbiBpbnRlZ2VyLlxuVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIndlaWdodCI6eyJkZXNjcmlwdGlvbiI6IldlaWdodCBhc3NvY2lhdGVkIHdpdGggbWF0Y2hpbmcgdGhlIGNvcnJlc3BvbmRpbmcgbm9kZVNlbGVjdG9yVGVybSwgaW4gdGhlIHJhbmdlIDEtMTAwLiIsImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifX0sInJlcXVpcmVkIjpbInByZWZlcmVuY2UiLCJ3ZWlnaHQiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwicmVxdWlyZWREdXJpbmdTY2hlZHVsaW5nSWdub3JlZER1cmluZ0V4ZWN1dGlvbiI6eyJkZXNjcmlwdGlvbiI6IklmIHRoZSBhZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgYXJlIG5vdCBtZXQgYXRcbnNjaGVkdWxpbmcgdGltZSwgdGhlIHBvZCB3aWxsIG5vdCBiZSBzY2hlZHVsZWQgb250byB0aGUgbm9kZS5cbklmIHRoZSBhZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgY2Vhc2UgdG8gYmUgbWV0XG5hdCBzb21lIHBvaW50IGR1cmluZyBwb2QgZXhlY3V0aW9uIChlLmcuIGR1ZSB0byBhbiB1cGRhdGUpLCB0aGUgc3lzdGVtXG5tYXkgb3IgbWF5IG5vdCB0cnkgdG8gZXZlbnR1YWxseSBldmljdCB0aGUgcG9kIGZyb20gaXRzIG5vZGUuIiwicHJvcGVydGllcyI6eyJub2RlU2VsZWN0b3JUZXJtcyI6eyJkZXNjcmlwdGlvbiI6IlJlcXVpcmVkLiBBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciB0ZXJtcy4gVGhlIHRlcm1zIGFyZSBPUmVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBudWxsIG9yIGVtcHR5IG5vZGUgc2VsZWN0b3IgdGVybSBtYXRjaGVzIG5vIG9iamVjdHMuIFRoZSByZXF1aXJlbWVudHMgb2ZcbnRoZW0gYXJlIEFORGVkLlxuVGhlIFRvcG9sb2d5U2VsZWN0b3JUZXJtIHR5cGUgaW1wbGVtZW50cyBhIHN1YnNldCBvZiB0aGUgTm9kZVNlbGVjdG9yVGVybS4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudHMgYnkgbm9kZSdzIGxhYmVscy4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yXG50aGF0IHJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJSZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMsIERvZXNOb3RFeGlzdC4gR3QsIGFuZCBMdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6IkFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgR3Qgb3IgTHQsIHRoZSB2YWx1ZXNcbmFycmF5IG11c3QgaGF2ZSBhIHNpbmdsZSBlbGVtZW50LCB3aGljaCB3aWxsIGJlIGludGVycHJldGVkIGFzIGFuIGludGVnZXIuXG5UaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hGaWVsZHMiOnsiZGVzY3JpcHRpb24iOiJBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudHMgYnkgbm9kZSdzIGZpZWxkcy4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yXG50aGF0IHJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJSZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMsIERvZXNOb3RFeGlzdC4gR3QsIGFuZCBMdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6IkFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgR3Qgb3IgTHQsIHRoZSB2YWx1ZXNcbmFycmF5IG11c3QgaGF2ZSBhIHNpbmdsZSBlbGVtZW50LCB3aGljaCB3aWxsIGJlIGludGVycHJldGVkIGFzIGFuIGludGVnZXIuXG5UaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJub2RlU2VsZWN0b3JUZXJtcyJdLCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn19LCJ0eXBlIjoib2JqZWN0In0sInBvZEFmZmluaXR5Ijp7ImRlc2NyaXB0aW9uIjoiRGVzY3JpYmVzIHBvZCBhZmZpbml0eSBzY2hlZHVsaW5nIHJ1bGVzIChlLmcuIGNvLWxvY2F0ZSB0aGlzIHBvZCBpbiB0aGUgc2FtZSBub2RlLCB6b25lLCBldGMuIGFzIHNvbWUgb3RoZXIgcG9kKHMpKS4iLCJwcm9wZXJ0aWVzIjp7InByZWZlcnJlZER1cmluZ1NjaGVkdWxpbmdJZ25vcmVkRHVyaW5nRXhlY3V0aW9uIjp7ImRlc2NyaXB0aW9uIjoiVGhlIHNjaGVkdWxlciB3aWxsIHByZWZlciB0byBzY2hlZHVsZSBwb2RzIHRvIG5vZGVzIHRoYXQgc2F0aXNmeVxudGhlIGFmZmluaXR5IGV4cHJlc3Npb25zIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkLCBidXQgaXQgbWF5IGNob29zZVxuYSBub2RlIHRoYXQgdmlvbGF0ZXMgb25lIG9yIG1vcmUgb2YgdGhlIGV4cHJlc3Npb25zLiBUaGUgbm9kZSB0aGF0IGlzXG5tb3N0IHByZWZlcnJlZCBpcyB0aGUgb25lIHdpdGggdGhlIGdyZWF0ZXN0IHN1bSBvZiB3ZWlnaHRzLCBpLmUuXG5mb3IgZWFjaCBub2RlIHRoYXQgbWVldHMgYWxsIG9mIHRoZSBzY2hlZHVsaW5nIHJlcXVpcmVtZW50cyAocmVzb3VyY2VcbnJlcXVlc3QsIHJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZyBhZmZpbml0eSBleHByZXNzaW9ucywgZXRjLiksXG5jb21wdXRlIGEgc3VtIGJ5IGl0ZXJhdGluZyB0aHJvdWdoIHRoZSBlbGVtZW50cyBvZiB0aGlzIGZpZWxkIGFuZCBhZGRpbmdcblwid2VpZ2h0XCIgdG8gdGhlIHN1bSBpZiB0aGUgbm9kZSBoYXMgcG9kcyB3aGljaCBtYXRjaGVzIHRoZSBjb3JyZXNwb25kaW5nIHBvZEFmZmluaXR5VGVybTsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJUaGUgd2VpZ2h0cyBvZiBhbGwgb2YgdGhlIG1hdGNoZWQgV2VpZ2h0ZWRQb2RBZmZpbml0eVRlcm0gZmllbGRzIGFyZSBhZGRlZCBwZXItbm9kZSB0byBmaW5kIHRoZSBtb3N0IHByZWZlcnJlZCBub2RlKHMpIiwicHJvcGVydGllcyI6eyJwb2RBZmZpbml0eVRlcm0iOnsiZGVzY3JpcHRpb24iOiJSZXF1aXJlZC4gQSBwb2QgYWZmaW5pdHkgdGVybSwgYXNzb2NpYXRlZCB3aXRoIHRoZSBjb3JyZXNwb25kaW5nIHdlaWdodC4iLCJwcm9wZXJ0aWVzIjp7ImxhYmVsU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgYSBzZXQgb2YgcmVzb3VyY2VzLCBpbiB0aGlzIGNhc2UgcG9kcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciB0aGUgc2V0IG9mIG5hbWVzcGFjZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgc2VsZWN0ZWQgYnkgdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIGxpc3RlZCBpbiB0aGUgbmFtZXNwYWNlcyBmaWVsZC5cbm51bGwgc2VsZWN0b3IgYW5kIG51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi5cbkFuIGVtcHR5IHNlbGVjdG9yICh7fSkgbWF0Y2hlcyBhbGwgbmFtZXNwYWNlcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VzIjp7ImRlc2NyaXB0aW9uIjoibmFtZXNwYWNlcyBzcGVjaWZpZXMgYSBzdGF0aWMgbGlzdCBvZiBuYW1lc3BhY2UgbmFtZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgbGlzdGVkIGluIHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBzZWxlY3RlZCBieSBuYW1lc3BhY2VTZWxlY3Rvci5cbm51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IGFuZCBudWxsIG5hbWVzcGFjZVNlbGVjdG9yIG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJ0b3BvbG9neUtleSI6eyJkZXNjcmlwdGlvbiI6IlRoaXMgcG9kIHNob3VsZCBiZSBjby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGggdGhlIHBvZHMgbWF0Y2hpbmdcbnRoZSBsYWJlbFNlbGVjdG9yIGluIHRoZSBzcGVjaWZpZWQgbmFtZXNwYWNlcywgd2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlXG53aG9zZSB2YWx1ZSBvZiB0aGUgbGFiZWwgd2l0aCBrZXkgdG9wb2xvZ3lLZXkgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoIGFueSBvZiB0aGVcbnNlbGVjdGVkIHBvZHMgaXMgcnVubmluZy5cbkVtcHR5IHRvcG9sb2d5S2V5IGlzIG5vdCBhbGxvd2VkLiIsInR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInRvcG9sb2d5S2V5Il0sInR5cGUiOiJvYmplY3QifSwid2VpZ2h0Ijp7ImRlc2NyaXB0aW9uIjoid2VpZ2h0IGFzc29jaWF0ZWQgd2l0aCBtYXRjaGluZyB0aGUgY29ycmVzcG9uZGluZyBwb2RBZmZpbml0eVRlcm0sXG5pbiB0aGUgcmFuZ2UgMS0xMDAuIiwiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwicmVxdWlyZWQiOlsicG9kQWZmaW5pdHlUZXJtIiwid2VpZ2h0Il0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sInJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJJZiB0aGUgYWZmaW5pdHkgcmVxdWlyZW1lbnRzIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkIGFyZSBub3QgbWV0IGF0XG5zY2hlZHVsaW5nIHRpbWUsIHRoZSBwb2Qgd2lsbCBub3QgYmUgc2NoZWR1bGVkIG9udG8gdGhlIG5vZGUuXG5JZiB0aGUgYWZmaW5pdHkgcmVxdWlyZW1lbnRzIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkIGNlYXNlIHRvIGJlIG1ldFxuYXQgc29tZSBwb2ludCBkdXJpbmcgcG9kIGV4ZWN1dGlvbiAoZS5nLiBkdWUgdG8gYSBwb2QgbGFiZWwgdXBkYXRlKSwgdGhlXG5zeXN0ZW0gbWF5IG9yIG1heSBub3QgdHJ5IHRvIGV2ZW50dWFsbHkgZXZpY3QgdGhlIHBvZCBmcm9tIGl0cyBub2RlLlxuV2hlbiB0aGVyZSBhcmUgbXVsdGlwbGUgZWxlbWVudHMsIHRoZSBsaXN0cyBvZiBub2RlcyBjb3JyZXNwb25kaW5nIHRvIGVhY2hcbnBvZEFmZmluaXR5VGVybSBhcmUgaW50ZXJzZWN0ZWQsIGkuZS4gYWxsIHRlcm1zIG11c3QgYmUgc2F0aXNmaWVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiRGVmaW5lcyBhIHNldCBvZiBwb2RzIChuYW1lbHkgdGhvc2UgbWF0Y2hpbmcgdGhlIGxhYmVsU2VsZWN0b3JcbnJlbGF0aXZlIHRvIHRoZSBnaXZlbiBuYW1lc3BhY2UocykpIHRoYXQgdGhpcyBwb2Qgc2hvdWxkIGJlXG5jby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGgsXG53aGVyZSBjby1sb2NhdGVkIGlzIGRlZmluZWQgYXMgcnVubmluZyBvbiBhIG5vZGUgd2hvc2UgdmFsdWUgb2ZcbnRoZSBsYWJlbCB3aXRoIGtleSBcdTAwM2N0b3BvbG9neUtleVx1MDAzZSBtYXRjaGVzIHRoYXQgb2YgYW55IG5vZGUgb24gd2hpY2hcbmEgcG9kIG9mIHRoZSBzZXQgb2YgcG9kcyBpcyBydW5uaW5nIiwicHJvcGVydGllcyI6eyJsYWJlbFNlbGVjdG9yIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBxdWVyeSBvdmVyIGEgc2V0IG9mIHJlc291cmNlcywgaW4gdGhpcyBjYXNlIHBvZHMuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoibWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvciB0aGF0XG5yZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6ImtleSBpcyB0aGUgbGFiZWwga2V5IHRoYXQgdGhlIHNlbGVjdG9yIGFwcGxpZXMgdG8uIiwidHlwZSI6InN0cmluZyJ9LCJvcGVyYXRvciI6eyJkZXNjcmlwdGlvbiI6Im9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLlxuVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LiIsInR5cGUiOiJzdHJpbmcifSwidmFsdWVzIjp7ImRlc2NyaXB0aW9uIjoidmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpY1xubWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoTGFiZWxzIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjp7InR5cGUiOiJzdHJpbmcifSwiZGVzY3JpcHRpb24iOiJtYXRjaExhYmVscyBpcyBhIG1hcCBvZiB7a2V5LHZhbHVlfSBwYWlycy4gQSBzaW5nbGUge2tleSx2YWx1ZX0gaW4gdGhlIG1hdGNoTGFiZWxzXG5tYXAgaXMgZXF1aXZhbGVudCB0byBhbiBlbGVtZW50IG9mIG1hdGNoRXhwcmVzc2lvbnMsIHdob3NlIGtleSBmaWVsZCBpcyBcImtleVwiLCB0aGVcbm9wZXJhdG9yIGlzIFwiSW5cIiwgYW5kIHRoZSB2YWx1ZXMgYXJyYXkgY29udGFpbnMgb25seSBcInZhbHVlXCIuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwibmFtZXNwYWNlU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgdGhlIHNldCBvZiBuYW1lc3BhY2VzIHRoYXQgdGhlIHRlcm0gYXBwbGllcyB0by5cblRoZSB0ZXJtIGlzIGFwcGxpZWQgdG8gdGhlIHVuaW9uIG9mIHRoZSBuYW1lc3BhY2VzIHNlbGVjdGVkIGJ5IHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBsaXN0ZWQgaW4gdGhlIG5hbWVzcGFjZXMgZmllbGQuXG5udWxsIHNlbGVjdG9yIGFuZCBudWxsIG9yIGVtcHR5IG5hbWVzcGFjZXMgbGlzdCBtZWFucyBcInRoaXMgcG9kJ3MgbmFtZXNwYWNlXCIuXG5BbiBlbXB0eSBzZWxlY3RvciAoe30pIG1hdGNoZXMgYWxsIG5hbWVzcGFjZXMuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoibWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvciB0aGF0XG5yZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6ImtleSBpcyB0aGUgbGFiZWwga2V5IHRoYXQgdGhlIHNlbGVjdG9yIGFwcGxpZXMgdG8uIiwidHlwZSI6InN0cmluZyJ9LCJvcGVyYXRvciI6eyJkZXNjcmlwdGlvbiI6Im9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLlxuVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LiIsInR5cGUiOiJzdHJpbmcifSwidmFsdWVzIjp7ImRlc2NyaXB0aW9uIjoidmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpY1xubWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoTGFiZWxzIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjp7InR5cGUiOiJzdHJpbmcifSwiZGVzY3JpcHRpb24iOiJtYXRjaExhYmVscyBpcyBhIG1hcCBvZiB7a2V5LHZhbHVlfSBwYWlycy4gQSBzaW5nbGUge2tleSx2YWx1ZX0gaW4gdGhlIG1hdGNoTGFiZWxzXG5tYXAgaXMgZXF1aXZhbGVudCB0byBhbiBlbGVtZW50IG9mIG1hdGNoRXhwcmVzc2lvbnMsIHdob3NlIGtleSBmaWVsZCBpcyBcImtleVwiLCB0aGVcbm9wZXJhdG9yIGlzIFwiSW5cIiwgYW5kIHRoZSB2YWx1ZXMgYXJyYXkgY29udGFpbnMgb25seSBcInZhbHVlXCIuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwibmFtZXNwYWNlcyI6eyJkZXNjcmlwdGlvbiI6Im5hbWVzcGFjZXMgc3BlY2lmaWVzIGEgc3RhdGljIGxpc3Qgb2YgbmFtZXNwYWNlIG5hbWVzIHRoYXQgdGhlIHRlcm0gYXBwbGllcyB0by5cblRoZSB0ZXJtIGlzIGFwcGxpZWQgdG8gdGhlIHVuaW9uIG9mIHRoZSBuYW1lc3BhY2VzIGxpc3RlZCBpbiB0aGlzIGZpZWxkXG5hbmQgdGhlIG9uZXMgc2VsZWN0ZWQgYnkgbmFtZXNwYWNlU2VsZWN0b3IuXG5udWxsIG9yIGVtcHR5IG5hbWVzcGFjZXMgbGlzdCBhbmQgbnVsbCBuYW1lc3BhY2VTZWxlY3RvciBtZWFucyBcInRoaXMgcG9kJ3MgbmFtZXNwYWNlXCIuIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifSwidG9wb2xvZ3lLZXkiOnsiZGVzY3JpcHRpb24iOiJUaGlzIHBvZCBzaG91bGQgYmUgY28tbG9jYXRlZCAoYWZmaW5pdHkpIG9yIG5vdCBjby1sb2NhdGVkIChhbnRpLWFmZmluaXR5KSB3aXRoIHRoZSBwb2RzIG1hdGNoaW5nXG50aGUgbGFiZWxTZWxlY3RvciBpbiB0aGUgc3BlY2lmaWVkIG5hbWVzcGFjZXMsIHdoZXJlIGNvLWxvY2F0ZWQgaXMgZGVmaW5lZCBhcyBydW5uaW5nIG9uIGEgbm9kZVxud2hvc2UgdmFsdWUgb2YgdGhlIGxhYmVsIHdpdGgga2V5IHRvcG9sb2d5S2V5IG1hdGNoZXMgdGhhdCBvZiBhbnkgbm9kZSBvbiB3aGljaCBhbnkgb2YgdGhlXG5zZWxlY3RlZCBwb2RzIGlzIHJ1bm5pbmcuXG5FbXB0eSB0b3BvbG9neUtleSBpcyBub3QgYWxsb3dlZC4iLCJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJ0b3BvbG9neUtleSJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9fSwidHlwZSI6Im9iamVjdCJ9LCJwb2RBbnRpQWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJEZXNjcmliZXMgcG9kIGFudGktYWZmaW5pdHkgc2NoZWR1bGluZyBydWxlcyAoZS5nLiBhdm9pZCBwdXR0aW5nIHRoaXMgcG9kIGluIHRoZSBzYW1lIG5vZGUsIHpvbmUsIGV0Yy4gYXMgc29tZSBvdGhlciBwb2QocykpLiIsInByb3BlcnRpZXMiOnsicHJlZmVycmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJUaGUgc2NoZWR1bGVyIHdpbGwgcHJlZmVyIHRvIHNjaGVkdWxlIHBvZHMgdG8gbm9kZXMgdGhhdCBzYXRpc2Z5XG50aGUgYW50aS1hZmZpbml0eSBleHByZXNzaW9ucyBzcGVjaWZpZWQgYnkgdGhpcyBmaWVsZCwgYnV0IGl0IG1heSBjaG9vc2VcbmEgbm9kZSB0aGF0IHZpb2xhdGVzIG9uZSBvciBtb3JlIG9mIHRoZSBleHByZXNzaW9ucy4gVGhlIG5vZGUgdGhhdCBpc1xubW9zdCBwcmVmZXJyZWQgaXMgdGhlIG9uZSB3aXRoIHRoZSBncmVhdGVzdCBzdW0gb2Ygd2VpZ2h0cywgaS5lLlxuZm9yIGVhY2ggbm9kZSB0aGF0IG1lZXRzIGFsbCBvZiB0aGUgc2NoZWR1bGluZyByZXF1aXJlbWVudHMgKHJlc291cmNlXG5yZXF1ZXN0LCByZXF1aXJlZER1cmluZ1NjaGVkdWxpbmcgYW50aS1hZmZpbml0eSBleHByZXNzaW9ucywgZXRjLiksXG5jb21wdXRlIGEgc3VtIGJ5IGl0ZXJhdGluZyB0aHJvdWdoIHRoZSBlbGVtZW50cyBvZiB0aGlzIGZpZWxkIGFuZCBhZGRpbmdcblwid2VpZ2h0XCIgdG8gdGhlIHN1bSBpZiB0aGUgbm9kZSBoYXMgcG9kcyB3aGljaCBtYXRjaGVzIHRoZSBjb3JyZXNwb25kaW5nIHBvZEFmZmluaXR5VGVybTsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJUaGUgd2VpZ2h0cyBvZiBhbGwgb2YgdGhlIG1hdGNoZWQgV2VpZ2h0ZWRQb2RBZmZpbml0eVRlcm0gZmllbGRzIGFyZSBhZGRlZCBwZXItbm9kZSB0byBmaW5kIHRoZSBtb3N0IHByZWZlcnJlZCBub2RlKHMpIiwicHJvcGVydGllcyI6eyJwb2RBZmZpbml0eVRlcm0iOnsiZGVzY3JpcHRpb24iOiJSZXF1aXJlZC4gQSBwb2QgYWZmaW5pdHkgdGVybSwgYXNzb2NpYXRlZCB3aXRoIHRoZSBjb3JyZXNwb25kaW5nIHdlaWdodC4iLCJwcm9wZXJ0aWVzIjp7ImxhYmVsU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgYSBzZXQgb2YgcmVzb3VyY2VzLCBpbiB0aGlzIGNhc2UgcG9kcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciB0aGUgc2V0IG9mIG5hbWVzcGFjZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgc2VsZWN0ZWQgYnkgdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIGxpc3RlZCBpbiB0aGUgbmFtZXNwYWNlcyBmaWVsZC5cbm51bGwgc2VsZWN0b3IgYW5kIG51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi5cbkFuIGVtcHR5IHNlbGVjdG9yICh7fSkgbWF0Y2hlcyBhbGwgbmFtZXNwYWNlcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VzIjp7ImRlc2NyaXB0aW9uIjoibmFtZXNwYWNlcyBzcGVjaWZpZXMgYSBzdGF0aWMgbGlzdCBvZiBuYW1lc3BhY2UgbmFtZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgbGlzdGVkIGluIHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBzZWxlY3RlZCBieSBuYW1lc3BhY2VTZWxlY3Rvci5cbm51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IGFuZCBudWxsIG5hbWVzcGFjZVNlbGVjdG9yIG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJ0b3BvbG9neUtleSI6eyJkZXNjcmlwdGlvbiI6IlRoaXMgcG9kIHNob3VsZCBiZSBjby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGggdGhlIHBvZHMgbWF0Y2hpbmdcbnRoZSBsYWJlbFNlbGVjdG9yIGluIHRoZSBzcGVjaWZpZWQgbmFtZXNwYWNlcywgd2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlXG53aG9zZSB2YWx1ZSBvZiB0aGUgbGFiZWwgd2l0aCBrZXkgdG9wb2xvZ3lLZXkgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoIGFueSBvZiB0aGVcbnNlbGVjdGVkIHBvZHMgaXMgcnVubmluZy5cbkVtcHR5IHRvcG9sb2d5S2V5IGlzIG5vdCBhbGxvd2VkLiIsInR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInRvcG9sb2d5S2V5Il0sInR5cGUiOiJvYmplY3QifSwid2VpZ2h0Ijp7ImRlc2NyaXB0aW9uIjoid2VpZ2h0IGFzc29jaWF0ZWQgd2l0aCBtYXRjaGluZyB0aGUgY29ycmVzcG9uZGluZyBwb2RBZmZpbml0eVRlcm0sXG5pbiB0aGUgcmFuZ2UgMS0xMDAuIiwiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwicmVxdWlyZWQiOlsicG9kQWZmaW5pdHlUZXJtIiwid2VpZ2h0Il0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sInJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJJZiB0aGUgYW50aS1hZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgYXJlIG5vdCBtZXQgYXRcbnNjaGVkdWxpbmcgdGltZSwgdGhlIHBvZCB3aWxsIG5vdCBiZSBzY2hlZHVsZWQgb250byB0aGUgbm9kZS5cbklmIHRoZSBhbnRpLWFmZmluaXR5IHJlcXVpcmVtZW50cyBzcGVjaWZpZWQgYnkgdGhpcyBmaWVsZCBjZWFzZSB0byBiZSBtZXRcbmF0IHNvbWUgcG9pbnQgZHVyaW5nIHBvZCBleGVjdXRpb24gKGUuZy4gZHVlIHRvIGEgcG9kIGxhYmVsIHVwZGF0ZSksIHRoZVxuc3lzdGVtIG1heSBvciBtYXkgbm90IHRyeSB0byBldmVudHVhbGx5IGV2aWN0IHRoZSBwb2QgZnJvbSBpdHMgbm9kZS5cbldoZW4gdGhlcmUgYXJlIG11bHRpcGxlIGVsZW1lbnRzLCB0aGUgbGlzdHMgb2Ygbm9kZXMgY29ycmVzcG9uZGluZyB0byBlYWNoXG5wb2RBZmZpbml0eVRlcm0gYXJlIGludGVyc2VjdGVkLCBpLmUuIGFsbCB0ZXJtcyBtdXN0IGJlIHNhdGlzZmllZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkRlZmluZXMgYSBzZXQgb2YgcG9kcyAobmFtZWx5IHRob3NlIG1hdGNoaW5nIHRoZSBsYWJlbFNlbGVjdG9yXG5yZWxhdGl2ZSB0byB0aGUgZ2l2ZW4gbmFtZXNwYWNlKHMpKSB0aGF0IHRoaXMgcG9kIHNob3VsZCBiZVxuY28tbG9jYXRlZCAoYWZmaW5pdHkpIG9yIG5vdCBjby1sb2NhdGVkIChhbnRpLWFmZmluaXR5KSB3aXRoLFxud2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlIHdob3NlIHZhbHVlIG9mXG50aGUgbGFiZWwgd2l0aCBrZXkgXHUwMDNjdG9wb2xvZ3lLZXlcdTAwM2UgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoXG5hIHBvZCBvZiB0aGUgc2V0IG9mIHBvZHMgaXMgcnVubmluZyIsInByb3BlcnRpZXMiOnsibGFiZWxTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciBhIHNldCBvZiByZXNvdXJjZXMsIGluIHRoaXMgY2FzZSBwb2RzLiIsInByb3BlcnRpZXMiOnsibWF0Y2hFeHByZXNzaW9ucyI6eyJkZXNjcmlwdGlvbiI6Im1hdGNoRXhwcmVzc2lvbnMgaXMgYSBsaXN0IG9mIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50cy4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50IGlzIGEgc2VsZWN0b3IgdGhhdCBjb250YWlucyB2YWx1ZXMsIGEga2V5LCBhbmQgYW4gb3BlcmF0b3IgdGhhdFxucmVsYXRlcyB0aGUga2V5IGFuZCB2YWx1ZXMuIiwicHJvcGVydGllcyI6eyJrZXkiOnsiZGVzY3JpcHRpb24iOiJrZXkgaXMgdGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6InZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWNcbm1lcmdlIHBhdGNoLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJrZXkiLCJvcGVyYXRvciJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJtYXRjaExhYmVscyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJ0eXBlIjoic3RyaW5nIn0sImRlc2NyaXB0aW9uIjoibWF0Y2hMYWJlbHMgaXMgYSBtYXAgb2Yge2tleSx2YWx1ZX0gcGFpcnMuIEEgc2luZ2xlIHtrZXksdmFsdWV9IGluIHRoZSBtYXRjaExhYmVsc1xubWFwIGlzIGVxdWl2YWxlbnQgdG8gYW4gZWxlbWVudCBvZiBtYXRjaEV4cHJlc3Npb25zLCB3aG9zZSBrZXkgZmllbGQgaXMgXCJrZXlcIiwgdGhlXG5vcGVyYXRvciBpcyBcIkluXCIsIGFuZCB0aGUgdmFsdWVzIGFycmF5IGNvbnRhaW5zIG9ubHkgXCJ2YWx1ZVwiLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIm5hbWVzcGFjZVNlbGVjdG9yIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBxdWVyeSBvdmVyIHRoZSBzZXQgb2YgbmFtZXNwYWNlcyB0aGF0IHRoZSB0ZXJtIGFwcGxpZXMgdG8uXG5UaGUgdGVybSBpcyBhcHBsaWVkIHRvIHRoZSB1bmlvbiBvZiB0aGUgbmFtZXNwYWNlcyBzZWxlY3RlZCBieSB0aGlzIGZpZWxkXG5hbmQgdGhlIG9uZXMgbGlzdGVkIGluIHRoZSBuYW1lc3BhY2VzIGZpZWxkLlxubnVsbCBzZWxlY3RvciBhbmQgbnVsbCBvciBlbXB0eSBuYW1lc3BhY2VzIGxpc3QgbWVhbnMgXCJ0aGlzIHBvZCdzIG5hbWVzcGFjZVwiLlxuQW4gZW1wdHkgc2VsZWN0b3IgKHt9KSBtYXRjaGVzIGFsbCBuYW1lc3BhY2VzLiIsInByb3BlcnRpZXMiOnsibWF0Y2hFeHByZXNzaW9ucyI6eyJkZXNjcmlwdGlvbiI6Im1hdGNoRXhwcmVzc2lvbnMgaXMgYSBsaXN0IG9mIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50cy4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50IGlzIGEgc2VsZWN0b3IgdGhhdCBjb250YWlucyB2YWx1ZXMsIGEga2V5LCBhbmQgYW4gb3BlcmF0b3IgdGhhdFxucmVsYXRlcyB0aGUga2V5IGFuZCB2YWx1ZXMuIiwicHJvcGVydGllcyI6eyJrZXkiOnsiZGVzY3JpcHRpb24iOiJrZXkgaXMgdGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6InZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWNcbm1lcmdlIHBhdGNoLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJrZXkiLCJvcGVyYXRvciJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJtYXRjaExhYmVscyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJ0eXBlIjoic3RyaW5nIn0sImRlc2NyaXB0aW9uIjoibWF0Y2hMYWJlbHMgaXMgYSBtYXAgb2Yge2tleSx2YWx1ZX0gcGFpcnMuIEEgc2luZ2xlIHtrZXksdmFsdWV9IGluIHRoZSBtYXRjaExhYmVsc1xubWFwIGlzIGVxdWl2YWxlbnQgdG8gYW4gZWxlbWVudCBvZiBtYXRjaEV4cHJlc3Npb25zLCB3aG9zZSBrZXkgZmllbGQgaXMgXCJrZXlcIiwgdGhlXG5vcGVyYXRvciBpcyBcIkluXCIsIGFuZCB0aGUgdmFsdWVzIGFycmF5IGNvbnRhaW5zIG9ubHkgXCJ2YWx1ZVwiLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIm5hbWVzcGFjZXMiOnsiZGVzY3JpcHRpb24iOiJuYW1lc3BhY2VzIHNwZWNpZmllcyBhIHN0YXRpYyBsaXN0IG9mIG5hbWVzcGFjZSBuYW1lcyB0aGF0IHRoZSB0ZXJtIGFwcGxpZXMgdG8uXG5UaGUgdGVybSBpcyBhcHBsaWVkIHRvIHRoZSB1bmlvbiBvZiB0aGUgbmFtZXNwYWNlcyBsaXN0ZWQgaW4gdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIHNlbGVjdGVkIGJ5IG5hbWVzcGFjZVNlbGVjdG9yLlxubnVsbCBvciBlbXB0eSBuYW1lc3BhY2VzIGxpc3QgYW5kIG51bGwgbmFtZXNwYWNlU2VsZWN0b3IgbWVhbnMgXCJ0aGlzIHBvZCdzIG5hbWVzcGFjZVwiLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In0sInRvcG9sb2d5S2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhpcyBwb2Qgc2hvdWxkIGJlIGNvLWxvY2F0ZWQgKGFmZmluaXR5KSBvciBub3QgY28tbG9jYXRlZCAoYW50aS1hZmZpbml0eSkgd2l0aCB0aGUgcG9kcyBtYXRjaGluZ1xudGhlIGxhYmVsU2VsZWN0b3IgaW4gdGhlIHNwZWNpZmllZCBuYW1lc3BhY2VzLCB3aGVyZSBjby1sb2NhdGVkIGlzIGRlZmluZWQgYXMgcnVubmluZyBvbiBhIG5vZGVcbndob3NlIHZhbHVlIG9mIHRoZSBsYWJlbCB3aXRoIGtleSB0b3BvbG9neUtleSBtYXRjaGVzIHRoYXQgb2YgYW55IG5vZGUgb24gd2hpY2ggYW55IG9mIHRoZVxuc2VsZWN0ZWQgcG9kcyBpcyBydW5uaW5nLlxuRW1wdHkgdG9wb2xvZ3lLZXkgaXMgbm90IGFsbG93ZWQuIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsidG9wb2xvZ3lLZXkiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifX0sInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QifSwiaW1hZ2UiOnsidHlwZSI6InN0cmluZyJ9LCJpbWFnZVB1bGxTZWNyZXRzIjp7Iml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwidHlwZSI6ImFycmF5In0sImxpbWl0cyI6eyJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IlJhdGVMaW1pdCBkZWZpbmVzIHRoZSBkZXNpcmVkIExpbWl0YWRvciBsaW1pdCIsInByb3BlcnRpZXMiOnsiY29uZGl0aW9ucyI6eyJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJtYXhfdmFsdWUiOnsidHlwZSI6ImludGVnZXIifSwibmFtZSI6eyJ0eXBlIjoic3RyaW5nIn0sIm5hbWVzcGFjZSI6eyJ0eXBlIjoic3RyaW5nIn0sInNlY29uZHMiOnsidHlwZSI6ImludGVnZXIifSwidmFyaWFibGVzIjp7Iml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJjb25kaXRpb25zIiwibWF4X3ZhbHVlIiwibmFtZXNwYWNlIiwic2Vjb25kcyIsInZhcmlhYmxlcyJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJsaXN0ZW5lciI6eyJwcm9wZXJ0aWVzIjp7ImdycGMiOnsicHJvcGVydGllcyI6eyJwb3J0Ijp7ImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifX0sInR5cGUiOiJvYmplY3QifSwiaHR0cCI6eyJwcm9wZXJ0aWVzIjp7InBvcnQiOnsiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9LCJwZGIiOnsicHJvcGVydGllcyI6eyJtYXhVbmF2YWlsYWJsZSI6eyJhbnlPZiI6W3sidHlwZSI6ImludGVnZXIifSx7InR5cGUiOiJzdHJpbmcifV0sImRlc2NyaXB0aW9uIjoiQW4gZXZpY3Rpb24gaXMgYWxsb3dlZCBpZiBhdCBtb3N0IFwibWF4VW5hdmFpbGFibGVcIiBsaW1pdGFkb3IgcG9kc1xuYXJlIHVuYXZhaWxhYmxlIGFmdGVyIHRoZSBldmljdGlvbiwgaS5lLiBldmVuIGluIGFic2VuY2Ugb2ZcbnRoZSBldmljdGVkIHBvZC4gRm9yIGV4YW1wbGUsIG9uZSBjYW4gcHJldmVudCBhbGwgdm9sdW50YXJ5IGV2aWN0aW9uc1xuYnkgc3BlY2lmeWluZyAwLiBUaGlzIGlzIGEgbXV0dWFsbHkgZXhjbHVzaXZlIHNldHRpbmcgd2l0aCBcIm1pbkF2YWlsYWJsZVwiLiIsIngta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nIjp0cnVlfSwibWluQXZhaWxhYmxlIjp7ImFueU9mIjpbeyJ0eXBlIjoiaW50ZWdlciJ9LHsidHlwZSI6InN0cmluZyJ9XSwiZGVzY3JpcHRpb24iOiJBbiBldmljdGlvbiBpcyBhbGxvd2VkIGlmIGF0IGxlYXN0IFwibWluQXZhaWxhYmxlXCIgbGltaXRhZG9yIHBvZHMgd2lsbFxuc3RpbGwgYmUgYXZhaWxhYmxlIGFmdGVyIHRoZSBldmljdGlvbiwgaS5lLiBldmVuIGluIHRoZSBhYnNlbmNlIG9mXG50aGUgZXZpY3RlZCBwb2QuICBTbyBmb3IgZXhhbXBsZSB5b3UgY2FuIHByZXZlbnQgYWxsIHZvbHVudGFyeVxuZXZpY3Rpb25zIGJ5IHNwZWNpZnlpbmcgXCIxMDAlXCIuIiwieC1rdWJlcm5ldGVzLWludC1vci1zdHJpbmciOnRydWV9fSwidHlwZSI6Im9iamVjdCJ9LCJyYXRlTGltaXRIZWFkZXJzIjp7ImRlc2NyaXB0aW9uIjoiUmF0ZUxpbWl0SGVhZGVyc1R5cGUgZGVmaW5lcyB0aGUgdmFsaWQgb3B0aW9ucyBmb3IgdGhlIC0tcmF0ZS1saW1pdC1oZWFkZXJzIGFyZyIsImVudW0iOlsiTk9ORSIsIkRSQUZUX1ZFUlNJT05fMDMiXSwidHlwZSI6InN0cmluZyJ9LCJyZXBsaWNhcyI6eyJ0eXBlIjoiaW50ZWdlciJ9LCJyZXNvdXJjZVJlcXVpcmVtZW50cyI6eyJkZXNjcmlwdGlvbiI6IlJlc291cmNlUmVxdWlyZW1lbnRzIGRlc2NyaWJlcyB0aGUgY29tcHV0ZSByZXNvdXJjZSByZXF1aXJlbWVudHMuIiwicHJvcGVydGllcyI6eyJjbGFpbXMiOnsiZGVzY3JpcHRpb24iOiJDbGFpbXMgbGlzdHMgdGhlIG5hbWVzIG9mIHJlc291cmNlcywgZGVmaW5lZCBpbiBzcGVjLnJlc291cmNlQ2xhaW1zLFxudGhhdCBhcmUgdXNlZCBieSB0aGlzIGNvbnRhaW5lci5cblxuXG5UaGlzIGlzIGFuIGFscGhhIGZpZWxkIGFuZCByZXF1aXJlcyBlbmFibGluZyB0aGVcbkR5bmFtaWNSZXNvdXJjZUFsbG9jYXRpb24gZmVhdHVyZSBnYXRlLlxuXG5cblRoaXMgZmllbGQgaXMgaW1tdXRhYmxlLiBJdCBjYW4gb25seSBiZSBzZXQgZm9yIGNvbnRhaW5lcnMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJSZXNvdXJjZUNsYWltIHJlZmVyZW5jZXMgb25lIGVudHJ5IGluIFBvZFNwZWMuUmVzb3VyY2VDbGFpbXMuIiwicHJvcGVydGllcyI6eyJuYW1lIjp7ImRlc2NyaXB0aW9uIjoiTmFtZSBtdXN0IG1hdGNoIHRoZSBuYW1lIG9mIG9uZSBlbnRyeSBpbiBwb2Quc3BlYy5yZXNvdXJjZUNsYWltcyBvZlxudGhlIFBvZCB3aGVyZSB0aGlzIGZpZWxkIGlzIHVzZWQuIEl0IG1ha2VzIHRoYXQgcmVzb3VyY2UgYXZhaWxhYmxlXG5pbnNpZGUgYSBjb250YWluZXIuIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsibmFtZSJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSIsIngta3ViZXJuZXRlcy1saXN0LW1hcC1rZXlzIjpbIm5hbWUiXSwieC1rdWJlcm5ldGVzLWxpc3QtdHlwZSI6Im1hcCJ9LCJsaW1pdHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsiYW55T2YiOlt7InR5cGUiOiJpbnRlZ2VyIn0seyJ0eXBlIjoic3RyaW5nIn1dLCJwYXR0ZXJuIjoiXihcXCt8LSk/KChbMC05XSsoXFwuWzAtOV0qKT8pfChcXC5bMC05XSspKSgoW0tNR1RQRV1pKXxbbnVta01HVFBFXXwoW2VFXShcXCt8LSk/KChbMC05XSsoXFwuWzAtOV0qKT8pfChcXC5bMC05XSspKSkpPyQiLCJ4LWt1YmVybmV0ZXMtaW50LW9yLXN0cmluZyI6dHJ1ZX0sImRlc2NyaXB0aW9uIjoiTGltaXRzIGRlc2NyaWJlcyB0aGUgbWF4aW11bSBhbW91bnQgb2YgY29tcHV0ZSByZXNvdXJjZXMgYWxsb3dlZC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvY29uZmlndXJhdGlvbi9tYW5hZ2UtcmVzb3VyY2VzLWNvbnRhaW5lcnMvIiwidHlwZSI6Im9iamVjdCJ9LCJyZXF1ZXN0cyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJhbnlPZiI6W3sidHlwZSI6ImludGVnZXIifSx7InR5cGUiOiJzdHJpbmcifV0sInBhdHRlcm4iOiJeKFxcK3wtKT8oKFswLTldKyhcXC5bMC05XSopPyl8KFxcLlswLTldKykpKChbS01HVFBFXWkpfFtudW1rTUdUUEVdfChbZUVdKFxcK3wtKT8oKFswLTldKyhcXC5bMC05XSopPyl8KFxcLlswLTldKykpKSk/JCIsIngta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nIjp0cnVlfSwiZGVzY3JpcHRpb24iOiJSZXF1ZXN0cyBkZXNjcmliZXMgdGhlIG1pbmltdW0gYW1vdW50IG9mIGNvbXB1dGUgcmVzb3VyY2VzIHJlcXVpcmVkLlxuSWYgUmVxdWVzdHMgaXMgb21pdHRlZCBmb3IgYSBjb250YWluZXIsIGl0IGRlZmF1bHRzIHRvIExpbWl0cyBpZiB0aGF0IGlzIGV4cGxpY2l0bHkgc3BlY2lmaWVkLFxub3RoZXJ3aXNlIHRvIGFuIGltcGxlbWVudGF0aW9uLWRlZmluZWQgdmFsdWUuIFJlcXVlc3RzIGNhbm5vdCBleGNlZWQgTGltaXRzLlxuTW9yZSBpbmZvOiBodHRwczovL2t1YmVybmV0ZXMuaW8vZG9jcy9jb25jZXB0cy9jb25maWd1cmF0aW9uL21hbmFnZS1yZXNvdXJjZXMtY29udGFpbmVycy8iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In0sInN0b3JhZ2UiOnsiZGVzY3JpcHRpb24iOiJTdG9yYWdlIGNvbnRhaW5zIHRoZSBvcHRpb25zIGZvciBMaW1pdGFkb3IgY291bnRlcnMgZGF0YWJhc2Ugb3IgaW4tbWVtb3J5IGRhdGEgc3RvcmFnZSIsInByb3BlcnRpZXMiOnsiZGlzayI6eyJwcm9wZXJ0aWVzIjp7Im9wdGltaXplIjp7ImRlc2NyaXB0aW9uIjoiRGlza09wdGltaXplVHlwZSBkZWZpbmVzIHRoZSB2YWxpZCBvcHRpb25zIGZvciBcIm9wdGltaXplXCIgb3B0aW9uIG9mIHRoZSBkaXNrIHBlcnNpc3RlbmNlIHR5cGUiLCJlbnVtIjpbInRocm91Z2hwdXQiLCJkaXNrIl0sInR5cGUiOiJzdHJpbmcifSwicGVyc2lzdGVudFZvbHVtZUNsYWltIjp7InByb3BlcnRpZXMiOnsicmVzb3VyY2VzIjp7ImRlc2NyaXB0aW9uIjoiUmVzb3VyY2VzIHJlcHJlc2VudHMgdGhlIG1pbmltdW0gcmVzb3VyY2VzIHRoZSB2b2x1bWUgc2hvdWxkIGhhdmUuXG5JZ25vcmVkIHdoZW4gVm9sdW1lTmFtZSBmaWVsZCBpcyBzZXQiLCJwcm9wZXJ0aWVzIjp7InJlcXVlc3RzIjp7ImFueU9mIjpbeyJ0eXBlIjoiaW50ZWdlciJ9LHsidHlwZSI6InN0cmluZyJ9XSwiZGVzY3JpcHRpb24iOiJTdG9yYWdlIFJlc291cmNlIHJlcXVlc3RzIHRvIGJlIHVzZWQgb24gdGhlIFBlcnNpc3RlbnRWb2x1bWVDbGFpbS5cblRvIGxlYXJuIG1vcmUgYWJvdXQgcmVzb3VyY2UgcmVxdWVzdHMgc2VlOlxuaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvY29uZmlndXJhdGlvbi9tYW5hZ2UtcmVzb3VyY2VzLWNvbnRhaW5lcnMvIiwicGF0dGVybiI6Il4oXFwrfC0pPygoWzAtOV0rKFxcLlswLTldKik/KXwoXFwuWzAtOV0rKSkoKFtLTUdUUEVdaSl8W251bWtNR1RQRV18KFtlRV0oXFwrfC0pPygoWzAtOV0rKFxcLlswLTldKik/KXwoXFwuWzAtOV0rKSkpKT8kIiwieC1rdWJlcm5ldGVzLWludC1vci1zdHJpbmciOnRydWV9fSwicmVxdWlyZWQiOlsicmVxdWVzdHMiXSwidHlwZSI6Im9iamVjdCJ9LCJzdG9yYWdlQ2xhc3NOYW1lIjp7InR5cGUiOiJzdHJpbmcifSwidm9sdW1lTmFtZSI6eyJkZXNjcmlwdGlvbiI6IlZvbHVtZU5hbWUgaXMgdGhlIGJpbmRpbmcgcmVmZXJlbmNlIHRvIHRoZSBQZXJzaXN0ZW50Vm9sdW1lIGJhY2tpbmcgdGhpcyBjbGFpbS4iLCJ0eXBlIjoic3RyaW5nIn19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In0sInJlZGlzIjp7InByb3BlcnRpZXMiOnsiY29uZmlnU2VjcmV0UmVmIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifX0sInR5cGUiOiJvYmplY3QifSwicmVkaXMtY2FjaGVkIjp7InByb3BlcnRpZXMiOnsiY29uZmlnU2VjcmV0UmVmIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwib3B0aW9ucyI6eyJwcm9wZXJ0aWVzIjp7ImJhdGNoLXNpemUiOnsiZGVzY3JpcHRpb24iOiJCYXRjaFNpemUgZGVmaW5lcyB0aGUgc2l6ZSBvZiBlbnRyaWVzIHRvIGZsdXNoIGluIGFzIHNpbmdsZSBmbHVzaCBbZGVmYXVsdDogMTAwXSIsInR5cGUiOiJpbnRlZ2VyIn0sImZsdXNoLXBlcmlvZCI6eyJkZXNjcmlwdGlvbiI6IkZsdXNoUGVyaW9kIGZvciBjb3VudGVycyBpbiBtaWxsaXNlY29uZHMgW2RlZmF1bHQ6IDEwMDBdIiwidHlwZSI6ImludGVnZXIifSwibWF4LWNhY2hlZCI6eyJkZXNjcmlwdGlvbiI6Ik1heENhY2hlZCByZWZlcnMgdG8gdGhlIG1heGltdW0gYW1vdW50IG9mIGNvdW50ZXJzIGNhY2hlZCBbZGVmYXVsdDogMTAwMDBdIiwidHlwZSI6ImludGVnZXIifSwicmVzcG9uc2UtdGltZW91dCI6eyJkZXNjcmlwdGlvbiI6IlJlc3BvbnNlVGltZW91dCBkZWZpbmVzIHRoZSB0aW1lb3V0IGZvciBSZWRpcyBjb21tYW5kcyBpbiBtaWxsaXNlY29uZHMgW2RlZmF1bHQ6IDM1MF0iLCJ0eXBlIjoiaW50ZWdlciJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9LCJ0ZWxlbWV0cnkiOnsiZGVzY3JpcHRpb24iOiJUZWxlbWV0cnkgZGVmaW5lcyB0aGUgbGV2ZWwgb2YgbWV0cmljcyBMaW1pdGFkb3Igd2lsbCBleHBvc2UgdG8gdGhlIHVzZXIiLCJlbnVtIjpbImJhc2ljIiwiZXhoYXVzdGl2ZSJdLCJ0eXBlIjoic3RyaW5nIn0sInRyYWNpbmciOnsicHJvcGVydGllcyI6eyJlbmRwb2ludCI6eyJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJlbmRwb2ludCJdLCJ0eXBlIjoib2JqZWN0In0sInZlcmJvc2l0eSI6eyJkZXNjcmlwdGlvbiI6IlNldHMgdGhlIGxldmVsIG9mIHZlcmJvc2l0eSIsIm1heGltdW0iOjQsIm1pbmltdW0iOjEsInR5cGUiOiJpbnRlZ2VyIn0sInZlcnNpb24iOnsiZGVzY3JpcHRpb24iOiJbRGVwcmVjYXRlZF0gVXNlIHNwZWMuaW1hZ2UgaW5zdGVhZC5cbiBEb2NrZXIgdGFnIHVzZWQgYXMgbGltaXRhZG9yIGltYWdlLiBUaGUgcmVwbyBpcyBoYXJkY29kZWQgdG8gcXVheS5pby9rdWFkcmFudC9saW1pdGFkb3IiLCJ0eXBlIjoic3RyaW5nIn19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLXZhbGlkYXRpb25zIjpbeyJtZXNzYWdlIjoiZGlzayBzdG9yYWdlIGRvZXMgbm90IGFsbG93IG11bHRpcGxlIHJlcGxpY2FzIiwicnVsZSI6IighaGFzKHNlbGYuc3RvcmFnZSkgfHwgIWhhcyhzZWxmLnN0b3JhZ2UuZGlzaykpIHx8ICghaGFzKHNlbGYucmVwbGljYXMpIHx8IHNlbGYucmVwbGljYXMgXHUwMDNjIDIpIn1dfSwic3RhdHVzIjp7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yU3RhdHVzIGRlZmluZXMgdGhlIG9ic2VydmVkIHN0YXRlIG9mIExpbWl0YWRvciIsInByb3BlcnRpZXMiOnsiY29uZGl0aW9ucyI6eyJkZXNjcmlwdGlvbiI6IlJlcHJlc2VudHMgdGhlIG9ic2VydmF0aW9ucyBvZiBhIGZvbydzIGN1cnJlbnQgc3RhdGUuXG5Lbm93biAuc3RhdHVzLmNvbmRpdGlvbnMudHlwZSBhcmU6IFwiUmVhZHlcIiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQ29uZGl0aW9uIGNvbnRhaW5zIGRldGFpbHMgZm9yIG9uZSBhc3BlY3Qgb2YgdGhlIGN1cnJlbnQgc3RhdGUgb2YgdGhpcyBBUEkgUmVzb3VyY2UuXG4tLS1cblRoaXMgc3RydWN0IGlzIGludGVuZGVkIGZvciBkaXJlY3QgdXNlIGFzIGFuIGFycmF5IGF0IHRoZSBmaWVsZCBwYXRoIC5zdGF0dXMuY29uZGl0aW9ucy4gIEZvciBleGFtcGxlLFxuXG5cblx0dHlwZSBGb29TdGF0dXMgc3RydWN0e1xuXHQgICAgLy8gUmVwcmVzZW50cyB0aGUgb2JzZXJ2YXRpb25zIG9mIGEgZm9vJ3MgY3VycmVudCBzdGF0ZS5cblx0ICAgIC8vIEtub3duIC5zdGF0dXMuY29uZGl0aW9ucy50eXBlIGFyZTogXCJBdmFpbGFibGVcIiwgXCJQcm9ncmVzc2luZ1wiLCBhbmQgXCJEZWdyYWRlZFwiXG5cdCAgICAvLyArcGF0Y2hNZXJnZUtleT10eXBlXG5cdCAgICAvLyArcGF0Y2hTdHJhdGVneT1tZXJnZVxuXHQgICAgLy8gK2xpc3RUeXBlPW1hcFxuXHQgICAgLy8gK2xpc3RNYXBLZXk9dHlwZVxuXHQgICAgQ29uZGl0aW9ucyBbXW1ldGF2MS5Db25kaXRpb24gYGpzb246XCJjb25kaXRpb25zLG9taXRlbXB0eVwiIHBhdGNoU3RyYXRlZ3k6XCJtZXJnZVwiIHBhdGNoTWVyZ2VLZXk6XCJ0eXBlXCIgcHJvdG9idWY6XCJieXRlcywxLHJlcCxuYW1lPWNvbmRpdGlvbnNcImBcblxuXG5cdCAgICAvLyBvdGhlciBmaWVsZHNcblx0fSIsInByb3BlcnRpZXMiOnsibGFzdFRyYW5zaXRpb25UaW1lIjp7ImRlc2NyaXB0aW9uIjoibGFzdFRyYW5zaXRpb25UaW1lIGlzIHRoZSBsYXN0IHRpbWUgdGhlIGNvbmRpdGlvbiB0cmFuc2l0aW9uZWQgZnJvbSBvbmUgc3RhdHVzIHRvIGFub3RoZXIuXG5UaGlzIHNob3VsZCBiZSB3aGVuIHRoZSB1bmRlcmx5aW5nIGNvbmRpdGlvbiBjaGFuZ2VkLiAgSWYgdGhhdCBpcyBub3Qga25vd24sIHRoZW4gdXNpbmcgdGhlIHRpbWUgd2hlbiB0aGUgQVBJIGZpZWxkIGNoYW5nZWQgaXMgYWNjZXB0YWJsZS4iLCJmb3JtYXQiOiJkYXRlLXRpbWUiLCJ0eXBlIjoic3RyaW5nIn0sIm1lc3NhZ2UiOnsiZGVzY3JpcHRpb24iOiJtZXNzYWdlIGlzIGEgaHVtYW4gcmVhZGFibGUgbWVzc2FnZSBpbmRpY2F0aW5nIGRldGFpbHMgYWJvdXQgdGhlIHRyYW5zaXRpb24uXG5UaGlzIG1heSBiZSBhbiBlbXB0eSBzdHJpbmcuIiwibWF4TGVuZ3RoIjozMjc2OCwidHlwZSI6InN0cmluZyJ9LCJvYnNlcnZlZEdlbmVyYXRpb24iOnsiZGVzY3JpcHRpb24iOiJvYnNlcnZlZEdlbmVyYXRpb24gcmVwcmVzZW50cyB0aGUgLm1ldGFkYXRhLmdlbmVyYXRpb24gdGhhdCB0aGUgY29uZGl0aW9uIHdhcyBzZXQgYmFzZWQgdXBvbi5cbkZvciBpbnN0YW5jZSwgaWYgLm1ldGFkYXRhLmdlbmVyYXRpb24gaXMgY3VycmVudGx5IDEyLCBidXQgdGhlIC5zdGF0dXMuY29uZGl0aW9uc1t4XS5vYnNlcnZlZEdlbmVyYXRpb24gaXMgOSwgdGhlIGNvbmRpdGlvbiBpcyBvdXQgb2YgZGF0ZVxud2l0aCByZXNwZWN0IHRvIHRoZSBjdXJyZW50IHN0YXRlIG9mIHRoZSBpbnN0YW5jZS4iLCJmb3JtYXQiOiJpbnQ2NCIsIm1pbmltdW0iOjAsInR5cGUiOiJpbnRlZ2VyIn0sInJlYXNvbiI6eyJkZXNjcmlwdGlvbiI6InJlYXNvbiBjb250YWlucyBhIHByb2dyYW1tYXRpYyBpZGVudGlmaWVyIGluZGljYXRpbmcgdGhlIHJlYXNvbiBmb3IgdGhlIGNvbmRpdGlvbidzIGxhc3QgdHJhbnNpdGlvbi5cblByb2R1Y2VycyBvZiBzcGVjaWZpYyBjb25kaXRpb24gdHlwZXMgbWF5IGRlZmluZSBleHBlY3RlZCB2YWx1ZXMgYW5kIG1lYW5pbmdzIGZvciB0aGlzIGZpZWxkLFxuYW5kIHdoZXRoZXIgdGhlIHZhbHVlcyBhcmUgY29uc2lkZXJlZCBhIGd1YXJhbnRlZWQgQVBJLlxuVGhlIHZhbHVlIHNob3VsZCBiZSBhIENhbWVsQ2FzZSBzdHJpbmcuXG5UaGlzIGZpZWxkIG1heSBub3QgYmUgZW1wdHkuIiwibWF4TGVuZ3RoIjoxMDI0LCJtaW5MZW5ndGgiOjEsInBhdHRlcm4iOiJeW0EtWmEtel0oW0EtWmEtejAtOV8sOl0qW0EtWmEtejAtOV9dKT8kIiwidHlwZSI6InN0cmluZyJ9LCJzdGF0dXMiOnsiZGVzY3JpcHRpb24iOiJzdGF0dXMgb2YgdGhlIGNvbmRpdGlvbiwgb25lIG9mIFRydWUsIEZhbHNlLCBVbmtub3duLiIsImVudW0iOlsiVHJ1ZSIsIkZhbHNlIiwiVW5rbm93biJdLCJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOnsiZGVzY3JpcHRpb24iOiJ0eXBlIG9mIGNvbmRpdGlvbiBpbiBDYW1lbENhc2Ugb3IgaW4gZm9vLmV4YW1wbGUuY29tL0NhbWVsQ2FzZS5cbi0tLVxuTWFueSAuY29uZGl0aW9uLnR5cGUgdmFsdWVzIGFyZSBjb25zaXN0ZW50IGFjcm9zcyByZXNvdXJjZXMgbGlrZSBBdmFpbGFibGUsIGJ1dCBiZWNhdXNlIGFyYml0cmFyeSBjb25kaXRpb25zIGNhbiBiZVxudXNlZnVsIChzZWUgLm5vZGUuc3RhdHVzLmNvbmRpdGlvbnMpLCB0aGUgYWJpbGl0eSB0byBkZWNvbmZsaWN0IGlzIGltcG9ydGFudC5cblRoZSByZWdleCBpdCBtYXRjaGVzIGlzIChkbnMxMTIzU3ViZG9tYWluRm10Lyk/KHF1YWxpZmllZE5hbWVGbXQpIiwibWF4TGVuZ3RoIjozMTYsInBhdHRlcm4iOiJeKFthLXowLTldKFstYS16MC05XSpbYS16MC05XSk/KFxcLlthLXowLTldKFstYS16MC05XSpbYS16MC05XSk/KSovKT8oKFtBLVphLXowLTldWy1BLVphLXowLTlfLl0qKT9bQS1aYS16MC05XSkkIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsibGFzdFRyYW5zaXRpb25UaW1lIiwibWVzc2FnZSIsInJlYXNvbiIsInN0YXR1cyIsInR5cGUiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkiLCJ4LWt1YmVybmV0ZXMtbGlzdC1tYXAta2V5cyI6WyJ0eXBlIl0sIngta3ViZXJuZXRlcy1saXN0LXR5cGUiOiJtYXAifSwib2JzZXJ2ZWRHZW5lcmF0aW9uIjp7ImRlc2NyaXB0aW9uIjoiT2JzZXJ2ZWRHZW5lcmF0aW9uIHJlZmxlY3RzIHRoZSBnZW5lcmF0aW9uIG9mIHRoZSBtb3N0IHJlY2VudGx5IG9ic2VydmVkIHNwZWMuIiwiZm9ybWF0IjoiaW50NjQiLCJ0eXBlIjoiaW50ZWdlciJ9LCJzZXJ2aWNlIjp7ImRlc2NyaXB0aW9uIjoiU2VydmljZSBwcm92aWRlcyBpbmZvcm1hdGlvbiBhYm91dCB0aGUgc2VydmljZSBleHBvc2luZyBsaW1pdGFkb3IgQVBJIiwicHJvcGVydGllcyI6eyJob3N0Ijp7InR5cGUiOiJzdHJpbmcifSwicG9ydHMiOnsicHJvcGVydGllcyI6eyJncnBjIjp7ImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifSwiaHR0cCI6eyJmb3JtYXQiOiJpbnQzMiIsInR5cGUiOiJpbnRlZ2VyIn19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJzZXJ2ZWQiOnRydWUsInN0b3JhZ2UiOnRydWUsInN1YnJlc291cmNlcyI6eyJzdGF0dXMiOnt9fX1dfSwic3RhdHVzIjp7ImFjY2VwdGVkTmFtZXMiOnsia2luZCI6IiIsInBsdXJhbCI6IiJ9LCJjb25kaXRpb25zIjpudWxsLCJzdG9yZWRWZXJzaW9ucyI6bnVsbH19
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsiYWxtLWV4YW1wbGVzIjoiW1xuICB7XG4gICAgXCJhcGlWZXJzaW9uXCI6IFwibGltaXRhZG9yLmt1YWRyYW50LmlvL3YxYWxwaGExXCIsXG4gICAgXCJraW5kXCI6IFwiTGltaXRhZG9yXCIsXG4gICAgXCJtZXRhZGF0YVwiOiB7XG4gICAgICBcIm5hbWVcIjogXCJsaW1pdGFkb3Itc2FtcGxlXCJcbiAgICB9LFxuICAgIFwic3BlY1wiOiB7XG4gICAgICBcImxpbWl0c1wiOiBbXG4gICAgICAgIHtcbiAgICAgICAgICBcImNvbmRpdGlvbnNcIjogW1xuICAgICAgICAgICAgXCJnZXRfdG95ID09ICd5ZXMnXCJcbiAgICAgICAgICBdLFxuICAgICAgICAgIFwibWF4X3ZhbHVlXCI6IDIsXG4gICAgICAgICAgXCJuYW1lXCI6IFwidG95X2dldF9yb3V0ZVwiLFxuICAgICAgICAgIFwibmFtZXNwYWNlXCI6IFwidG95c3RvcmUtYXBwXCIsXG4gICAgICAgICAgXCJzZWNvbmRzXCI6IDMwLFxuICAgICAgICAgIFwidmFyaWFibGVzXCI6IFtdXG4gICAgICAgIH1cbiAgICAgIF0sXG4gICAgICBcImxpc3RlbmVyXCI6IHtcbiAgICAgICAgXCJncnBjXCI6IHtcbiAgICAgICAgICBcInBvcnRcIjogODA4MVxuICAgICAgICB9LFxuICAgICAgICBcImh0dHBcIjoge1xuICAgICAgICAgIFwicG9ydFwiOiA4MDgwXG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9XG4gIH1cbl0iLCJjYXBhYmlsaXRpZXMiOiJCYXNpYyBJbnN0YWxsIiwiY2F0ZWdvcmllcyI6IkludGVncmF0aW9uIFx1MDAyNiBEZWxpdmVyeSIsImNvbnRhaW5lckltYWdlIjoicmVnaXN0cnkucmVkaGF0LmlvL3JoY2wtMS9saW1pdGFkb3ItcmhlbDktb3BlcmF0b3JAc2hhMjU2OmIzMWJhMjkzODEyNzg4ZGM3ZTIxYzE0NzAzYWM2MWZkZDViZmYwMTA5NDhhZGEzMzcxNTU0NGJhNTA3ODUxZjciLCJjcmVhdGVkQXQiOiIyMyBTZXAgMjAyNSwgMTI6MTkiLCJkZXNjcmlwdGlvbiI6IkVuYWJsZXMgcmF0ZSBsaW1pdGluZyBmb3IgR2F0ZXdheXMgYW5kIGFwcGxpY2F0aW9ucyBpbiBhIEdhdGV3YXkgQVBJIG5ldHdvcmsiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2NuZiI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby9jbmkiOiJmYWxzZSIsImZlYXR1cmVzLm9wZXJhdG9ycy5vcGVuc2hpZnQuaW8vY3NpIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2Rpc2Nvbm5lY3RlZCI6InRydWUiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2ZpcHMtY29tcGxpYW50IjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Byb3h5LWF3YXJlIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Rscy1wcm9maWxlcyI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby90b2tlbi1hdXRoLWF3cyI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby90b2tlbi1hdXRoLWF6dXJlIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Rva2VuLWF1dGgtZ2NwIjoiZmFsc2UiLCJvcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3ZhbGlkLXN1YnNjcmlwdGlvbiI6IltcIlJlZCBIYXQgQ29ubmVjdGl2aXR5IExpbmtcIl0iLCJvcGVyYXRvcnMub3BlcmF0b3JmcmFtZXdvcmsuaW8vYnVpbGRlciI6Im9wZXJhdG9yLXNkay12MS4zMi4wIiwib3BlcmF0b3JzLm9wZXJhdG9yZnJhbWV3b3JrLmlvL3Byb2plY3RfbGF5b3V0IjoiZ28ua3ViZWJ1aWxkZXIuaW8vdjMiLCJyZXBvc2l0b3J5IjoiaHR0cHM6Ly9naXRodWIuY29tL2t1YWRyYW50L2xpbWl0YWRvci1vcGVyYXRvciIsInN1cHBvcnQiOiJrdWFkcmFudCJ9LCJsYWJlbHMiOnsib3BlcmF0b3JmcmFtZXdvcmsuaW8vb3MubGludXgiOiJzdXBwb3J0ZWQifSwibmFtZSI6ImxpbWl0YWRvci1vcGVyYXRvci52MS4xLjEiLCJuYW1lc3BhY2UiOiJwbGFjZWhvbGRlciJ9LCJzcGVjIjp7ImFwaXNlcnZpY2VkZWZpbml0aW9ucyI6e30sImN1c3RvbXJlc291cmNlZGVmaW5pdGlvbnMiOnsib3duZWQiOlt7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yIGlzIHRoZSBTY2hlbWEgZm9yIHRoZSBsaW1pdGFkb3JzIEFQSSIsImRpc3BsYXlOYW1lIjoiTGltaXRhZG9yIiwia2luZCI6IkxpbWl0YWRvciIsIm5hbWUiOiJsaW1pdGFkb3JzLmxpbWl0YWRvci5rdWFkcmFudC5pbyIsInZlcnNpb24iOiJ2MWFscGhhMSJ9XX0sImRlc2NyaXB0aW9uIjoiVGhlIExpbWl0YWRvciBvcGVyYXRvciBpbnN0YWxscyBhbmQgbWFpbnRhaW5zIGxpbWl0YWRvciBpbnN0YW5jZXMiLCJkaXNwbGF5TmFtZSI6IkxpbWl0YWRvciIsImljb24iOlt7ImJhc2U2NGRhdGEiOiJpVkJPUncwS0dnb0FBQUFOU1VoRVVnQUFBWHdBQUFGOENBWUFBQURNNXdES0FBQUFDWEJJV1hNQUFHNjZBQUJ1dWdIVzNyRVhBQUFnQUVsRVFWUjRuTzNkZjJ6VDE3My84VGNRbDhRRTI4T0FETVVrc0lrb0lWbmNhRlNEUmpmNWE1cGEzWkpxZjFTcjdsZGswdjRvdXQ4Sjc0K3BXeldKSU8xMlEvc25hSnJhUHlZVmRMOXF0VCttaG43VmFkby9KVmZRVG1OcUhTV0FFcTJRa0FJV0VHb2JFNXZhbFB1SEU2QWRGSC9PT1o5Zi9qd2ZValhwWG81OVZLa3ZIODU1bi9kWmNmZnVYUUVBTkw2VmJrOEFBT0FNQWg4QUFvTEFCNENBSVBBQklDQUlmQUFJQ0FJZkFBS0N3QWVBZ0NEd0FTQWdDSHdBQ0lnbXR5ZlFxTHE2dXZwWHJWcjFuVkFvTkxCeTVjcHZORGMzZDZ4YXRhcFpSQ1FhamNiY25oL2d0bncrbnhNUnVYUG5UcmxjTGs5LzhjVVhuMVVxbGZFN2QrNzg0K3pac3lmZG5sOGpXa0ZyQlgwOVBUM3BWYXRXZmIrbHBlVmJMUzB0bTF0YlcxdmNuaFBnZDhWaXNWUXFsUzdmdm4xN3NsS3BqRTlPVG82NlBTZS9JL0F0NnV6c2JIdmlpU2RlWHIxNjlmZGJXMXM3Q0hmQU9jVmlzVlFzRnFkdjM3NzlsODgvLy95TmMrZk96Yms5Sno4aDhPdlEzZDM5WW5OejgvNUlKUEkwQVE5NFI3RllMQlVLaGIrWHkrWFhwNmFtL3VqMmZMeU93SCtFN3U3dUY4UGg4TTlqc1ZoM2MzTXpaeDJBeDVYTDVXb3VsNXRhWEZ6OERlSC9jQVQrQTdxNnV2ckQ0ZkN2MXExYjl3d2hEL2hYdVZ5dTNyaHg0OVRpNHVJdk9RQytqOEFYa1ZRcTlZZG9OUG9EcW1lQXhwUFA1M1A1ZlA1UG1Vem14MjdQeFcyQkRmek96czYyTld2V0hHTTFEd1REOHFyLzFxMWIrNEo2MkJ1NHdPL3E2dXB2YlczOTNmcjE2M3VibXBwV3VEMGZBTTZxVnF0M3IxKy9QbEVzRm44U3RPMmV3QVIrVjFkWGZ6UWFQYnBodzRadnVqMFhBTjV3N2RxMVQvTDUvSEJRZ3IvaEEzOTU2MmJ6NXMwRGJzOEZnRGRkdm54NVBBaGJQUTBkK0gxOWZlOGtFb205Yk4wQWVKeHF0WG8zbTgwZS8raWpqMTV3ZXk1MmFjakE3K25wU1cvYXRPbTNYajJNclZRcVVpZ1VIdnIvVzFoWWNIZzJnSDNpOGZoRC8rK1JTRVJDb1pERHM2bFB1Vnl1WHJseTVXZU4yTXFob1FLL3M3T3pMUjZQLzIzZHVuVUp0K2RTS0JSa2NYRlJDb1dDNVBQNWV5RmZxVlRjbmhyZ0dhRlE2Rjc0UjZOUmlVUWlFZzZISlJLSnVEMDF1WEhqUm5aaFllRzdqYlROMHpDQjcrYjJUYWxVa3V2WHI5OExkMWJwZ0w1NFBIN3ZSMkQ5K3ZYUzB1SjhWNU5HMitieGZlQjNkbmEyYmR5NE1lUDBwYWxzTmlzTEN3dVN6V1psY1hIUnlhOEdBaWtjRGtzaWtaQjRQQzZKaExOL2ljL244N21yVjYrbS9MN2E5M1hnOS9iMi92ckpKNTk4eFlsVmZhVlNrV3cyZSs4ZkFPNUtKQkwzL25IaVBLQmFyZDY5ZE9uUzRZbUppVi9ZL21VMjhXWGdkM1oydHExZHUzWXNrVWlrN1A2dTVZQ2ZuNSszKzZzQUtFb21rL2ZDMzI3WmJEWno4K2JOSVQrdTluMFgrRjFkWGYySlJPS3ZkcllwcmxRcWN1SENCWm1mbjJlN0J2Q1JjRGdzeVdSU3RtM2JadXVxdjFnc2xyTFo3UGY4ZG1ITFY0RnY5eFpPcVZTUzZlbHBWdk5BQTBnbWs5TFIwV0hiWWE4ZnQzaDhFL2g5ZlgzdmJObXlaY2lPejE1WVdKRHo1OCt6Tnc4MG9FUWlJZHUzYjMva25RQmRuMzc2NlpoZnFuaDhFZmk3ZCsvK3B4MDljRXFsa256ODhjZVVVUUlCRUkvSDVhbW5uckpseFgvdDJyVlBQdnp3dzI4Wi8yRERQQjM0ZHBWY1Zpb1ZPWFBtREZzM1FBQWxrMG5adVhPbjhUMStQNVJ1ZWpid096czcyelp0Mm5UTzlPSHN6TXlNbkQ5L25odXZRSUNGUWlIWnZuMjc3Tml4dytqbkZvdkYwcFVyVnpxOUd2cWVEUHlubjM3NjI2MnRyWDh6R2ZZTEN3c3lOVFgxeUI0MkFJSW5Fb2xJZDNlMzBmMTlMNGUrNXdLL3U3djd4YTFidDc1dHFoS25VcW5jVzlVRHdNTXNyL1pOYmZOVXE5VzdGeTllL0tIWEhsUDNWT0NiRHZ0Q29TQ25UNSttbGg3QVk0WERZZG0xYTVleHhtMWVESDNQQlA2V0xWdSsvZTF2Znp0akt1eG5abVprZW5yYXhFY0JDSkNPamc1amUvdlZhdlh1aFFzWHRubGxlOGNUZ1cveWdMWlNxY2pwMDZjcHRRU2dMQjZQeTY1ZHU0eHM4WGhwVDkvMXdEY1o5b1ZDUVQ3NDRBTXFjQUJvQzRWQ3NtZlBIaU5iUEY0Si9aVnVmcm1JeU1hTkd6TW13bjUrZmw3R3g4Y0pld0JHVkNvVkdSOGZOM0pmcDdXMXRXWGp4bzBaQTlQUzRtcmc3OTY5KzU4bUxsWE56TXhJSnVQNnYwc0FEU2lUeWNqTXpJejI1MFNqMGRqdTNidi9hV0JLeWx3TC9MNit2bmRNdEV2SVpESWN6Z0t3MWZUMHRKRkY1WVlORzc3WjE5ZjNqb0VwS1hFbDhIdDdlMyt0MndpdFVxbElKcE9oUFFJQVI4elB6MHNtazlIZU50NnlaY3RRYjIvdnJ3MU55eExIRDIyN3VycjYyOXZiLzBlbi9MSlNxY2dISDN6QXJWa0Fqb3RFSXJKbnp4NnRDcDVxdFhwM2RuYjIzNXp1cCsvb0NyK3pzN010a1VqOGxiQUg0RmNtcWdHYm1wcFdKQktKdjNaMmRyWVpuTnBqT1JyNGE5ZXVIZE9weUNIc0FYaUJpZEJ2YlcxdFdidDI3WmpCYVQyV1k0SGYyOXY3YTkwM2FNK2NPVVBZQS9DRVFxRWdaODZjMGZxTVJDS1JjbkkvMzVFOS9NN096clp0MjdaZDBObks0WUFXZ0JjbGswbEpwZFRYc2s2MlgzQmtoYjl4NDBhdEhqa3pNek9FUFFCUG1wK2YxNnJUYjJwcVd1SFVwU3piQTcrdnIrOGRuY3RWOC9QejFOa0Q4TFRwNldtdFJXazBHbzA1VVo5dmErQXZWZVhzVlIxZktCUzRRUXZBRnpLWmpOWVpZeUtSMkd0MzFZNnRnUitQeC8rbXVwV3pYSkVEQUg2aFU3blQxTlMwSWg2UC84M3dsTDdFdHNEdjZlbEpyMXUzTHFFNi92VHAwelJDQStBcnkrM1pWYTFidHk3UjA5T1ROamlsTDdFdDhEZHQydlJiMWJFek16UDBzd2ZnU3dzTEMxcUh1RHJaK1RpMkJINWZYOTg3emMzTlRTcGpDNFVDaDdRQWZHMTZlbHA1UDcrNXVibkpyZ05jNDRHdmMxQ3IrOWNoQVBBS25XMXB1dzV3alFmK21qVnJqcWtlMU03TXpQRGdPSUNHc0xpNHFMeTEwOVRVdEdMTm1qWEhERS9KYk9CM2RYWDFiOTY4ZVVCbDdNTENncHcvZjk3a2RBREFWZWZQbjFjK2o5eThlZk5BVjFkWHY4bjVHQTM4YURSNlZIWHMxTlNVd1prQWdEZm9aSnRPcGo2TXNjRHY2dXJxVjMzQmFtWm1ocVpvQUJwU29WQlEzdHJac0dIRE4wMnU4bzBGZm10cjYrOVV4bFVxRmJaeUFEUzA4K2ZQS3gvZ3FtYnJ3eGdKL003T3pyYjE2OWYzcW93OWMrWU1GNndBTkxSS3BhTGNTbm45K3ZXOXBpcDJqQVMrYW1WT3FWU2lDeWFBUUppZm41ZFNxV1I1bk1tS0hTT0J2MjdkdW1kVXhuMzg4Y2Ntdmg0QWZFRTE4MVF6OXF1MEF6K1ZTdjFCNVZidHdzSUM3Uk1BQklwcTdqVTNOemVsVXFrLzZINi9kdUJIbzlFZnFJempvQlpBRUtsbW4ycldQa2dyOEx1NnV2cFZIamNwbFVxU3pXWjF2aG9BZkNtYnpTcnQ1VWVqMFpodWlhWlc0SWZENFYrcGpLTTVHb0FnVTgxQTFjeGRwaFg0S2djSmxVcUZ5aHdBZ1RZL1A2OVVqcTU3ZUtzYytOM2QzUytxSE5aZXVIQkI5U3NCb0dHb1pHRnpjM05UZDNmM2k2cmZxUno0NFhENDV5cmpXTjBEZ0hvV3FtYXZpRWJneDJLeGJxdGpzdGtzN1k4QlFHcnRrMVdLVjFTeWQ1bFM0S3R1NTFDWkF3RDNxV1NpenJhT1V1QTNOemZ2dHpxR3cxb0ErRExWdzF1VkRCWlJEUHhJSlBLMDFUR3M3Z0hnWDZsa28wb0dpeWdFZm1kbloxdHJhMnVMMVhFRVBnRDhLNVZzYkcxdGJWSHBvR2s1OEo5NDRvbVhyWTRSSWZBQjRHRlVzMUVsaXkwSC91clZxNzl2ZFF4aER3Q1BwcEtSS2xsc09mQmJXMXM3ckk2aEt5WUFQSnBLUnFwa3NVcmdzMzhQQUFhcDd1TmJIV01wOEh0NmV0Sld2NkJVS25IWkNnQyt4dUxpb2xJSFRhdVpiQ253VzFwYUxPOFpYYjkrM2VvUUFBZ2NsYXdNaFVJRFZ2NjhwY0JmdFdyVnQ2eE5SNlJRS0ZnZEFnQ0JvNUtWcTFldjdySHk1NjJ1OERkYm00NUlQcCszT2dRQUFrY2xLNjFtc3FYQVZ6a2tvRUlIQUI1UHNWTEhVaWJYSGZncVQydXhuUU1BOVZQSlRDdlpYSGZncjFxMTZqdFdKMEoxRGdEVVR5VXpyV1J6M1lGdjlUUlloQlUrQUZpaGtwbFdzcm51d0YrNWN1VTNyRTZFQTFzQXFKOUtabHJKNXJvRHY3bTUyZkkxWHBVK3p3QVFWSXE5OGV2T1ppdDcrTTFXSjhLV0RnRFVUeVV6cldTejhwdTI5V0NGRHdEMXN6c3o2dzc4YURRYXMvTEJoRDBBV0djMU82MWtzMjByZkxaekFNQTZPN1BUMWkwZEFJQjNFUGdBRUJBRVBnQUVCSUVQQUFGUlYrQS8vL3p6N1ZZL21Db2RBSERHaWhVcjJ1djVjM1VGL3J2dnZqdHJkUUpVNlFDQWRTcnRGZTdldlR0Yno1OWpTd2NBUEtSYXJkcjIyUVErQUFRRWdROEFBVUhnQTBCQUVQZ0FFQkFFUGdBRUJJRVBBQUZCNEFOQVFCRDRBQkFRQkQ0QUJBU0JEd0FCUWVBRFFFQVErQUFRRUFRK0FBUUVnUThBQVVIZ0EwQkFFUGdBRUJBRVBnQUVCSUVQQUFGQjRBTkFRQkQ0QUJBUUJENEFCRVNUMnhPQW5sZ3NKcWxVeXUxcGFEdHg0b1NyMzk4aklsRlhaK0I5a3lLU2Qzc1MwRUxnKzFRc0ZwUFIwVkhadDIrZjIxTXhZbTV1VGtaR1J1VG8wYU9PZnU5ekl2S2FpQ1FkL1ZiL2VsdEVYaFdDMzYvWTB2R2hXQ3dtSjA2Y2FKaXdGeEZwYTJ1VE45OTgwOUhBZjBWRS9sc0lleXQrS0NML1gvamJrRjhSK0Q0ME5qWW12YjI5YmsvREZ2djI3Wk9ob1NIYnYrYzVxUVUrck9zV2tmL245aVNnaE1EM21hR2hJUmtZR0hCN0dyWWFIUjIxL1R0ZXMvMGJHdHN6VXZ2UmhMOFErRDZ5dkcvZjZOcmEybVJ3Y05DMnozOUYyTVl4Z1I5Ti95SHdmU1NkVGt0Ylc1dmIwL0MxcUlqc2Qzc1NEU0lwYkl2NURZSHZFKzN0N1pKT3A5MmVodSs5SmlJUnR5ZlJRUGFMeUZhM0o0RzZFZmcrTVRJeUl0RW90UkU2K3FWV1pRSnpJc0lxMzA4SWZCOFlIQnhzcUJMTXg1bWJtN1BsSWhiQlpJOGZTdTNIRk41SDRQdkF5TWlJMjFOd2xCMWJWeTlKcmJJRTl1REgxQjhJZkk4YkhoNXUrRExNQngwN2Rrekd4c2FNZm1aVUNDUzdQU08xSDFWNEc0SHZZVUVwd3hTcGJlTzg4TUlMTWp3OGJQeXpYeGJLTUozd21uQUQxK3ZvcGVOaDZYUmErYUQyUnovNmtjek96cHFka0kzc2FwNjJWZFRMTUUrSnlHR0RjL0dMSGhINUw0VnhFYW45dUFieDM1bGZFUGdlMWQ3ZUxnY1BIbFFhT3o0KzduZ1RNcS9TS2NOOFZXb2RJb1BtcElnOEsycG5IcTlJcmNIYVJhTXpnaWxzNlhpVXpsYU9IZHNpZnRRdnRlQlM4WVlFTSt5WC9hZkdXRzdnZWhlQjcwR0RnNE95ZCs5ZXBiRkhqaHp4MVZhT25WU0RweUJzUzF5VTJvK2VpbWVGTWsydkl2QTlTSFYxbjgvbkExZkMrU2d2U2Eycm80ckRRcjkza2RxL2g0TGlXRmI1M2tUZ2UwdzZuVlp1ZlR3eU1pSzVYTTd3alB3bkt1cUJNeThpcnh1Y2k1L2xSZjF2T3QxQ3p5SXZJdkE5SkJhTEthL1FKeVltQWxQQytUaXZpUHBCcmM3ZWRTTjZYVVNtRk1lK0lwUnBlZzJCN3lFNi9YSm9yRmF6VldxbGdTcE9TYTFDQlYvMnF1STQrdXg0RDRIdkVlM3Q3WExnd0FHbHNjZVBIM2Y5RVhDditMM0dXRmIzRDNkU1JQNnNPUFpsb1p1bWx4RDRIcUZUTjgvcXZxWmYxUHZsSEJacXg3K082aXBmUk85SEdHWVIrQjZnODJ6aG9VT0hLTU5jb2hvc0JWRXZRUXlLaTZKK2dQdU1VS2JwRlFTK0IraVVZWEpRVzdOZjFQdmx2Q3FVWWRiakRWRXYwMlNWN3cwRXZzdEdSa2FVbnkxTXA5T1VZWXBlTjh3cEVYbkw0RndhV1Y3VXQzWjREdEViQ0h3WHhXSXg1ZjEzK3VYY3A5c3ZCL1Y3UzJyVlRDcjJDMldhYmlQd1hUUTZPcXBjaHNtTjJwb2VVWCsyOEcyaERGT0Y2bDUrUkxpQjZ6WUMzeVdwVkVyNTJjSmp4NDVSaHJtRWZqbk9PeW0xSDBzVlA1VGFqelRjUWVDN2hINDUrcDRUOVRMTTE0VXlUQjMwMmZFbkF0OEZPczhXam82T1VvYTVSS2RmRG1XWWVpNktlcytoWjZUMll3M25FZmdPMCttWE16YzN4K3AreVN1aVhvWkpOMHd6M3BEYWo2Y0tua04wQjRIdnNIUTZyVldHQ2YxbkN5bkRORU8zVEZPMTV4SFVFZmdPYW05djF5ckRIQnNiTXp3amY5THBoa2tacGxudmlWNlpKbjEybkVYZ080aHVtUHI2UmE4TU04alBGdHFGYnByK1FlQTdaSEJ3VUtzTU01UEpHSjZSUDZrR1JFRlkzZHRsVXZUS05PbXo0eHdDM3lFNlpaaXM3bXRlRXIweVRBNXE3Zk9xVUticEJ3UytBNGFIaDNtMlVKUHVzNFZjc3JKWFh0VExOTHVsOW1NTyt4SDROb3ZGWXNxcis3bTVPYnBoTG5sWk9LajF1c05DbWFiWEVmZzJTNmZUeWdlMXc4UERaaWZqVTF0RmZlLytsTlFxU2VBTTFWZkRJa0tacGhNSWZCdTF0N2ZMd1lNSGxjYU9qNC9UTDJlSnpoNHZ6eFk2NjZTb2wybStJcFJwMm8zQXQ1SE9kZ3lyKzVwK0VYbFdjZXdiUXI4Y04rajh5SEtBYXk4QzN5YURnNE95ZCs5ZXBiRkhqaHloWDg0U3VtSDZ6MFZSNzFYMHJGQ21hU2NDM3lhcWo1UFFEZk8rL1ZLcjRGQkJ2eHgzNlhUVDVEbEUreEQ0TnREdGwwTVpwdDZ6aGZPaVhpSUlNM1Q3N0tqMlNzTFhJL0FOMCttR09URXh3Yk9GUzNUNjVYQlE2dzF2U2UzTllCV3ZDR1dhZGlEd0RhTmZqcjZ0b2w2aTkyZmgyVUl2b2MrT3R4RDRCcVZTS1RsdzRJRFMyT1BIajFPR3VVUm5ENWRMVnQ1eVVtby93aXBlRnNvMFRTUHdEZElwdzJSMVg5TXY2djF5RGd0bG1GNms4eVBNQWE1WkJMNGhRME5EeXM4V0hqcDBpRExNSmFyL2dSZUVad3U5NnFLb2w4anlIS0paQkw0aDlNdlJwL05zNGF0Q0dhYVg2VDZIQ0RNSWZBTkdSa2FVeXpEcGhsa1RGWjR0YkdSNVVWL2xKNFVEWEZNSWZFMnhXRXpyMlVMS01HdGVFL1V5VEc3VStzTmJvdmNjSW1XYStnaDhUYU9qbzhwbG1OeW9yZWtSdldjTEtjUDBEOVVmNTRpd3RXTUNnYTlCOTlsQ3lqQnI2SmNUSENkRjd6bkVIb056Q1NJQ1g0UHFDcDErT2ZjOUozclBGbEtHNlQ4NmZYWlk1ZXNoOEJVTkR3OHJsMkdPam81U2hpbjZ6eFpTaHVsUEYwVzkxOUV6d25PSU9naDhCVHI5Y3VibTVsamRMM2xaS01NTUtwM25FT216bzQ3QVY2RGJEUk8xSy9NNlpaZzhXK2gvT3QwMGVRNVJEWUZ2VVh0N3UxWVo1dGpZbU9FWitaTk9OMHo2NVRTRzkwU3ZUSk0rTzlZUitCYnBsR0d5dXEvcEY3MHl6RW1EYzdGYkxCYVR3Y0ZCR1JrWmtjSEJRV2x2YjNkN1NwNmkwMDJUQTF6ckNId0xkSjh0ekdReWhtZmtUenBsbUg1WjNjZGlNVGw2OUtoODl0bG44djc3Nzh2Qmd3ZmwvZmZmbHdzWExzaUpFeWNJL2lXVHduT0lUaUx3TFZEdGVVTVo1bjB2aWZxemhhK0xQdzVxMjl2YlpYWjI5cEYzTkFZR0JpU1R5VWdxbFhKNFp0NUVtYVp6Q1B3NkRROFBTMjl2cjlKWSt1WFU2SlpoK3VXUzFkalkyR08zL2FMUnFJeU5qVWtzRm5Ob1Z0NmwwMmVuV3lqVHRJTEFyNU5PR1NiZE1HdGVrc1ovdHRES3dxQ3RyVTJHaDRmdG5aQlB2QzU2Wlpxb0Q0RmZoOEhCUWVVeVRQNkR2dTlaeFhHbnhCLzljbUt4bU9VZjk2R2hJWnRtNHorcVArcEpZUysvWGdTK2pjYkh4K21YOHdEVkZncCtXZDJydkdlc2VsdTdFWjBVOVRKTkxtTFZoOENIcDcwaC91aVgwOTdlcnZ5ZU1lQVVBcjhPcWdldUF3TURNamc0YUhZeVBtWjE5ZWFuYnBpcTd4cU1qNCtibllpUDZieG43SWRGZ1JjUStIWElaREl5Tnplbk5KWUhUdTc3czhVL2YxajhVWVk1T0Rpb3ZEWER6ZXY3Vk44em5oZC9YY1p6RTRGZko5VXFuYmEyTm03WUxubEw2cS9FbUJMMWpvcE9VLzFSeitmekxBaVc3QmYxUm5wKytWdWdGeEQ0ZFRwNjlLaE1URXdvalIwWkdhSGVXbXFyOWYrUXgxK3lLU3o5T1QvUWJhVEgvWXphZ2F0cWFlV1U4SjZ4RlFTK0Jhb3I5V2cweWszYkpaTWk4bS95NlAzOHQwV2tWL3l4SjZ2VEpwdjNqTytqa1o1ekNId0xUcHc0SWNlUEgxY2FlK0RBQWE3U0w3a29Jdjh1SWlrUmVWNUUvdS9TLzI2VFdnbW1IL2J0UlhqUDJJUWVVVzkxL0dmeHgvME1MeUh3TFVxbjA1TFBxMFVTTjI2LzdLTFUvb045YStsLy9STDBJaUtwVklyM2pBMElRaU05THlId0xacWRuVlVPN29HQkFXNVdOZ2dhNmVualBXUG5FZmdLUmtkSGxjczBXZVg3MzlEUUVPOFpHOEI3eHM0ajhCWGtjam10TWsxV2VQNmwwaTluR1kzMDdudEY5TW93L2JUOTV5VUV2cUtqUjQ4cTM1Sk1wOU04Z09GVGxHSHEwMzNQbURKTWRRUytCdFdWT21XYS9zUjd4bVpRaHVrZUFsL0RpUk1uNU5peFkwcGo5KzNiUjU4ZG4xSHBocm1NMjlZMVFYclAySXNJZkUwNlpacXM4djFqY0hCUXF3eVQ5NHhyVkcvVVVvWnBCb0d2S1pmTGFaVnA4a0NLUDZqK09PZnplVmIzUzE0U3ZUSk1EbXIxRWZnR2pJeU1LSmRwMG1mSCs0YUhoN1hLTURtbzFldVg0NmYzakwyT3dEZEVkUlZITjAxdjB5M0RaTnV1NW1WUkw4TmtLOGNjQXQrUXNiRXg1VExOZ3djUFVxYnBVZWwwV3ZtZ2x1MjZtcTJpdnJvL0pTTHZHWnhMMEJINEJ1bXMxTG1RNHozdDdlMXk4T0JCcGJHOFozeWY2bzFhRWYrOFord1hCTDVCbVV4R2podzVvalIyNzk2OWxHbDZqTTZQTUt2N21uNFJlVlp4ckYvZU0vWVRBdCt3a1pFUnVtazJnTUhCUWRtN2Q2L1MyQ05IanRBdlo0bE9OMHdPYXMwajhBM1Q2YlBUMjl2THl0QWo2SWFwN3lVUjZWWWNTNzhjZXhENE50RHRwa21acHJ2UzZiVDA5dllxajZVTXMxYUdxZE1OMHkvdkdmc05nVzhUMVpVNmZYYmNwZk5zNGNURUJNOFdMdEhwbDhOQnJYMElmSnZvUG9kSW1hWTc2SmVqYjZ2d2JLRlhFZmcyMGdrQVZvck9hMjl2bHdNSERpaU5QWDc4T0dXWVMzNnZNWlpMVnZZaThHMDBPenNyaHc0ZFVobzdNREJBbWFiRGRINWtXZDNYOUl0NnY1ekRRaG1tM1FoOG00Mk9qaXFYYWJMS2Q0N09zNFdIRGgyaURIT0o2dXErSUR4YjZBUUMzMmE1WEk0K096N0FzNFg2OW90ZXZ4ektNTzFINER2ZzZOR2pNakV4b1RTV2JwcjJHeGtaVVg2MmNHUmtoREpNMGV1R09TVThXK2dVQXQ4aHFpdjFhRFRLQ3RKR3NWaE02OWxDdHQxcVhoT2VMZlFEQXQ4aHVzOGhwbElwd3pPQ1NHMHJSN1VNay9zU05UMmk5MndoWlpqT0lmQWRSSjhkYjBtbFVsclBGbEtHV1VPL0hQOGc4QjAwT3p1cjlSemkwTkNRNFJrRkcvMXk5RDBuZXM4V1VvYnBMQUxmWWJwOWRtQ0c3ck9GbEdIcTk4dWhETk41Qkw3RGRMcHB0clcxc2JJMFFLZGZEczhXM3FmN2JDRmxtTTRqOEYxdzlPaFI1ZWNRMCtrMGZYWTBwZE5wNVRKTTdrWFViSlZhM2IwS25pMTBENEh2RXAweVRWYVk2dHJiMjdYS01NZkd4Z3pQeUo5MHVtRlNodWtlQXQ4bG1VeEdxMHlUUGp0cTZJYXByMS8weWpBbkRjNEYxaEQ0TGtxbjA4cGxtcXp5clJzY0hOUXF3OHhrTW9abjVFK3FOMm9Md3VyZWJRUytpM0s1bkZhWkpzOGhXcU5UaHNucXZ1WWwwU3ZENUtEV1hRUyt5MFpHUm5nTzBRSER3OFBLenhiU0w2ZEd0d3lUUzFidUkvQTlRT2NBbDVYbjQ4VmlNYnBoR3ZDeThHeWgzeEg0SGpBMk5xWmNwbm53NEVIS05COGpuVTRySDlTeWJWYXpWZFQzN2s4Si9YSzhnc0QzQ0oxZ1lRWDZhTzN0N1hMdzRFR2xzZVBqNC9UTFdhSzZsU1BDNnQ1TENIeVBtSjJkbFNOSGppaU4zYnQzTDJXYWo2RFR2cGpWZlUyL2lEeXJPUFlOb1YrT2x4RDRIa0kzVGJNR0J3ZDV0dEFBdW1FMkRnTGZRM1Q2N1BUMjluS0EreFdxcS90OFBzOFA2Skw5SXRLdE9QYXdVSWJwTlFTK3g0eU9qdkljb2dHNi9YSW93OVIvdHZCMWczT0JHUVMrQjlGblI0OU9OOHlKaVFtZUxWeEN2NXpHUStCNzBJa1RKK1Q0OGVOS1l3OGNPQkQ0TWszNjVlamJLclc2ZXhWL0Zzb3d2WXJBOXlpZDRBbnlDaldWU3NtQkF3ZVV4aDQvZnB3eXpDVy8xeGpMNnQ2N210eWVBQjV1ZG5aV0RoMDZwRlJEdnR4bko0aFZKcXBiT1hiM3krbTM3WlBONnhIMWZqbUhoVEpNTHlQd1BXeDBkRlQ1bHVpYmI3NXB3NHdhbDEzUEZqNG50YkpHMVplaC9LUWdQRnZvZFd6cGVGZ3VsMk5QMlFGMjljdjV2WWo4dHdRajdFVjR0dEFQQ0h5UDAza09FZld4b3h2bWM2TCtTSWdmblJLUnQ5eWVCQjZMd1BjQlNpM3RNejQrYnNzaHQwN3ZHVC9pUnEwL0VQZytjT0xFQ2VYbkVQSDE3UGd4N1pmZ2JPT0kxSjR0cEF6VEh3aDhuOURwczRPSE8zYnNHR1dZbXVpWDR5OEV2ay9NenM3UzM4VWduaTAwNDNXaEROTlBDSHdmR1IwZFZYNE9FVjgyT2pwS3Z4eE5QRnZvUHdTK2oxQ21hY2JjM0p5dEIrRW5wUmFHalk0YnRmNUQ0UHVNem5PSXFISGlSN1BSdy9DVWlMem45aVJnR1lIdlEwTkRROG90bElQdXB6LzlxWXlOamRuK1BlOUpyWHFsRVUySnlIKzRQUWtvSWZCOUtKZkx5ZURnb1BLVGlFRTBOemNuTDd6d2dxTUgzLzhwSXY5SEdtdDc1MjBSK1hmaFJxMWYwVXZIcDViMzgwZEdSaVNWU3JrOUhVL0w1WEtTeVdSYytlNzNsdjdwa2RxREluNDJLUVM5M3hINFBwZkw1YWdsOTRGSnR5Y0FDRnM2QUJBWUJENEFCQVNCRHdBQlFlQURRRUFRK0FBUUVBUStBQVFFZ1E4QUFVSGdBMEJBRVBnQUVCQUVQZ0FFQklFUEFBRkI0QU5BUUJENEFCQVFCRDRBQkFTQkR3QUJRZUFEUUVBUStBQVFFQVErQUFRRWdROEFBVUhnQTBCQUVQZ0FFQkFFUGdBRWhHMkJINGxFN1Bwb0FHaFk4WGpjOHBqbm4zKyt2WjQvWjF2Z2gwSWh1ejRhQVBDQWQ5OTlkN2FlUDhlV0RnQUVCSUVQQUFGQjRBTkFRQkQ0QUJBUVZPa0FnSWZZbVoxMUIzNCtuODlaK1dDcWRBREFPcXZaYVNXYmJkM1NJZlFCb0g1MloyYmRnWC9uenAyeTFROW5Xd2NBNnFlU21WYXl1ZTdBTDVmTDAxWW53Z29mQU9xbmtwbFdzcm51d1AvaWl5OCtzenFSYURScWRRZ0FCSlpLWmxySjVyb0R2MUtwakZ1ZENGczZBRkEvbGN5MGtzMVc5dkQvWVhVaTRYRFk2aEFBQ0N5VnpMU1N6WFVIL3RtelowOWFuUWdyZkFDb24wcG1Xc2xtUzJXWnhXS3haSFV5S3EwK0FTQm9WTExTYWlaYkN2eFNxWFRaMm5RNHVBV0FlcWhrcGRWTXRocjQvN1EySGJaMUFLQWVLbGw1Ky9idFNTdC8zbExnMzdsejV5L1dwaU95ZnYxNnEwTUFJSEJVc3RKcTlhU2x3SitjbkJ5MU5oMlJscFlXcW5VQTRHdUV3MkZwYVdteFBNNXFKbHZ1cGFOeWNKdElKS3dPQVlEQVVNbElsU3hXQ1h6TExSYW8xQUdBUjFPczBMR2N4WllELy9idDI1YjM4Vm5oQThDanFXU2tTaFpiRHZ6UFAvLzhEYXRqUkFoOUFIZ1kxV3hVeVdMTGdYL3UzTGs1OXZFQndBelYvZnR6NTg3TldSMm45QUJLb1ZENHU5VXhCRDRBL0N1VmJGVEpZQkhGd0MrWHk2OWJIUk1LaFNTWlRLcDhIUUEwcEdReXFkb0QzM0lHaXlnRy90VFUxQi9MNVhMVjZqaFcrUUJ3bjBvbWxzdmw2dFRVMUI5VnZrLzVUZHRjTGpkbGRVd2lrZUFTRmdCSTdiS1ZTdUNyWk84eTVjQmZYRno4amNvNHRuVUFRRDBMVmJOWFJDUHdWYmQxdG0zYnB2cVZBTkF3VkxKUVp6dEhSQ1B3UlVSdTNMaHh5dW9ZRG04QkJKM3FZYTFLNWo1SUsvQVhGeGQvcVRLdW82TkQ1MnNCd05kVU0xQTFjNWRwQmY3WnMyZFA1dlA1bk5WeExTMHRWT3dBQ0tSRUlxSFVHVE9meitkVW5wcDlrRmJnTDAzaVR5cmp0bS9mcnZ2VkFPQTdxdG1ubXJVUDBnNzhUQ2J6WTVYRDIzZzhUaGROQUlHaW1udmxjcm1heVdSK3JQdjkyb0V2b242UThOUlRUNW40ZWdEd0JkWE0wejJzWFdZazhHL2R1cld2V3EzZXRUcXVwYVdGaWgwQWdaQk1KcFgyN3F2VjZ0MWJ0Mjd0TXpFSEk0Ri83dHk1dWV2WHIwK29qTjI1YzZkU2VSSUErRVVvRkpLZE8zY3FqYjErL2ZxRVNtZk1oekVTK0NJaXhXTHhKeXJqUXFFUUI3Z0FHdHIyN2R1VkY3YXEyZEw3SzFRQUFBZ0dTVVJCVlBvd3hnTC83Tm16SjY5ZHUvYUp5dGdkTzNaSUpCSXhOUlVBOEl4SUpDSTdkdXhRR252dDJyVlBkRXN4SDJRczhFVkU4dm44c09yWTd1NXVnek1CQUcvUXlUYWRUSDBZbzRGLzl1elprNWN2WHg1WEdSdVB4OW5hQWRCUXRtL2ZybHgrZnZueTVYR1RxM3NSdzRFdm9sNnhJMUxiMnFGOU1vQkdFQTZIbGJkeVRGYm1QTWg0NEo4N2QyNHVtODBlVnhrYkNvVmsxNjVkcHFjRUFJN2J0V3VYOGtGdE5wczlicW95NTBIR0ExOUU1S09QUG5wQjVmYXRTTzJBZytacUFQeXNvNk5EdVJDbFhDNVhQL3Jvb3hjTVQwbEViQXA4RVpFclY2NzhUSFhzamgwN2FMc0F3SmZpOGJqeVZvNklYblkram0yQlB6azVPWHJqeG8yczZuaWR2dzRCZ0J0MHQ2VnYzTGlSblp5Y0hEVTRwUyt4TGZCRlJCWVdGcjZyZW9BYkNvVmt6NTQ5cHFjRUFMYlpzMmVQOGtLMVdxM2VYVmhZK0s3aEtYMkpyWUd2YzRBclV0dlBUNlZTSnFjRUFMWklwVkphRjBqdE9xaDlrSzJCTDFJN3dGVjVKR1ZaTXBua0VCZUFwM1YwZEdnMWdzem44em03RG1vZlpIdmdpNGhjdlhvMXBicTFJMUk3eEtXckpnQXZTaWFUV29lMDFXcjE3dFdyVngzWnluQWs4TStkT3pkMzZkS2x3enFma1VxbENIMEFucEpNSnJXM25TOWR1blRZN3EyY1pZNEV2b2pJeE1URUw3TFpiRWJuTTNidTNFbVROUUNlRUlsRWxGc2VMOHRtczVtSmlZbGZHSnJTWXprVytDSWlOMi9lSENvV2l5WFY4Y3VWTzRRK0FEZEZJaEd0aWh3UmtXS3hXTHA1OCthUXdXazlscU9CdjFTMTh6MmQvWHhDSDRDYlRJUjl0VnE5bTgxbXYrZlVWczR5UndOZnBOWlJVM2MvZnpuMDJkTUg0S1JrTXFrZDlpSzFmWHZUblREcnNlTHVYZVhGdHBhK3ZyNTN0bXpab3YzWG1Vd21JL1B6OHlhbUJBQ1BaT0tBVmtUazAwOC9IWE9pQlBOaFhBdDhFWkhkdTNmL2M4T0dEZC9VL1p5Wm1SbVpucDQyTVNVQStCY2RIUjFhcFpmTHJsMjc5c21ISDM3NExRTlRVdUpxNEl1SURBd01mQmFOUm1PNm56TS9QeStaakZZUkVBRDhDMU1sNGZsOFBqYytQdjROQTFOUzV2Z2UvbGRkdlhvMXBWTzVzeXlaVE1yQXdBQU4xd0FZRVFxRlpHQmd3RWpZRjR2RmtsT1hxNzZPNnl0OEVaSE96czYyVFpzMm5XdHRiVzNSL2F4S3BTS25UNStXaFlVRkUxTURFRUR4ZU54WXg5NWlzVmk2Y3VWS3A5TVZPUS9qaWNBWHFZWCt0bTNiTGpRMU5hMHc4WG5zNndOUVlXcS9YcVJXZm5uaHdvVnRYZ2g3RVE4RnZvaElkM2YzaTF1M2JuM2JWT2dYQ2dVNWZmcTBMQzR1bXZnNEFBMHNIQTdMcmwyN2pOM3hxVmFyZHk5ZXZQakRxYW1wUHhyNVFBTThGZmdpNWtPL1Vxbkl6TXlNbkQ5LzNzVEhBV2hBMjdkdmx4MDdkaGc3QS9SaTJJdDRNUEJGek83cEwxdFlXSkNwcVNrcEZBcW1QaEtBejBVaUVlbnU3amI2cEtxWDl1eS95cE9CTDJKUDZJdkl2ZFYrcFZJeCtiRUFmQ1FVQ3QxYjFadms1YkFYOFhEZ2k5UkNmK1BHalJrVGRmb1BxbFFxY3ViTUdXN29BZ0dVVENabDU4NmR4a3U0OC9sODd1clZxeW12aHIySXh3Ti9tYWtidVY5VktwWGs0NDgvcG9RVENJQjRQQzVQUGZXVXRMUVkzVFFRRWZkdjBOYkxGNEV2WXE3M3pzTXNMQ3pJK2ZQbkpadk4ydkh4QUZ5VVNDUmsrL2J0UnZmcEgrUm1ieHlyZkJQNElpSzl2YjIvZnZMSkoxOHhWY0h6VmFWU1NhYW5wOW5xQVJyQThudllkcXpvUldxVk9KY3VYVHJzNUFNbXVud1YrQ0lpWFYxZC9ZbEU0cSttRDNNZlZLbFU1TUtGQ3pJL1AwOE5QK0FqNFhCWWtzbWtiTnUyemRZMks4VmlzWlROWnIvblJvdGpIYjRMZkpIYVllN2F0V3ZIRW9tRTdiMHBzdG1zWkxOWlZ2MkFoeVdUU1Vra0VwSklKR3ovcm13Mm03bDU4K2FRbHc5bkg4V1hnYi9NN2kyZUIxVXFsWHZoejE0LzRMN2xnRThrRW80MFRmVGpGczVYK1Ryd1Jld3IzWHljYkRZckN3c0xrczFtMmZZQkhCQU9oeVdSU0VnOEhuZGtKZjhnUDVSYzFzUDNnYitzcjYvdm5VUWlzZGVKMWY1WGxVb2x1WDc5dWhRS0Jjbm44NVI1QWdiRTQzR0pScU1TaVVSay9mcjF0aDIrZnAybHQyZVArNlVLNTNFYUp2QkZhcXY5ZUR6K3QzWHIxam43OC84UWhVSkJGaGNYNy8wSVZDb1ZLUlFLM1BBRkhoQUtoU1FTaVVnb0ZMb1g3dUZ3MkZnRE14MDNidHpJTGl3c2ZOZnZxL29ITlZUZ0wrdnA2VWx2MnJUcHQ4M056VTF1eitWUkh2VzNBUDUyZ0VieXFOcjM1WkQzb25LNVhMMXk1Y3JQSmljblI5MmVpMmtOR2ZqTDNOem1BZUF2amJaOTh6QU5IZmdpdFcyZU5XdldITnU4ZWZPQTIzTUI0RTJYTDE4ZXYzWHIxcjVHMnI1NW1JWVAvR1ZkWFYzOTBXajBxQjA5ZVFENDA3VnIxejdKNS9QRGZydEFwU293Z2Irc3E2dXJ2N1cxOVhmcjE2L3ZaYXNIQ0o1cXRYcjMrdlhyRThWaThTZEJDZnBsZ1F2OFpjdGJQZXZXclh2R3k0ZTdBTXdvbDh2Vkd6ZHVuQXJDMXMyakJEYndINVJLcGY0UWpVWi80UFRsTFFEMnkrZnp1WHcrLzZkTUp2Tmp0K2ZpTmdML0FWMWRYZjNoY1BoWHJQb0JmMXRlelM4dUx2NHlhTnMyWDRmQWY0VHU3dTRYdytId3oyT3hXRGZoRDNoZnVWeXU1bks1cWNYRnhkOTQ3ZkZ3cnlEdzY5RGQzZjFpYzNQei9rZ2s4clNkYlprQldGTXNGa3VGUXVIdjVYTDVkVUwrOFFoOGl6bzdPOXVlZU9LSmwxZXZYdjM5MXRiV0RuNEFBT2NVaThWU3NWaWN2bjM3OWw4Ky8venpONEo2K0txS3dEZWdwNmNuSFFxRkJsYXZYdDNUMHRLeW1SOEJRRit4V0N5VlNxWEx0Mi9mbnF4VUt1T04yT3JBYVFTK1RicTZ1dnBYclZyMW5WQW9OTEJ5NWNwdk5EYzNkNnhhdGFwWlJJUnFJS0JXUFNNaWN1Zk9uWEs1WEo3KzRvc3ZQcXRVS3VOMzd0ejVCd2V0OWlEd0FTQWdWcm85QVFDQU13aDhBQWdJQWg4QUFvTEFCNENBSVBBQklDQUlmQUFJQ0FJZkFBS0N3QWVBZ0NEd0FTQWcvaGZuYUh3a3pmaTdnZ0FBQUFCSlJVNUVya0pnZ2c9PSIsIm1lZGlhdHlwZSI6ImltYWdlL3BuZyJ9XSwiaW5zdGFsbCI6eyJzcGVjIjp7ImNsdXN0ZXJQZXJtaXNzaW9ucyI6W3sicnVsZXMiOlt7ImFwaUdyb3VwcyI6WyIiXSwicmVzb3VyY2VzIjpbImNvbmZpZ21hcHMiLCJwZXJzaXN0ZW50dm9sdW1lY2xhaW1zIiwic2VjcmV0cyIsInNlcnZpY2VzIl0sInZlcmJzIjpbImNyZWF0ZSIsImRlbGV0ZSIsImdldCIsImxpc3QiLCJ1cGRhdGUiLCJ3YXRjaCJdfSx7ImFwaUdyb3VwcyI6WyIiXSwicmVzb3VyY2VzIjpbInBvZHMiXSwidmVyYnMiOlsibGlzdCIsInVwZGF0ZSIsIndhdGNoIl19LHsiYXBpR3JvdXBzIjpbImFwcHMiXSwicmVzb3VyY2VzIjpbImRlcGxveW1lbnRzIl0sInZlcmJzIjpbImNyZWF0ZSIsImRlbGV0ZSIsImdldCIsImxpc3QiLCJ1cGRhdGUiLCJ3YXRjaCJdfSx7ImFwaUdyb3VwcyI6WyJsaW1pdGFkb3Iua3VhZHJhbnQuaW8iXSwicmVzb3VyY2VzIjpbImxpbWl0YWRvcnMiXSwidmVyYnMiOlsiY3JlYXRlIiwiZGVsZXRlIiwiZ2V0IiwibGlzdCIsInBhdGNoIiwidXBkYXRlIiwid2F0Y2giXX0seyJhcGlHcm91cHMiOlsibGltaXRhZG9yLmt1YWRyYW50LmlvIl0sInJlc291cmNlcyI6WyJsaW1pdGFkb3JzL2ZpbmFsaXplcnMiXSwidmVyYnMiOlsidXBkYXRlIl19LHsiYXBpR3JvdXBzIjpbImxpbWl0YWRvci5rdWFkcmFudC5pbyJdLCJyZXNvdXJjZXMiOlsibGltaXRhZG9ycy9zdGF0dXMiXSwidmVyYnMiOlsiZ2V0IiwicGF0Y2giLCJ1cGRhdGUiXX0seyJhcGlHcm91cHMiOlsicG9saWN5Il0sInJlc291cmNlcyI6WyJwb2RkaXNydXB0aW9uYnVkZ2V0cyJdLCJ2ZXJicyI6WyJjcmVhdGUiLCJkZWxldGUiLCJnZXQiLCJsaXN0IiwidXBkYXRlIiwid2F0Y2giXX1dLCJzZXJ2aWNlQWNjb3VudE5hbWUiOiJsaW1pdGFkb3Itb3BlcmF0b3ItY29udHJvbGxlci1tYW5hZ2VyIn1dLCJkZXBsb3ltZW50cyI6W3sibGFiZWwiOnsiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9LCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciIsInNwZWMiOnsicmVwbGljYXMiOjEsInNlbGVjdG9yIjp7Im1hdGNoTGFiZWxzIjp7ImNvbnRyb2wtcGxhbmUiOiJjb250cm9sbGVyLW1hbmFnZXIifX0sInN0cmF0ZWd5Ijp7fSwidGVtcGxhdGUiOnsibWV0YWRhdGEiOnsibGFiZWxzIjp7ImFwcCI6ImxpbWl0YWRvci1vcGVyYXRvciIsImNvbnRyb2wtcGxhbmUiOiJjb250cm9sbGVyLW1hbmFnZXIifX0sInNwZWMiOnsiY29udGFpbmVycyI6W3siYXJncyI6WyItLWxlYWRlci1lbGVjdCJdLCJjb21tYW5kIjpbIi9tYW5hZ2VyIl0sImVudiI6W3sibmFtZSI6IlJFTEFURURfSU1BR0VfTElNSVRBRE9SIiwidmFsdWUiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOUBzaGEyNTY6OTQ3MWFhZGNlMWExN2FhY2IxYmY2NTNiNzVlMGQ3OTI0ZjhmOWUxNDQ5NTQ0NDBlMGQ5YzliZTZmZDQzMmU4YyJ9XSwiaW1hZ2UiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOS1vcGVyYXRvckBzaGEyNTY6YjMxYmEyOTM4MTI3ODhkYzdlMjFjMTQ3MDNhYzYxZmRkNWJmZjAxMDk0OGFkYTMzNzE1NTQ0YmE1MDc4NTFmNyIsImxpdmVuZXNzUHJvYmUiOnsiaHR0cEdldCI6eyJwYXRoIjoiL2hlYWx0aHoiLCJwb3J0Ijo4MDgxfSwiaW5pdGlhbERlbGF5U2Vjb25kcyI6MTUsInBlcmlvZFNlY29uZHMiOjIwfSwibmFtZSI6Im1hbmFnZXIiLCJwb3J0cyI6W3siY29udGFpbmVyUG9ydCI6ODA4MCwibmFtZSI6Im1ldHJpY3MifV0sInJlYWRpbmVzc1Byb2JlIjp7Imh0dHBHZXQiOnsicGF0aCI6Ii9yZWFkeXoiLCJwb3J0Ijo4MDgxfSwiaW5pdGlhbERlbGF5U2Vjb25kcyI6NSwicGVyaW9kU2Vjb25kcyI6MTB9LCJyZXNvdXJjZXMiOnsibGltaXRzIjp7ImNwdSI6IjIwMG0iLCJtZW1vcnkiOiIzMDBNaSJ9LCJyZXF1ZXN0cyI6eyJjcHUiOiIyMDBtIiwibWVtb3J5IjoiMjAwTWkifX0sInNlY3VyaXR5Q29udGV4dCI6eyJhbGxvd1ByaXZpbGVnZUVzY2FsYXRpb24iOmZhbHNlfX1dLCJzZWN1cml0eUNvbnRleHQiOnsicnVuQXNOb25Sb290Ijp0cnVlfSwic2VydmljZUFjY291bnROYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciIsInRlcm1pbmF0aW9uR3JhY2VQZXJpb2RTZWNvbmRzIjoxMH19fX1dLCJwZXJtaXNzaW9ucyI6W3sicnVsZXMiOlt7ImFwaUdyb3VwcyI6WyIiLCJjb29yZGluYXRpb24uazhzLmlvIl0sInJlc291cmNlcyI6WyJjb25maWdtYXBzIiwibGVhc2VzIl0sInZlcmJzIjpbImdldCIsImxpc3QiLCJ3YXRjaCIsImNyZWF0ZSIsInVwZGF0ZSIsInBhdGNoIiwiZGVsZXRlIl19LHsiYXBpR3JvdXBzIjpbIiJdLCJyZXNvdXJjZXMiOlsiZXZlbnRzIl0sInZlcmJzIjpbImNyZWF0ZSIsInBhdGNoIl19XSwic2VydmljZUFjY291bnROYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciJ9XX0sInN0cmF0ZWd5IjoiZGVwbG95bWVudCJ9LCJpbnN0YWxsTW9kZXMiOlt7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJPd25OYW1lc3BhY2UifSx7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJTaW5nbGVOYW1lc3BhY2UifSx7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJNdWx0aU5hbWVzcGFjZSJ9LHsic3VwcG9ydGVkIjp0cnVlLCJ0eXBlIjoiQWxsTmFtZXNwYWNlcyJ9XSwia2V5d29yZHMiOlsiYXBpIiwicmF0ZS1saW1pdCIsImt1YWRyYW50Il0sImxpbmtzIjpbeyJuYW1lIjoiTGltaXRhZG9yIE9wZXJhdG9yIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL0t1YWRyYW50L2xpbWl0YWRvci1vcGVyYXRvciJ9LHsibmFtZSI6Ikt1YWRyYW50IERvY3MiLCJ1cmwiOiJodHRwczovL2t1YWRyYW50LmlvIn1dLCJtYWludGFpbmVycyI6W3siZW1haWwiOiJlYXN0aXpsZUByZWRoYXQuY29tIiwibmFtZSI6IkVndXpraSBBc3RpeiBMZXphdW4ifSx7ImVtYWlsIjoiYXNuYXBzQHJlZGhhdC5jb20iLCJuYW1lIjoiQWxleCBTbmFwcyJ9LHsiZW1haWwiOiJkaWRpZXJAcmVkaGF0LmNvbSIsIm5hbWUiOiJEaWRpZXIgRGkgQ2VzYXJlIn1dLCJtYXR1cml0eSI6ImFscGhhIiwibWluS3ViZVZlcnNpb24iOiIxLjI1LjAiLCJwcm92aWRlciI6eyJuYW1lIjoiUmVkIEhhdCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9LdWFkcmFudC9saW1pdGFkb3Itb3BlcmF0b3IifSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOUBzaGEyNTY6OTQ3MWFhZGNlMWExN2FhY2IxYmY2NTNiNzVlMGQ3OTI0ZjhmOWUxNDQ5NTQ0NDBlMGQ5YzliZTZmZDQzMmU4YyIsIm5hbWUiOiJsaW1pdGFkb3IifV0sInZlcnNpb24iOiIxLjEuMSJ9fQ==
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoicmJhYy5hdXRob3JpemF0aW9uLms4cy5pby92MSIsImtpbmQiOiJDbHVzdGVyUm9sZSIsIm1ldGFkYXRhIjp7ImNyZWF0aW9uVGltZXN0YW1wIjpudWxsLCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLW1ldHJpY3MtcmVhZGVyIn0sInJ1bGVzIjpbeyJub25SZXNvdXJjZVVSTHMiOlsiL21ldHJpY3MiXSwidmVyYnMiOlsiZ2V0Il19XX0=
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoidjEiLCJkYXRhIjp7ImNvbnRyb2xsZXJfbWFuYWdlcl9jb25maWcueWFtbCI6ImFwaVZlcnNpb246IGNvbnRyb2xsZXItcnVudGltZS5zaWdzLms4cy5pby92MWFscGhhMVxua2luZDogQ29udHJvbGxlck1hbmFnZXJDb25maWdcbmhlYWx0aDpcbiAgaGVhbHRoUHJvYmVCaW5kQWRkcmVzczogOjgwODFcbm1ldHJpY3M6XG4gIGJpbmRBZGRyZXNzOiA6ODA4MFxud2ViaG9vazpcbiAgcG9ydDogOTQ0M1xubGVhZGVyRWxlY3Rpb246XG4gIGxlYWRlckVsZWN0OiB0cnVlXG4gIHJlc291cmNlTmFtZTogMzc0NWExNmUua3VhZHJhbnQuaW9cbiJ9LCJraW5kIjoiQ29uZmlnTWFwIiwibWV0YWRhdGEiOnsibmFtZSI6ImxpbWl0YWRvci1vcGVyYXRvci1tYW5hZ2VyLWNvbmZpZyJ9fQ==
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoidjEiLCJraW5kIjoiU2VydmljZSIsIm1ldGFkYXRhIjp7ImNyZWF0aW9uVGltZXN0YW1wIjpudWxsLCJsYWJlbHMiOnsiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9LCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLW1ldHJpY3MifSwic3BlYyI6eyJwb3J0cyI6W3sibmFtZSI6Im1ldHJpY3MiLCJwb3J0Ijo4MDgwLCJ0YXJnZXRQb3J0IjoibWV0cmljcyJ9XSwic2VsZWN0b3IiOnsiYXBwIjoibGltaXRhZG9yLW9wZXJhdG9yIiwiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9fSwic3RhdHVzIjp7ImxvYWRCYWxhbmNlciI6e319fQ==
+relatedImages:
+  - image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-1-limitador-operator-bundle@sha256:93c6f058da352883789f7db0150b1097a5f09e1268e24914ad964d5fdc83f6e1
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:b31ba293812788dc7e21c14703ac61fdd5bff010948ada33715544ba507851f7
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:9471aadce1a17aacb1bf653b75e0d7924f8f9e144954440e0d9c9be6fd432e8c
+    name: limitador
 schema: olm.bundle

--- a/catalog/4.20/limitador-operator/catalog.yaml
+++ b/catalog/4.20/limitador-operator/catalog.yaml
@@ -7,9 +7,11 @@ name: limitador-operator
 schema: olm.package
 ---
 entries:
-- name: limitador-operator.v1.0.2
-- name: limitador-operator.v1.1.0
-  replaces: limitador-operator.v1.0.2
+  - name: limitador-operator.v1.0.2
+  - name: limitador-operator.v1.1.0
+    replaces: limitador-operator.v1.0.2
+  - name: limitador-operator.v1.1.1
+    replaces: limitador-operator.v1.1.0
 name: stable
 package: limitador-operator
 schema: olm.channel
@@ -18,236 +20,269 @@ image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:21a579a5fd5c93
 name: limitador-operator.v1.0.2
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 1.0.2
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.0.2
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
-      createdAt: "2024-10-18T10:24:00Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: Enables rate limiting for Gateways and applications in a Gateway
-      API network. - Part of Red Hat Connectivity Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
+        createdAt: "2024-10-18T10:24:00Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: Enables rate limiting for Gateways and applications in a Gateway API network. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
-  name: limitador-rhel9-operator-4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:0112e4478abe28486670bb1221b4039ca0b4bde314d72c28485008ea7d6f73c1
-  name: limitador
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:21a579a5fd5c93677f68e5a79baaa9f9f77f2fd1310a4ce77532014844610630
-  name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
+    name: limitador-rhel9-operator-4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:4c6319b592e497f294a96b37914598bfd122bbdbba4568a4ee4550860fa3892c
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:0112e4478abe28486670bb1221b4039ca0b4bde314d72c28485008ea7d6f73c1
+    name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:21a579a5fd5c93677f68e5a79baaa9f9f77f2fd1310a4ce77532014844610630
+    name: ""
 schema: olm.bundle
 ---
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
 name: limitador-operator.v1.1.0
 package: limitador-operator
 properties:
-- type: olm.gvk
-  value:
-    group: limitador.kuadrant.io
-    kind: Limitador
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: limitador-operator
-    version: 1.1.0
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "limitador.kuadrant.io/v1alpha1",
-            "kind": "Limitador",
-            "metadata": {
-              "name": "limitador-sample"
-            },
-            "spec": {
-              "limits": [
-                {
-                  "conditions": [
-                    "get_toy == 'yes'"
-                  ],
-                  "max_value": 2,
-                  "name": "toy_get_route",
-                  "namespace": "toystore-app",
-                  "seconds": 30,
-                  "variables": []
-                }
-              ],
-              "listener": {
-                "grpc": {
-                  "port": 8081
-                },
-                "http": {
-                  "port": 8080
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.1.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "limitador.kuadrant.io/v1alpha1",
+              "kind": "Limitador",
+              "metadata": {
+                "name": "limitador-sample"
+              },
+              "spec": {
+                "limits": [
+                  {
+                    "conditions": [
+                      "get_toy == 'yes'"
+                    ],
+                    "max_value": 2,
+                    "name": "toy_get_route",
+                    "namespace": "toystore-app",
+                    "seconds": 30,
+                    "variables": []
+                  }
+                ],
+                "listener": {
+                  "grpc": {
+                    "port": 8081
+                  },
+                  "http": {
+                    "port": 8080
+                  }
                 }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      categories: Integration & Delivery
-      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-      createdAt: "2025-04-07T15:52:04Z"
-      description: Enables rate limiting for Gateways and applications in a Gateway
-        API network
-      features.operators.openshift.io/disconnected: "false"
-      features.operators.openshift.io/fips-compliant: "false"
-      features.operators.openshift.io/proxy-aware: "false"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.32.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-      repository: https://github.com/Kuadrant/limitador-operator
-      support: kuadrant
-      tectonic-visibility: ocs
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Limitador is the Schema for the limitadors API
-        displayName: Limitador
-        kind: Limitador
-        name: limitadors.limitador.kuadrant.io
-        version: v1alpha1
-    description: Enables rate limiting for Gateways and applications in a Gateway
-      API network. - Part of Red Hat Connectivity Link
-    displayName: Red Hat - Limitador Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - api
-    - rate-limit
-    - kuadrant
-    links:
-    - name: GitHub
-      url: https://github.com/kuadrant/limitador-operator
-    - name: Documentation
-      url: https://github.com/Kuadrant/limitador/tree/main/docs
-    maintainers:
-    - email: eastizle@redhat.com
-      name: Eguzki Astiz Lezaun
-    - email: asnaps@redhat.com
-      name: Alex Snaps
-    - email: didier@redhat.com
-      name: Didier Di Cesare
-    maturity: alpha
-    minKubeVersion: 1.25.0
-    provider:
-      name: Red Hat
-      url: https://github.com/Kuadrant/limitador-operator
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+        createdAt: "2025-04-07T15:52:04Z"
+        description: Enables rate limiting for Gateways and applications in a Gateway API network
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.32.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/Kuadrant/limitador-operator
+        support: kuadrant
+        tectonic-visibility: ocs
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Limitador is the Schema for the limitadors API
+            displayName: Limitador
+            kind: Limitador
+            name: limitadors.limitador.kuadrant.io
+            version: v1alpha1
+      description: Enables rate limiting for Gateways and applications in a Gateway API network. - Part of Red Hat Connectivity Link
+      displayName: Red Hat - Limitador Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - rate-limit
+        - kuadrant
+      links:
+        - name: GitHub
+          url: https://github.com/kuadrant/limitador-operator
+        - name: Documentation
+          url: https://github.com/Kuadrant/limitador/tree/main/docs
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: asnaps@redhat.com
+          name: Alex Snaps
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/limitador-operator
 relatedImages:
-- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
-  name: ""
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-  name: limitador-rhel9-operator-edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34-annotation
-- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
-  name: manager
-- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:98f85a05da53fbf7f20845d1969441620407cc13a185fd52714308679f116425
-  name: limitador
+  - image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:4c56cd8462531cf8ba39316a0c6f7493240bfa4a6ace77352fe7ac1597e2fd90
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+    name: limitador-rhel9-operator-edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34-annotation
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:edb28f112a0d3536f2f52467f38df685d953f46f1999cbd61f4fd4fa4805cd34
+    name: manager
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:98f85a05da53fbf7f20845d1969441620407cc13a185fd52714308679f116425
+    name: limitador
+schema: olm.bundle
+---
+image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-1-limitador-operator-bundle@sha256:93c6f058da352883789f7db0150b1097a5f09e1268e24914ad964d5fdc83f6e1
+name: limitador-operator.v1.1.1
+package: limitador-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: limitador.kuadrant.io
+      kind: Limitador
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: limitador-operator
+      version: 1.1.1
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsiY29udHJvbGxlci1nZW4ua3ViZWJ1aWxkZXIuaW8vdmVyc2lvbiI6InYwLjE1LjAifSwiY3JlYXRpb25UaW1lc3RhbXAiOm51bGwsIm5hbWUiOiJsaW1pdGFkb3JzLmxpbWl0YWRvci5rdWFkcmFudC5pbyJ9LCJzcGVjIjp7Imdyb3VwIjoibGltaXRhZG9yLmt1YWRyYW50LmlvIiwibmFtZXMiOnsia2luZCI6IkxpbWl0YWRvciIsImxpc3RLaW5kIjoiTGltaXRhZG9yTGlzdCIsInBsdXJhbCI6ImxpbWl0YWRvcnMiLCJzaW5ndWxhciI6ImxpbWl0YWRvciJ9LCJzY29wZSI6Ik5hbWVzcGFjZWQiLCJ2ZXJzaW9ucyI6W3siYWRkaXRpb25hbFByaW50ZXJDb2x1bW5zIjpbeyJkZXNjcmlwdGlvbiI6IkxpbWl0YWRvciBSZWFkeSIsImpzb25QYXRoIjoiLnN0YXR1cy5jb25kaXRpb25zWz8oQC50eXBlPT1cIlJlYWR5XCIpXS5zdGF0dXMiLCJuYW1lIjoiUmVhZHkiLCJwcmlvcml0eSI6MiwidHlwZSI6InN0cmluZyJ9LHsianNvblBhdGgiOiIubWV0YWRhdGEuY3JlYXRpb25UaW1lc3RhbXAiLCJuYW1lIjoiQWdlIiwidHlwZSI6ImRhdGUifV0sIm5hbWUiOiJ2MWFscGhhMSIsInNjaGVtYSI6eyJvcGVuQVBJVjNTY2hlbWEiOnsiZGVzY3JpcHRpb24iOiJMaW1pdGFkb3IgaXMgdGhlIFNjaGVtYSBmb3IgdGhlIGxpbWl0YWRvcnMgQVBJIiwicHJvcGVydGllcyI6eyJhcGlWZXJzaW9uIjp7ImRlc2NyaXB0aW9uIjoiQVBJVmVyc2lvbiBkZWZpbmVzIHRoZSB2ZXJzaW9uZWQgc2NoZW1hIG9mIHRoaXMgcmVwcmVzZW50YXRpb24gb2YgYW4gb2JqZWN0LlxuU2VydmVycyBzaG91bGQgY29udmVydCByZWNvZ25pemVkIHNjaGVtYXMgdG8gdGhlIGxhdGVzdCBpbnRlcm5hbCB2YWx1ZSwgYW5kXG5tYXkgcmVqZWN0IHVucmVjb2duaXplZCB2YWx1ZXMuXG5Nb3JlIGluZm86IGh0dHBzOi8vZ2l0Lms4cy5pby9jb21tdW5pdHkvY29udHJpYnV0b3JzL2RldmVsL3NpZy1hcmNoaXRlY3R1cmUvYXBpLWNvbnZlbnRpb25zLm1kI3Jlc291cmNlcyIsInR5cGUiOiJzdHJpbmcifSwia2luZCI6eyJkZXNjcmlwdGlvbiI6IktpbmQgaXMgYSBzdHJpbmcgdmFsdWUgcmVwcmVzZW50aW5nIHRoZSBSRVNUIHJlc291cmNlIHRoaXMgb2JqZWN0IHJlcHJlc2VudHMuXG5TZXJ2ZXJzIG1heSBpbmZlciB0aGlzIGZyb20gdGhlIGVuZHBvaW50IHRoZSBjbGllbnQgc3VibWl0cyByZXF1ZXN0cyB0by5cbkNhbm5vdCBiZSB1cGRhdGVkLlxuSW4gQ2FtZWxDYXNlLlxuTW9yZSBpbmZvOiBodHRwczovL2dpdC5rOHMuaW8vY29tbXVuaXR5L2NvbnRyaWJ1dG9ycy9kZXZlbC9zaWctYXJjaGl0ZWN0dXJlL2FwaS1jb252ZW50aW9ucy5tZCN0eXBlcy1raW5kcyIsInR5cGUiOiJzdHJpbmcifSwibWV0YWRhdGEiOnsidHlwZSI6Im9iamVjdCJ9LCJzcGVjIjp7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yU3BlYyBkZWZpbmVzIHRoZSBkZXNpcmVkIHN0YXRlIG9mIExpbWl0YWRvciIsInByb3BlcnRpZXMiOnsiYWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJBZmZpbml0eSBpcyBhIGdyb3VwIG9mIGFmZmluaXR5IHNjaGVkdWxpbmcgcnVsZXMuIiwicHJvcGVydGllcyI6eyJub2RlQWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJEZXNjcmliZXMgbm9kZSBhZmZpbml0eSBzY2hlZHVsaW5nIHJ1bGVzIGZvciB0aGUgcG9kLiIsInByb3BlcnRpZXMiOnsicHJlZmVycmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJUaGUgc2NoZWR1bGVyIHdpbGwgcHJlZmVyIHRvIHNjaGVkdWxlIHBvZHMgdG8gbm9kZXMgdGhhdCBzYXRpc2Z5XG50aGUgYWZmaW5pdHkgZXhwcmVzc2lvbnMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQsIGJ1dCBpdCBtYXkgY2hvb3NlXG5hIG5vZGUgdGhhdCB2aW9sYXRlcyBvbmUgb3IgbW9yZSBvZiB0aGUgZXhwcmVzc2lvbnMuIFRoZSBub2RlIHRoYXQgaXNcbm1vc3QgcHJlZmVycmVkIGlzIHRoZSBvbmUgd2l0aCB0aGUgZ3JlYXRlc3Qgc3VtIG9mIHdlaWdodHMsIGkuZS5cbmZvciBlYWNoIG5vZGUgdGhhdCBtZWV0cyBhbGwgb2YgdGhlIHNjaGVkdWxpbmcgcmVxdWlyZW1lbnRzIChyZXNvdXJjZVxucmVxdWVzdCwgcmVxdWlyZWREdXJpbmdTY2hlZHVsaW5nIGFmZmluaXR5IGV4cHJlc3Npb25zLCBldGMuKSxcbmNvbXB1dGUgYSBzdW0gYnkgaXRlcmF0aW5nIHRocm91Z2ggdGhlIGVsZW1lbnRzIG9mIHRoaXMgZmllbGQgYW5kIGFkZGluZ1xuXCJ3ZWlnaHRcIiB0byB0aGUgc3VtIGlmIHRoZSBub2RlIG1hdGNoZXMgdGhlIGNvcnJlc3BvbmRpbmcgbWF0Y2hFeHByZXNzaW9uczsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBbiBlbXB0eSBwcmVmZXJyZWQgc2NoZWR1bGluZyB0ZXJtIG1hdGNoZXMgYWxsIG9iamVjdHMgd2l0aCBpbXBsaWNpdCB3ZWlnaHQgMFxuKGkuZS4gaXQncyBhIG5vLW9wKS4gQSBudWxsIHByZWZlcnJlZCBzY2hlZHVsaW5nIHRlcm0gbWF0Y2hlcyBubyBvYmplY3RzIChpLmUuIGlzIGFsc28gYSBuby1vcCkuIiwicHJvcGVydGllcyI6eyJwcmVmZXJlbmNlIjp7ImRlc2NyaXB0aW9uIjoiQSBub2RlIHNlbGVjdG9yIHRlcm0sIGFzc29jaWF0ZWQgd2l0aCB0aGUgY29ycmVzcG9uZGluZyB3ZWlnaHQuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoiQSBsaXN0IG9mIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnRzIGJ5IG5vZGUncyBsYWJlbHMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvclxudGhhdCByZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6IlRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoiUmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzLCBEb2VzTm90RXhpc3QuIEd0LCBhbmQgTHQuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJBbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEd0IG9yIEx0LCB0aGUgdmFsdWVzXG5hcnJheSBtdXN0IGhhdmUgYSBzaW5nbGUgZWxlbWVudCwgd2hpY2ggd2lsbCBiZSBpbnRlcnByZXRlZCBhcyBhbiBpbnRlZ2VyLlxuVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoRmllbGRzIjp7ImRlc2NyaXB0aW9uIjoiQSBsaXN0IG9mIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnRzIGJ5IG5vZGUncyBmaWVsZHMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIG5vZGUgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvclxudGhhdCByZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6IlRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoiUmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzLCBEb2VzTm90RXhpc3QuIEd0LCBhbmQgTHQuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJBbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEd0IG9yIEx0LCB0aGUgdmFsdWVzXG5hcnJheSBtdXN0IGhhdmUgYSBzaW5nbGUgZWxlbWVudCwgd2hpY2ggd2lsbCBiZSBpbnRlcnByZXRlZCBhcyBhbiBpbnRlZ2VyLlxuVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIndlaWdodCI6eyJkZXNjcmlwdGlvbiI6IldlaWdodCBhc3NvY2lhdGVkIHdpdGggbWF0Y2hpbmcgdGhlIGNvcnJlc3BvbmRpbmcgbm9kZVNlbGVjdG9yVGVybSwgaW4gdGhlIHJhbmdlIDEtMTAwLiIsImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifX0sInJlcXVpcmVkIjpbInByZWZlcmVuY2UiLCJ3ZWlnaHQiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwicmVxdWlyZWREdXJpbmdTY2hlZHVsaW5nSWdub3JlZER1cmluZ0V4ZWN1dGlvbiI6eyJkZXNjcmlwdGlvbiI6IklmIHRoZSBhZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgYXJlIG5vdCBtZXQgYXRcbnNjaGVkdWxpbmcgdGltZSwgdGhlIHBvZCB3aWxsIG5vdCBiZSBzY2hlZHVsZWQgb250byB0aGUgbm9kZS5cbklmIHRoZSBhZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgY2Vhc2UgdG8gYmUgbWV0XG5hdCBzb21lIHBvaW50IGR1cmluZyBwb2QgZXhlY3V0aW9uIChlLmcuIGR1ZSB0byBhbiB1cGRhdGUpLCB0aGUgc3lzdGVtXG5tYXkgb3IgbWF5IG5vdCB0cnkgdG8gZXZlbnR1YWxseSBldmljdCB0aGUgcG9kIGZyb20gaXRzIG5vZGUuIiwicHJvcGVydGllcyI6eyJub2RlU2VsZWN0b3JUZXJtcyI6eyJkZXNjcmlwdGlvbiI6IlJlcXVpcmVkLiBBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciB0ZXJtcy4gVGhlIHRlcm1zIGFyZSBPUmVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBudWxsIG9yIGVtcHR5IG5vZGUgc2VsZWN0b3IgdGVybSBtYXRjaGVzIG5vIG9iamVjdHMuIFRoZSByZXF1aXJlbWVudHMgb2ZcbnRoZW0gYXJlIEFORGVkLlxuVGhlIFRvcG9sb2d5U2VsZWN0b3JUZXJtIHR5cGUgaW1wbGVtZW50cyBhIHN1YnNldCBvZiB0aGUgTm9kZVNlbGVjdG9yVGVybS4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudHMgYnkgbm9kZSdzIGxhYmVscy4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yXG50aGF0IHJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJSZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMsIERvZXNOb3RFeGlzdC4gR3QsIGFuZCBMdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6IkFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgR3Qgb3IgTHQsIHRoZSB2YWx1ZXNcbmFycmF5IG11c3QgaGF2ZSBhIHNpbmdsZSBlbGVtZW50LCB3aGljaCB3aWxsIGJlIGludGVycHJldGVkIGFzIGFuIGludGVnZXIuXG5UaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hGaWVsZHMiOnsiZGVzY3JpcHRpb24iOiJBIGxpc3Qgb2Ygbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudHMgYnkgbm9kZSdzIGZpZWxkcy4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbm9kZSBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yXG50aGF0IHJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJSZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMsIERvZXNOb3RFeGlzdC4gR3QsIGFuZCBMdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6IkFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgR3Qgb3IgTHQsIHRoZSB2YWx1ZXNcbmFycmF5IG11c3QgaGF2ZSBhIHNpbmdsZSBlbGVtZW50LCB3aGljaCB3aWxsIGJlIGludGVycHJldGVkIGFzIGFuIGludGVnZXIuXG5UaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJub2RlU2VsZWN0b3JUZXJtcyJdLCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn19LCJ0eXBlIjoib2JqZWN0In0sInBvZEFmZmluaXR5Ijp7ImRlc2NyaXB0aW9uIjoiRGVzY3JpYmVzIHBvZCBhZmZpbml0eSBzY2hlZHVsaW5nIHJ1bGVzIChlLmcuIGNvLWxvY2F0ZSB0aGlzIHBvZCBpbiB0aGUgc2FtZSBub2RlLCB6b25lLCBldGMuIGFzIHNvbWUgb3RoZXIgcG9kKHMpKS4iLCJwcm9wZXJ0aWVzIjp7InByZWZlcnJlZER1cmluZ1NjaGVkdWxpbmdJZ25vcmVkRHVyaW5nRXhlY3V0aW9uIjp7ImRlc2NyaXB0aW9uIjoiVGhlIHNjaGVkdWxlciB3aWxsIHByZWZlciB0byBzY2hlZHVsZSBwb2RzIHRvIG5vZGVzIHRoYXQgc2F0aXNmeVxudGhlIGFmZmluaXR5IGV4cHJlc3Npb25zIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkLCBidXQgaXQgbWF5IGNob29zZVxuYSBub2RlIHRoYXQgdmlvbGF0ZXMgb25lIG9yIG1vcmUgb2YgdGhlIGV4cHJlc3Npb25zLiBUaGUgbm9kZSB0aGF0IGlzXG5tb3N0IHByZWZlcnJlZCBpcyB0aGUgb25lIHdpdGggdGhlIGdyZWF0ZXN0IHN1bSBvZiB3ZWlnaHRzLCBpLmUuXG5mb3IgZWFjaCBub2RlIHRoYXQgbWVldHMgYWxsIG9mIHRoZSBzY2hlZHVsaW5nIHJlcXVpcmVtZW50cyAocmVzb3VyY2VcbnJlcXVlc3QsIHJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZyBhZmZpbml0eSBleHByZXNzaW9ucywgZXRjLiksXG5jb21wdXRlIGEgc3VtIGJ5IGl0ZXJhdGluZyB0aHJvdWdoIHRoZSBlbGVtZW50cyBvZiB0aGlzIGZpZWxkIGFuZCBhZGRpbmdcblwid2VpZ2h0XCIgdG8gdGhlIHN1bSBpZiB0aGUgbm9kZSBoYXMgcG9kcyB3aGljaCBtYXRjaGVzIHRoZSBjb3JyZXNwb25kaW5nIHBvZEFmZmluaXR5VGVybTsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJUaGUgd2VpZ2h0cyBvZiBhbGwgb2YgdGhlIG1hdGNoZWQgV2VpZ2h0ZWRQb2RBZmZpbml0eVRlcm0gZmllbGRzIGFyZSBhZGRlZCBwZXItbm9kZSB0byBmaW5kIHRoZSBtb3N0IHByZWZlcnJlZCBub2RlKHMpIiwicHJvcGVydGllcyI6eyJwb2RBZmZpbml0eVRlcm0iOnsiZGVzY3JpcHRpb24iOiJSZXF1aXJlZC4gQSBwb2QgYWZmaW5pdHkgdGVybSwgYXNzb2NpYXRlZCB3aXRoIHRoZSBjb3JyZXNwb25kaW5nIHdlaWdodC4iLCJwcm9wZXJ0aWVzIjp7ImxhYmVsU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgYSBzZXQgb2YgcmVzb3VyY2VzLCBpbiB0aGlzIGNhc2UgcG9kcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciB0aGUgc2V0IG9mIG5hbWVzcGFjZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgc2VsZWN0ZWQgYnkgdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIGxpc3RlZCBpbiB0aGUgbmFtZXNwYWNlcyBmaWVsZC5cbm51bGwgc2VsZWN0b3IgYW5kIG51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi5cbkFuIGVtcHR5IHNlbGVjdG9yICh7fSkgbWF0Y2hlcyBhbGwgbmFtZXNwYWNlcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VzIjp7ImRlc2NyaXB0aW9uIjoibmFtZXNwYWNlcyBzcGVjaWZpZXMgYSBzdGF0aWMgbGlzdCBvZiBuYW1lc3BhY2UgbmFtZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgbGlzdGVkIGluIHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBzZWxlY3RlZCBieSBuYW1lc3BhY2VTZWxlY3Rvci5cbm51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IGFuZCBudWxsIG5hbWVzcGFjZVNlbGVjdG9yIG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJ0b3BvbG9neUtleSI6eyJkZXNjcmlwdGlvbiI6IlRoaXMgcG9kIHNob3VsZCBiZSBjby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGggdGhlIHBvZHMgbWF0Y2hpbmdcbnRoZSBsYWJlbFNlbGVjdG9yIGluIHRoZSBzcGVjaWZpZWQgbmFtZXNwYWNlcywgd2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlXG53aG9zZSB2YWx1ZSBvZiB0aGUgbGFiZWwgd2l0aCBrZXkgdG9wb2xvZ3lLZXkgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoIGFueSBvZiB0aGVcbnNlbGVjdGVkIHBvZHMgaXMgcnVubmluZy5cbkVtcHR5IHRvcG9sb2d5S2V5IGlzIG5vdCBhbGxvd2VkLiIsInR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInRvcG9sb2d5S2V5Il0sInR5cGUiOiJvYmplY3QifSwid2VpZ2h0Ijp7ImRlc2NyaXB0aW9uIjoid2VpZ2h0IGFzc29jaWF0ZWQgd2l0aCBtYXRjaGluZyB0aGUgY29ycmVzcG9uZGluZyBwb2RBZmZpbml0eVRlcm0sXG5pbiB0aGUgcmFuZ2UgMS0xMDAuIiwiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwicmVxdWlyZWQiOlsicG9kQWZmaW5pdHlUZXJtIiwid2VpZ2h0Il0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sInJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJJZiB0aGUgYWZmaW5pdHkgcmVxdWlyZW1lbnRzIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkIGFyZSBub3QgbWV0IGF0XG5zY2hlZHVsaW5nIHRpbWUsIHRoZSBwb2Qgd2lsbCBub3QgYmUgc2NoZWR1bGVkIG9udG8gdGhlIG5vZGUuXG5JZiB0aGUgYWZmaW5pdHkgcmVxdWlyZW1lbnRzIHNwZWNpZmllZCBieSB0aGlzIGZpZWxkIGNlYXNlIHRvIGJlIG1ldFxuYXQgc29tZSBwb2ludCBkdXJpbmcgcG9kIGV4ZWN1dGlvbiAoZS5nLiBkdWUgdG8gYSBwb2QgbGFiZWwgdXBkYXRlKSwgdGhlXG5zeXN0ZW0gbWF5IG9yIG1heSBub3QgdHJ5IHRvIGV2ZW50dWFsbHkgZXZpY3QgdGhlIHBvZCBmcm9tIGl0cyBub2RlLlxuV2hlbiB0aGVyZSBhcmUgbXVsdGlwbGUgZWxlbWVudHMsIHRoZSBsaXN0cyBvZiBub2RlcyBjb3JyZXNwb25kaW5nIHRvIGVhY2hcbnBvZEFmZmluaXR5VGVybSBhcmUgaW50ZXJzZWN0ZWQsIGkuZS4gYWxsIHRlcm1zIG11c3QgYmUgc2F0aXNmaWVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiRGVmaW5lcyBhIHNldCBvZiBwb2RzIChuYW1lbHkgdGhvc2UgbWF0Y2hpbmcgdGhlIGxhYmVsU2VsZWN0b3JcbnJlbGF0aXZlIHRvIHRoZSBnaXZlbiBuYW1lc3BhY2UocykpIHRoYXQgdGhpcyBwb2Qgc2hvdWxkIGJlXG5jby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGgsXG53aGVyZSBjby1sb2NhdGVkIGlzIGRlZmluZWQgYXMgcnVubmluZyBvbiBhIG5vZGUgd2hvc2UgdmFsdWUgb2ZcbnRoZSBsYWJlbCB3aXRoIGtleSBcdTAwM2N0b3BvbG9neUtleVx1MDAzZSBtYXRjaGVzIHRoYXQgb2YgYW55IG5vZGUgb24gd2hpY2hcbmEgcG9kIG9mIHRoZSBzZXQgb2YgcG9kcyBpcyBydW5uaW5nIiwicHJvcGVydGllcyI6eyJsYWJlbFNlbGVjdG9yIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBxdWVyeSBvdmVyIGEgc2V0IG9mIHJlc291cmNlcywgaW4gdGhpcyBjYXNlIHBvZHMuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoibWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvciB0aGF0XG5yZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6ImtleSBpcyB0aGUgbGFiZWwga2V5IHRoYXQgdGhlIHNlbGVjdG9yIGFwcGxpZXMgdG8uIiwidHlwZSI6InN0cmluZyJ9LCJvcGVyYXRvciI6eyJkZXNjcmlwdGlvbiI6Im9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLlxuVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LiIsInR5cGUiOiJzdHJpbmcifSwidmFsdWVzIjp7ImRlc2NyaXB0aW9uIjoidmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpY1xubWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoTGFiZWxzIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjp7InR5cGUiOiJzdHJpbmcifSwiZGVzY3JpcHRpb24iOiJtYXRjaExhYmVscyBpcyBhIG1hcCBvZiB7a2V5LHZhbHVlfSBwYWlycy4gQSBzaW5nbGUge2tleSx2YWx1ZX0gaW4gdGhlIG1hdGNoTGFiZWxzXG5tYXAgaXMgZXF1aXZhbGVudCB0byBhbiBlbGVtZW50IG9mIG1hdGNoRXhwcmVzc2lvbnMsIHdob3NlIGtleSBmaWVsZCBpcyBcImtleVwiLCB0aGVcbm9wZXJhdG9yIGlzIFwiSW5cIiwgYW5kIHRoZSB2YWx1ZXMgYXJyYXkgY29udGFpbnMgb25seSBcInZhbHVlXCIuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwibmFtZXNwYWNlU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgdGhlIHNldCBvZiBuYW1lc3BhY2VzIHRoYXQgdGhlIHRlcm0gYXBwbGllcyB0by5cblRoZSB0ZXJtIGlzIGFwcGxpZWQgdG8gdGhlIHVuaW9uIG9mIHRoZSBuYW1lc3BhY2VzIHNlbGVjdGVkIGJ5IHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBsaXN0ZWQgaW4gdGhlIG5hbWVzcGFjZXMgZmllbGQuXG5udWxsIHNlbGVjdG9yIGFuZCBudWxsIG9yIGVtcHR5IG5hbWVzcGFjZXMgbGlzdCBtZWFucyBcInRoaXMgcG9kJ3MgbmFtZXNwYWNlXCIuXG5BbiBlbXB0eSBzZWxlY3RvciAoe30pIG1hdGNoZXMgYWxsIG5hbWVzcGFjZXMuIiwicHJvcGVydGllcyI6eyJtYXRjaEV4cHJlc3Npb25zIjp7ImRlc2NyaXB0aW9uIjoibWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnQgaXMgYSBzZWxlY3RvciB0aGF0IGNvbnRhaW5zIHZhbHVlcywgYSBrZXksIGFuZCBhbiBvcGVyYXRvciB0aGF0XG5yZWxhdGVzIHRoZSBrZXkgYW5kIHZhbHVlcy4iLCJwcm9wZXJ0aWVzIjp7ImtleSI6eyJkZXNjcmlwdGlvbiI6ImtleSBpcyB0aGUgbGFiZWwga2V5IHRoYXQgdGhlIHNlbGVjdG9yIGFwcGxpZXMgdG8uIiwidHlwZSI6InN0cmluZyJ9LCJvcGVyYXRvciI6eyJkZXNjcmlwdGlvbiI6Im9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLlxuVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LiIsInR5cGUiOiJzdHJpbmcifSwidmFsdWVzIjp7ImRlc2NyaXB0aW9uIjoidmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbixcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpY1xubWVyZ2UgcGF0Y2guIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifX0sInJlcXVpcmVkIjpbImtleSIsIm9wZXJhdG9yIl0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sIm1hdGNoTGFiZWxzIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjp7InR5cGUiOiJzdHJpbmcifSwiZGVzY3JpcHRpb24iOiJtYXRjaExhYmVscyBpcyBhIG1hcCBvZiB7a2V5LHZhbHVlfSBwYWlycy4gQSBzaW5nbGUge2tleSx2YWx1ZX0gaW4gdGhlIG1hdGNoTGFiZWxzXG5tYXAgaXMgZXF1aXZhbGVudCB0byBhbiBlbGVtZW50IG9mIG1hdGNoRXhwcmVzc2lvbnMsIHdob3NlIGtleSBmaWVsZCBpcyBcImtleVwiLCB0aGVcbm9wZXJhdG9yIGlzIFwiSW5cIiwgYW5kIHRoZSB2YWx1ZXMgYXJyYXkgY29udGFpbnMgb25seSBcInZhbHVlXCIuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwibmFtZXNwYWNlcyI6eyJkZXNjcmlwdGlvbiI6Im5hbWVzcGFjZXMgc3BlY2lmaWVzIGEgc3RhdGljIGxpc3Qgb2YgbmFtZXNwYWNlIG5hbWVzIHRoYXQgdGhlIHRlcm0gYXBwbGllcyB0by5cblRoZSB0ZXJtIGlzIGFwcGxpZWQgdG8gdGhlIHVuaW9uIG9mIHRoZSBuYW1lc3BhY2VzIGxpc3RlZCBpbiB0aGlzIGZpZWxkXG5hbmQgdGhlIG9uZXMgc2VsZWN0ZWQgYnkgbmFtZXNwYWNlU2VsZWN0b3IuXG5udWxsIG9yIGVtcHR5IG5hbWVzcGFjZXMgbGlzdCBhbmQgbnVsbCBuYW1lc3BhY2VTZWxlY3RvciBtZWFucyBcInRoaXMgcG9kJ3MgbmFtZXNwYWNlXCIuIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyJ9LCJ0eXBlIjoiYXJyYXkifSwidG9wb2xvZ3lLZXkiOnsiZGVzY3JpcHRpb24iOiJUaGlzIHBvZCBzaG91bGQgYmUgY28tbG9jYXRlZCAoYWZmaW5pdHkpIG9yIG5vdCBjby1sb2NhdGVkIChhbnRpLWFmZmluaXR5KSB3aXRoIHRoZSBwb2RzIG1hdGNoaW5nXG50aGUgbGFiZWxTZWxlY3RvciBpbiB0aGUgc3BlY2lmaWVkIG5hbWVzcGFjZXMsIHdoZXJlIGNvLWxvY2F0ZWQgaXMgZGVmaW5lZCBhcyBydW5uaW5nIG9uIGEgbm9kZVxud2hvc2UgdmFsdWUgb2YgdGhlIGxhYmVsIHdpdGgga2V5IHRvcG9sb2d5S2V5IG1hdGNoZXMgdGhhdCBvZiBhbnkgbm9kZSBvbiB3aGljaCBhbnkgb2YgdGhlXG5zZWxlY3RlZCBwb2RzIGlzIHJ1bm5pbmcuXG5FbXB0eSB0b3BvbG9neUtleSBpcyBub3QgYWxsb3dlZC4iLCJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJ0b3BvbG9neUtleSJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9fSwidHlwZSI6Im9iamVjdCJ9LCJwb2RBbnRpQWZmaW5pdHkiOnsiZGVzY3JpcHRpb24iOiJEZXNjcmliZXMgcG9kIGFudGktYWZmaW5pdHkgc2NoZWR1bGluZyBydWxlcyAoZS5nLiBhdm9pZCBwdXR0aW5nIHRoaXMgcG9kIGluIHRoZSBzYW1lIG5vZGUsIHpvbmUsIGV0Yy4gYXMgc29tZSBvdGhlciBwb2QocykpLiIsInByb3BlcnRpZXMiOnsicHJlZmVycmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJUaGUgc2NoZWR1bGVyIHdpbGwgcHJlZmVyIHRvIHNjaGVkdWxlIHBvZHMgdG8gbm9kZXMgdGhhdCBzYXRpc2Z5XG50aGUgYW50aS1hZmZpbml0eSBleHByZXNzaW9ucyBzcGVjaWZpZWQgYnkgdGhpcyBmaWVsZCwgYnV0IGl0IG1heSBjaG9vc2VcbmEgbm9kZSB0aGF0IHZpb2xhdGVzIG9uZSBvciBtb3JlIG9mIHRoZSBleHByZXNzaW9ucy4gVGhlIG5vZGUgdGhhdCBpc1xubW9zdCBwcmVmZXJyZWQgaXMgdGhlIG9uZSB3aXRoIHRoZSBncmVhdGVzdCBzdW0gb2Ygd2VpZ2h0cywgaS5lLlxuZm9yIGVhY2ggbm9kZSB0aGF0IG1lZXRzIGFsbCBvZiB0aGUgc2NoZWR1bGluZyByZXF1aXJlbWVudHMgKHJlc291cmNlXG5yZXF1ZXN0LCByZXF1aXJlZER1cmluZ1NjaGVkdWxpbmcgYW50aS1hZmZpbml0eSBleHByZXNzaW9ucywgZXRjLiksXG5jb21wdXRlIGEgc3VtIGJ5IGl0ZXJhdGluZyB0aHJvdWdoIHRoZSBlbGVtZW50cyBvZiB0aGlzIGZpZWxkIGFuZCBhZGRpbmdcblwid2VpZ2h0XCIgdG8gdGhlIHN1bSBpZiB0aGUgbm9kZSBoYXMgcG9kcyB3aGljaCBtYXRjaGVzIHRoZSBjb3JyZXNwb25kaW5nIHBvZEFmZmluaXR5VGVybTsgdGhlXG5ub2RlKHMpIHdpdGggdGhlIGhpZ2hlc3Qgc3VtIGFyZSB0aGUgbW9zdCBwcmVmZXJyZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJUaGUgd2VpZ2h0cyBvZiBhbGwgb2YgdGhlIG1hdGNoZWQgV2VpZ2h0ZWRQb2RBZmZpbml0eVRlcm0gZmllbGRzIGFyZSBhZGRlZCBwZXItbm9kZSB0byBmaW5kIHRoZSBtb3N0IHByZWZlcnJlZCBub2RlKHMpIiwicHJvcGVydGllcyI6eyJwb2RBZmZpbml0eVRlcm0iOnsiZGVzY3JpcHRpb24iOiJSZXF1aXJlZC4gQSBwb2QgYWZmaW5pdHkgdGVybSwgYXNzb2NpYXRlZCB3aXRoIHRoZSBjb3JyZXNwb25kaW5nIHdlaWdodC4iLCJwcm9wZXJ0aWVzIjp7ImxhYmVsU2VsZWN0b3IiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHF1ZXJ5IG92ZXIgYSBzZXQgb2YgcmVzb3VyY2VzLCBpbiB0aGlzIGNhc2UgcG9kcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciB0aGUgc2V0IG9mIG5hbWVzcGFjZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgc2VsZWN0ZWQgYnkgdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIGxpc3RlZCBpbiB0aGUgbmFtZXNwYWNlcyBmaWVsZC5cbm51bGwgc2VsZWN0b3IgYW5kIG51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi5cbkFuIGVtcHR5IHNlbGVjdG9yICh7fSkgbWF0Y2hlcyBhbGwgbmFtZXNwYWNlcy4iLCJwcm9wZXJ0aWVzIjp7Im1hdGNoRXhwcmVzc2lvbnMiOnsiZGVzY3JpcHRpb24iOiJtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudCBpcyBhIHNlbGVjdG9yIHRoYXQgY29udGFpbnMgdmFsdWVzLCBhIGtleSwgYW5kIGFuIG9wZXJhdG9yIHRoYXRcbnJlbGF0ZXMgdGhlIGtleSBhbmQgdmFsdWVzLiIsInByb3BlcnRpZXMiOnsia2V5Ijp7ImRlc2NyaXB0aW9uIjoia2V5IGlzIHRoZSBsYWJlbCBrZXkgdGhhdCB0aGUgc2VsZWN0b3IgYXBwbGllcyB0by4iLCJ0eXBlIjoic3RyaW5nIn0sIm9wZXJhdG9yIjp7ImRlc2NyaXB0aW9uIjoib3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuXG5WYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuIiwidHlwZSI6InN0cmluZyJ9LCJ2YWx1ZXMiOnsiZGVzY3JpcHRpb24iOiJ2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLFxudGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljXG5tZXJnZSBwYXRjaC4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9fSwicmVxdWlyZWQiOlsia2V5Iiwib3BlcmF0b3IiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifSwibWF0Y2hMYWJlbHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyJ9LCJkZXNjcmlwdGlvbiI6Im1hdGNoTGFiZWxzIGlzIGEgbWFwIG9mIHtrZXksdmFsdWV9IHBhaXJzLiBBIHNpbmdsZSB7a2V5LHZhbHVlfSBpbiB0aGUgbWF0Y2hMYWJlbHNcbm1hcCBpcyBlcXVpdmFsZW50IHRvIGFuIGVsZW1lbnQgb2YgbWF0Y2hFeHByZXNzaW9ucywgd2hvc2Uga2V5IGZpZWxkIGlzIFwia2V5XCIsIHRoZVxub3BlcmF0b3IgaXMgXCJJblwiLCBhbmQgdGhlIHZhbHVlcyBhcnJheSBjb250YWlucyBvbmx5IFwidmFsdWVcIi4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCIsIngta3ViZXJuZXRlcy1tYXAtdHlwZSI6ImF0b21pYyJ9LCJuYW1lc3BhY2VzIjp7ImRlc2NyaXB0aW9uIjoibmFtZXNwYWNlcyBzcGVjaWZpZXMgYSBzdGF0aWMgbGlzdCBvZiBuYW1lc3BhY2UgbmFtZXMgdGhhdCB0aGUgdGVybSBhcHBsaWVzIHRvLlxuVGhlIHRlcm0gaXMgYXBwbGllZCB0byB0aGUgdW5pb24gb2YgdGhlIG5hbWVzcGFjZXMgbGlzdGVkIGluIHRoaXMgZmllbGRcbmFuZCB0aGUgb25lcyBzZWxlY3RlZCBieSBuYW1lc3BhY2VTZWxlY3Rvci5cbm51bGwgb3IgZW1wdHkgbmFtZXNwYWNlcyBsaXN0IGFuZCBudWxsIG5hbWVzcGFjZVNlbGVjdG9yIG1lYW5zIFwidGhpcyBwb2QncyBuYW1lc3BhY2VcIi4iLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJ0b3BvbG9neUtleSI6eyJkZXNjcmlwdGlvbiI6IlRoaXMgcG9kIHNob3VsZCBiZSBjby1sb2NhdGVkIChhZmZpbml0eSkgb3Igbm90IGNvLWxvY2F0ZWQgKGFudGktYWZmaW5pdHkpIHdpdGggdGhlIHBvZHMgbWF0Y2hpbmdcbnRoZSBsYWJlbFNlbGVjdG9yIGluIHRoZSBzcGVjaWZpZWQgbmFtZXNwYWNlcywgd2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlXG53aG9zZSB2YWx1ZSBvZiB0aGUgbGFiZWwgd2l0aCBrZXkgdG9wb2xvZ3lLZXkgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoIGFueSBvZiB0aGVcbnNlbGVjdGVkIHBvZHMgaXMgcnVubmluZy5cbkVtcHR5IHRvcG9sb2d5S2V5IGlzIG5vdCBhbGxvd2VkLiIsInR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInRvcG9sb2d5S2V5Il0sInR5cGUiOiJvYmplY3QifSwid2VpZ2h0Ijp7ImRlc2NyaXB0aW9uIjoid2VpZ2h0IGFzc29jaWF0ZWQgd2l0aCBtYXRjaGluZyB0aGUgY29ycmVzcG9uZGluZyBwb2RBZmZpbml0eVRlcm0sXG5pbiB0aGUgcmFuZ2UgMS0xMDAuIiwiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwicmVxdWlyZWQiOlsicG9kQWZmaW5pdHlUZXJtIiwid2VpZ2h0Il0sInR5cGUiOiJvYmplY3QifSwidHlwZSI6ImFycmF5In0sInJlcXVpcmVkRHVyaW5nU2NoZWR1bGluZ0lnbm9yZWREdXJpbmdFeGVjdXRpb24iOnsiZGVzY3JpcHRpb24iOiJJZiB0aGUgYW50aS1hZmZpbml0eSByZXF1aXJlbWVudHMgc3BlY2lmaWVkIGJ5IHRoaXMgZmllbGQgYXJlIG5vdCBtZXQgYXRcbnNjaGVkdWxpbmcgdGltZSwgdGhlIHBvZCB3aWxsIG5vdCBiZSBzY2hlZHVsZWQgb250byB0aGUgbm9kZS5cbklmIHRoZSBhbnRpLWFmZmluaXR5IHJlcXVpcmVtZW50cyBzcGVjaWZpZWQgYnkgdGhpcyBmaWVsZCBjZWFzZSB0byBiZSBtZXRcbmF0IHNvbWUgcG9pbnQgZHVyaW5nIHBvZCBleGVjdXRpb24gKGUuZy4gZHVlIHRvIGEgcG9kIGxhYmVsIHVwZGF0ZSksIHRoZVxuc3lzdGVtIG1heSBvciBtYXkgbm90IHRyeSB0byBldmVudHVhbGx5IGV2aWN0IHRoZSBwb2QgZnJvbSBpdHMgbm9kZS5cbldoZW4gdGhlcmUgYXJlIG11bHRpcGxlIGVsZW1lbnRzLCB0aGUgbGlzdHMgb2Ygbm9kZXMgY29ycmVzcG9uZGluZyB0byBlYWNoXG5wb2RBZmZpbml0eVRlcm0gYXJlIGludGVyc2VjdGVkLCBpLmUuIGFsbCB0ZXJtcyBtdXN0IGJlIHNhdGlzZmllZC4iLCJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IkRlZmluZXMgYSBzZXQgb2YgcG9kcyAobmFtZWx5IHRob3NlIG1hdGNoaW5nIHRoZSBsYWJlbFNlbGVjdG9yXG5yZWxhdGl2ZSB0byB0aGUgZ2l2ZW4gbmFtZXNwYWNlKHMpKSB0aGF0IHRoaXMgcG9kIHNob3VsZCBiZVxuY28tbG9jYXRlZCAoYWZmaW5pdHkpIG9yIG5vdCBjby1sb2NhdGVkIChhbnRpLWFmZmluaXR5KSB3aXRoLFxud2hlcmUgY28tbG9jYXRlZCBpcyBkZWZpbmVkIGFzIHJ1bm5pbmcgb24gYSBub2RlIHdob3NlIHZhbHVlIG9mXG50aGUgbGFiZWwgd2l0aCBrZXkgXHUwMDNjdG9wb2xvZ3lLZXlcdTAwM2UgbWF0Y2hlcyB0aGF0IG9mIGFueSBub2RlIG9uIHdoaWNoXG5hIHBvZCBvZiB0aGUgc2V0IG9mIHBvZHMgaXMgcnVubmluZyIsInByb3BlcnRpZXMiOnsibGFiZWxTZWxlY3RvciI6eyJkZXNjcmlwdGlvbiI6IkEgbGFiZWwgcXVlcnkgb3ZlciBhIHNldCBvZiByZXNvdXJjZXMsIGluIHRoaXMgY2FzZSBwb2RzLiIsInByb3BlcnRpZXMiOnsibWF0Y2hFeHByZXNzaW9ucyI6eyJkZXNjcmlwdGlvbiI6Im1hdGNoRXhwcmVzc2lvbnMgaXMgYSBsaXN0IG9mIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50cy4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50IGlzIGEgc2VsZWN0b3IgdGhhdCBjb250YWlucyB2YWx1ZXMsIGEga2V5LCBhbmQgYW4gb3BlcmF0b3IgdGhhdFxucmVsYXRlcyB0aGUga2V5IGFuZCB2YWx1ZXMuIiwicHJvcGVydGllcyI6eyJrZXkiOnsiZGVzY3JpcHRpb24iOiJrZXkgaXMgdGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6InZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWNcbm1lcmdlIHBhdGNoLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJrZXkiLCJvcGVyYXRvciJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJtYXRjaExhYmVscyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJ0eXBlIjoic3RyaW5nIn0sImRlc2NyaXB0aW9uIjoibWF0Y2hMYWJlbHMgaXMgYSBtYXAgb2Yge2tleSx2YWx1ZX0gcGFpcnMuIEEgc2luZ2xlIHtrZXksdmFsdWV9IGluIHRoZSBtYXRjaExhYmVsc1xubWFwIGlzIGVxdWl2YWxlbnQgdG8gYW4gZWxlbWVudCBvZiBtYXRjaEV4cHJlc3Npb25zLCB3aG9zZSBrZXkgZmllbGQgaXMgXCJrZXlcIiwgdGhlXG5vcGVyYXRvciBpcyBcIkluXCIsIGFuZCB0aGUgdmFsdWVzIGFycmF5IGNvbnRhaW5zIG9ubHkgXCJ2YWx1ZVwiLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIm5hbWVzcGFjZVNlbGVjdG9yIjp7ImRlc2NyaXB0aW9uIjoiQSBsYWJlbCBxdWVyeSBvdmVyIHRoZSBzZXQgb2YgbmFtZXNwYWNlcyB0aGF0IHRoZSB0ZXJtIGFwcGxpZXMgdG8uXG5UaGUgdGVybSBpcyBhcHBsaWVkIHRvIHRoZSB1bmlvbiBvZiB0aGUgbmFtZXNwYWNlcyBzZWxlY3RlZCBieSB0aGlzIGZpZWxkXG5hbmQgdGhlIG9uZXMgbGlzdGVkIGluIHRoZSBuYW1lc3BhY2VzIGZpZWxkLlxubnVsbCBzZWxlY3RvciBhbmQgbnVsbCBvciBlbXB0eSBuYW1lc3BhY2VzIGxpc3QgbWVhbnMgXCJ0aGlzIHBvZCdzIG5hbWVzcGFjZVwiLlxuQW4gZW1wdHkgc2VsZWN0b3IgKHt9KSBtYXRjaGVzIGFsbCBuYW1lc3BhY2VzLiIsInByb3BlcnRpZXMiOnsibWF0Y2hFeHByZXNzaW9ucyI6eyJkZXNjcmlwdGlvbiI6Im1hdGNoRXhwcmVzc2lvbnMgaXMgYSBsaXN0IG9mIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50cy4gVGhlIHJlcXVpcmVtZW50cyBhcmUgQU5EZWQuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJBIGxhYmVsIHNlbGVjdG9yIHJlcXVpcmVtZW50IGlzIGEgc2VsZWN0b3IgdGhhdCBjb250YWlucyB2YWx1ZXMsIGEga2V5LCBhbmQgYW4gb3BlcmF0b3IgdGhhdFxucmVsYXRlcyB0aGUga2V5IGFuZCB2YWx1ZXMuIiwicHJvcGVydGllcyI6eyJrZXkiOnsiZGVzY3JpcHRpb24iOiJrZXkgaXMgdGhlIGxhYmVsIGtleSB0aGF0IHRoZSBzZWxlY3RvciBhcHBsaWVzIHRvLiIsInR5cGUiOiJzdHJpbmcifSwib3BlcmF0b3IiOnsiZGVzY3JpcHRpb24iOiJvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy5cblZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4iLCJ0eXBlIjoic3RyaW5nIn0sInZhbHVlcyI6eyJkZXNjcmlwdGlvbiI6InZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sXG50aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCxcbnRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWNcbm1lcmdlIHBhdGNoLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJrZXkiLCJvcGVyYXRvciJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJtYXRjaExhYmVscyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJ0eXBlIjoic3RyaW5nIn0sImRlc2NyaXB0aW9uIjoibWF0Y2hMYWJlbHMgaXMgYSBtYXAgb2Yge2tleSx2YWx1ZX0gcGFpcnMuIEEgc2luZ2xlIHtrZXksdmFsdWV9IGluIHRoZSBtYXRjaExhYmVsc1xubWFwIGlzIGVxdWl2YWxlbnQgdG8gYW4gZWxlbWVudCBvZiBtYXRjaEV4cHJlc3Npb25zLCB3aG9zZSBrZXkgZmllbGQgaXMgXCJrZXlcIiwgdGhlXG5vcGVyYXRvciBpcyBcIkluXCIsIGFuZCB0aGUgdmFsdWVzIGFycmF5IGNvbnRhaW5zIG9ubHkgXCJ2YWx1ZVwiLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLW1hcC10eXBlIjoiYXRvbWljIn0sIm5hbWVzcGFjZXMiOnsiZGVzY3JpcHRpb24iOiJuYW1lc3BhY2VzIHNwZWNpZmllcyBhIHN0YXRpYyBsaXN0IG9mIG5hbWVzcGFjZSBuYW1lcyB0aGF0IHRoZSB0ZXJtIGFwcGxpZXMgdG8uXG5UaGUgdGVybSBpcyBhcHBsaWVkIHRvIHRoZSB1bmlvbiBvZiB0aGUgbmFtZXNwYWNlcyBsaXN0ZWQgaW4gdGhpcyBmaWVsZFxuYW5kIHRoZSBvbmVzIHNlbGVjdGVkIGJ5IG5hbWVzcGFjZVNlbGVjdG9yLlxubnVsbCBvciBlbXB0eSBuYW1lc3BhY2VzIGxpc3QgYW5kIG51bGwgbmFtZXNwYWNlU2VsZWN0b3IgbWVhbnMgXCJ0aGlzIHBvZCdzIG5hbWVzcGFjZVwiLiIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In0sInRvcG9sb2d5S2V5Ijp7ImRlc2NyaXB0aW9uIjoiVGhpcyBwb2Qgc2hvdWxkIGJlIGNvLWxvY2F0ZWQgKGFmZmluaXR5KSBvciBub3QgY28tbG9jYXRlZCAoYW50aS1hZmZpbml0eSkgd2l0aCB0aGUgcG9kcyBtYXRjaGluZ1xudGhlIGxhYmVsU2VsZWN0b3IgaW4gdGhlIHNwZWNpZmllZCBuYW1lc3BhY2VzLCB3aGVyZSBjby1sb2NhdGVkIGlzIGRlZmluZWQgYXMgcnVubmluZyBvbiBhIG5vZGVcbndob3NlIHZhbHVlIG9mIHRoZSBsYWJlbCB3aXRoIGtleSB0b3BvbG9neUtleSBtYXRjaGVzIHRoYXQgb2YgYW55IG5vZGUgb24gd2hpY2ggYW55IG9mIHRoZVxuc2VsZWN0ZWQgcG9kcyBpcyBydW5uaW5nLlxuRW1wdHkgdG9wb2xvZ3lLZXkgaXMgbm90IGFsbG93ZWQuIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsidG9wb2xvZ3lLZXkiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkifX0sInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJvYmplY3QifSwiaW1hZ2UiOnsidHlwZSI6InN0cmluZyJ9LCJpbWFnZVB1bGxTZWNyZXRzIjp7Iml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwidHlwZSI6ImFycmF5In0sImxpbWl0cyI6eyJpdGVtcyI6eyJkZXNjcmlwdGlvbiI6IlJhdGVMaW1pdCBkZWZpbmVzIHRoZSBkZXNpcmVkIExpbWl0YWRvciBsaW1pdCIsInByb3BlcnRpZXMiOnsiY29uZGl0aW9ucyI6eyJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOiJhcnJheSJ9LCJtYXhfdmFsdWUiOnsidHlwZSI6ImludGVnZXIifSwibmFtZSI6eyJ0eXBlIjoic3RyaW5nIn0sIm5hbWVzcGFjZSI6eyJ0eXBlIjoic3RyaW5nIn0sInNlY29uZHMiOnsidHlwZSI6ImludGVnZXIifSwidmFyaWFibGVzIjp7Iml0ZW1zIjp7InR5cGUiOiJzdHJpbmcifSwidHlwZSI6ImFycmF5In19LCJyZXF1aXJlZCI6WyJjb25kaXRpb25zIiwibWF4X3ZhbHVlIiwibmFtZXNwYWNlIiwic2Vjb25kcyIsInZhcmlhYmxlcyJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSJ9LCJsaXN0ZW5lciI6eyJwcm9wZXJ0aWVzIjp7ImdycGMiOnsicHJvcGVydGllcyI6eyJwb3J0Ijp7ImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifX0sInR5cGUiOiJvYmplY3QifSwiaHR0cCI6eyJwcm9wZXJ0aWVzIjp7InBvcnQiOnsiZm9ybWF0IjoiaW50MzIiLCJ0eXBlIjoiaW50ZWdlciJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9LCJwZGIiOnsicHJvcGVydGllcyI6eyJtYXhVbmF2YWlsYWJsZSI6eyJhbnlPZiI6W3sidHlwZSI6ImludGVnZXIifSx7InR5cGUiOiJzdHJpbmcifV0sImRlc2NyaXB0aW9uIjoiQW4gZXZpY3Rpb24gaXMgYWxsb3dlZCBpZiBhdCBtb3N0IFwibWF4VW5hdmFpbGFibGVcIiBsaW1pdGFkb3IgcG9kc1xuYXJlIHVuYXZhaWxhYmxlIGFmdGVyIHRoZSBldmljdGlvbiwgaS5lLiBldmVuIGluIGFic2VuY2Ugb2ZcbnRoZSBldmljdGVkIHBvZC4gRm9yIGV4YW1wbGUsIG9uZSBjYW4gcHJldmVudCBhbGwgdm9sdW50YXJ5IGV2aWN0aW9uc1xuYnkgc3BlY2lmeWluZyAwLiBUaGlzIGlzIGEgbXV0dWFsbHkgZXhjbHVzaXZlIHNldHRpbmcgd2l0aCBcIm1pbkF2YWlsYWJsZVwiLiIsIngta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nIjp0cnVlfSwibWluQXZhaWxhYmxlIjp7ImFueU9mIjpbeyJ0eXBlIjoiaW50ZWdlciJ9LHsidHlwZSI6InN0cmluZyJ9XSwiZGVzY3JpcHRpb24iOiJBbiBldmljdGlvbiBpcyBhbGxvd2VkIGlmIGF0IGxlYXN0IFwibWluQXZhaWxhYmxlXCIgbGltaXRhZG9yIHBvZHMgd2lsbFxuc3RpbGwgYmUgYXZhaWxhYmxlIGFmdGVyIHRoZSBldmljdGlvbiwgaS5lLiBldmVuIGluIHRoZSBhYnNlbmNlIG9mXG50aGUgZXZpY3RlZCBwb2QuICBTbyBmb3IgZXhhbXBsZSB5b3UgY2FuIHByZXZlbnQgYWxsIHZvbHVudGFyeVxuZXZpY3Rpb25zIGJ5IHNwZWNpZnlpbmcgXCIxMDAlXCIuIiwieC1rdWJlcm5ldGVzLWludC1vci1zdHJpbmciOnRydWV9fSwidHlwZSI6Im9iamVjdCJ9LCJyYXRlTGltaXRIZWFkZXJzIjp7ImRlc2NyaXB0aW9uIjoiUmF0ZUxpbWl0SGVhZGVyc1R5cGUgZGVmaW5lcyB0aGUgdmFsaWQgb3B0aW9ucyBmb3IgdGhlIC0tcmF0ZS1saW1pdC1oZWFkZXJzIGFyZyIsImVudW0iOlsiTk9ORSIsIkRSQUZUX1ZFUlNJT05fMDMiXSwidHlwZSI6InN0cmluZyJ9LCJyZXBsaWNhcyI6eyJ0eXBlIjoiaW50ZWdlciJ9LCJyZXNvdXJjZVJlcXVpcmVtZW50cyI6eyJkZXNjcmlwdGlvbiI6IlJlc291cmNlUmVxdWlyZW1lbnRzIGRlc2NyaWJlcyB0aGUgY29tcHV0ZSByZXNvdXJjZSByZXF1aXJlbWVudHMuIiwicHJvcGVydGllcyI6eyJjbGFpbXMiOnsiZGVzY3JpcHRpb24iOiJDbGFpbXMgbGlzdHMgdGhlIG5hbWVzIG9mIHJlc291cmNlcywgZGVmaW5lZCBpbiBzcGVjLnJlc291cmNlQ2xhaW1zLFxudGhhdCBhcmUgdXNlZCBieSB0aGlzIGNvbnRhaW5lci5cblxuXG5UaGlzIGlzIGFuIGFscGhhIGZpZWxkIGFuZCByZXF1aXJlcyBlbmFibGluZyB0aGVcbkR5bmFtaWNSZXNvdXJjZUFsbG9jYXRpb24gZmVhdHVyZSBnYXRlLlxuXG5cblRoaXMgZmllbGQgaXMgaW1tdXRhYmxlLiBJdCBjYW4gb25seSBiZSBzZXQgZm9yIGNvbnRhaW5lcnMuIiwiaXRlbXMiOnsiZGVzY3JpcHRpb24iOiJSZXNvdXJjZUNsYWltIHJlZmVyZW5jZXMgb25lIGVudHJ5IGluIFBvZFNwZWMuUmVzb3VyY2VDbGFpbXMuIiwicHJvcGVydGllcyI6eyJuYW1lIjp7ImRlc2NyaXB0aW9uIjoiTmFtZSBtdXN0IG1hdGNoIHRoZSBuYW1lIG9mIG9uZSBlbnRyeSBpbiBwb2Quc3BlYy5yZXNvdXJjZUNsYWltcyBvZlxudGhlIFBvZCB3aGVyZSB0aGlzIGZpZWxkIGlzIHVzZWQuIEl0IG1ha2VzIHRoYXQgcmVzb3VyY2UgYXZhaWxhYmxlXG5pbnNpZGUgYSBjb250YWluZXIuIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsibmFtZSJdLCJ0eXBlIjoib2JqZWN0In0sInR5cGUiOiJhcnJheSIsIngta3ViZXJuZXRlcy1saXN0LW1hcC1rZXlzIjpbIm5hbWUiXSwieC1rdWJlcm5ldGVzLWxpc3QtdHlwZSI6Im1hcCJ9LCJsaW1pdHMiOnsiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsiYW55T2YiOlt7InR5cGUiOiJpbnRlZ2VyIn0seyJ0eXBlIjoic3RyaW5nIn1dLCJwYXR0ZXJuIjoiXihcXCt8LSk/KChbMC05XSsoXFwuWzAtOV0qKT8pfChcXC5bMC05XSspKSgoW0tNR1RQRV1pKXxbbnVta01HVFBFXXwoW2VFXShcXCt8LSk/KChbMC05XSsoXFwuWzAtOV0qKT8pfChcXC5bMC05XSspKSkpPyQiLCJ4LWt1YmVybmV0ZXMtaW50LW9yLXN0cmluZyI6dHJ1ZX0sImRlc2NyaXB0aW9uIjoiTGltaXRzIGRlc2NyaWJlcyB0aGUgbWF4aW11bSBhbW91bnQgb2YgY29tcHV0ZSByZXNvdXJjZXMgYWxsb3dlZC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvY29uZmlndXJhdGlvbi9tYW5hZ2UtcmVzb3VyY2VzLWNvbnRhaW5lcnMvIiwidHlwZSI6Im9iamVjdCJ9LCJyZXF1ZXN0cyI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6eyJhbnlPZiI6W3sidHlwZSI6ImludGVnZXIifSx7InR5cGUiOiJzdHJpbmcifV0sInBhdHRlcm4iOiJeKFxcK3wtKT8oKFswLTldKyhcXC5bMC05XSopPyl8KFxcLlswLTldKykpKChbS01HVFBFXWkpfFtudW1rTUdUUEVdfChbZUVdKFxcK3wtKT8oKFswLTldKyhcXC5bMC05XSopPyl8KFxcLlswLTldKykpKSk/JCIsIngta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nIjp0cnVlfSwiZGVzY3JpcHRpb24iOiJSZXF1ZXN0cyBkZXNjcmliZXMgdGhlIG1pbmltdW0gYW1vdW50IG9mIGNvbXB1dGUgcmVzb3VyY2VzIHJlcXVpcmVkLlxuSWYgUmVxdWVzdHMgaXMgb21pdHRlZCBmb3IgYSBjb250YWluZXIsIGl0IGRlZmF1bHRzIHRvIExpbWl0cyBpZiB0aGF0IGlzIGV4cGxpY2l0bHkgc3BlY2lmaWVkLFxub3RoZXJ3aXNlIHRvIGFuIGltcGxlbWVudGF0aW9uLWRlZmluZWQgdmFsdWUuIFJlcXVlc3RzIGNhbm5vdCBleGNlZWQgTGltaXRzLlxuTW9yZSBpbmZvOiBodHRwczovL2t1YmVybmV0ZXMuaW8vZG9jcy9jb25jZXB0cy9jb25maWd1cmF0aW9uL21hbmFnZS1yZXNvdXJjZXMtY29udGFpbmVycy8iLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In0sInN0b3JhZ2UiOnsiZGVzY3JpcHRpb24iOiJTdG9yYWdlIGNvbnRhaW5zIHRoZSBvcHRpb25zIGZvciBMaW1pdGFkb3IgY291bnRlcnMgZGF0YWJhc2Ugb3IgaW4tbWVtb3J5IGRhdGEgc3RvcmFnZSIsInByb3BlcnRpZXMiOnsiZGlzayI6eyJwcm9wZXJ0aWVzIjp7Im9wdGltaXplIjp7ImRlc2NyaXB0aW9uIjoiRGlza09wdGltaXplVHlwZSBkZWZpbmVzIHRoZSB2YWxpZCBvcHRpb25zIGZvciBcIm9wdGltaXplXCIgb3B0aW9uIG9mIHRoZSBkaXNrIHBlcnNpc3RlbmNlIHR5cGUiLCJlbnVtIjpbInRocm91Z2hwdXQiLCJkaXNrIl0sInR5cGUiOiJzdHJpbmcifSwicGVyc2lzdGVudFZvbHVtZUNsYWltIjp7InByb3BlcnRpZXMiOnsicmVzb3VyY2VzIjp7ImRlc2NyaXB0aW9uIjoiUmVzb3VyY2VzIHJlcHJlc2VudHMgdGhlIG1pbmltdW0gcmVzb3VyY2VzIHRoZSB2b2x1bWUgc2hvdWxkIGhhdmUuXG5JZ25vcmVkIHdoZW4gVm9sdW1lTmFtZSBmaWVsZCBpcyBzZXQiLCJwcm9wZXJ0aWVzIjp7InJlcXVlc3RzIjp7ImFueU9mIjpbeyJ0eXBlIjoiaW50ZWdlciJ9LHsidHlwZSI6InN0cmluZyJ9XSwiZGVzY3JpcHRpb24iOiJTdG9yYWdlIFJlc291cmNlIHJlcXVlc3RzIHRvIGJlIHVzZWQgb24gdGhlIFBlcnNpc3RlbnRWb2x1bWVDbGFpbS5cblRvIGxlYXJuIG1vcmUgYWJvdXQgcmVzb3VyY2UgcmVxdWVzdHMgc2VlOlxuaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvY29uZmlndXJhdGlvbi9tYW5hZ2UtcmVzb3VyY2VzLWNvbnRhaW5lcnMvIiwicGF0dGVybiI6Il4oXFwrfC0pPygoWzAtOV0rKFxcLlswLTldKik/KXwoXFwuWzAtOV0rKSkoKFtLTUdUUEVdaSl8W251bWtNR1RQRV18KFtlRV0oXFwrfC0pPygoWzAtOV0rKFxcLlswLTldKik/KXwoXFwuWzAtOV0rKSkpKT8kIiwieC1rdWJlcm5ldGVzLWludC1vci1zdHJpbmciOnRydWV9fSwicmVxdWlyZWQiOlsicmVxdWVzdHMiXSwidHlwZSI6Im9iamVjdCJ9LCJzdG9yYWdlQ2xhc3NOYW1lIjp7InR5cGUiOiJzdHJpbmcifSwidm9sdW1lTmFtZSI6eyJkZXNjcmlwdGlvbiI6IlZvbHVtZU5hbWUgaXMgdGhlIGJpbmRpbmcgcmVmZXJlbmNlIHRvIHRoZSBQZXJzaXN0ZW50Vm9sdW1lIGJhY2tpbmcgdGhpcyBjbGFpbS4iLCJ0eXBlIjoic3RyaW5nIn19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In0sInJlZGlzIjp7InByb3BlcnRpZXMiOnsiY29uZmlnU2VjcmV0UmVmIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifX0sInR5cGUiOiJvYmplY3QifSwicmVkaXMtY2FjaGVkIjp7InByb3BlcnRpZXMiOnsiY29uZmlnU2VjcmV0UmVmIjp7ImRlc2NyaXB0aW9uIjoiTG9jYWxPYmplY3RSZWZlcmVuY2UgY29udGFpbnMgZW5vdWdoIGluZm9ybWF0aW9uIHRvIGxldCB5b3UgbG9jYXRlIHRoZVxucmVmZXJlbmNlZCBvYmplY3QgaW5zaWRlIHRoZSBzYW1lIG5hbWVzcGFjZS4iLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsiZGVzY3JpcHRpb24iOiJOYW1lIG9mIHRoZSByZWZlcmVudC5cbk1vcmUgaW5mbzogaHR0cHM6Ly9rdWJlcm5ldGVzLmlvL2RvY3MvY29uY2VwdHMvb3ZlcnZpZXcvd29ya2luZy13aXRoLW9iamVjdHMvbmFtZXMvI25hbWVzXG5UT0RPOiBBZGQgb3RoZXIgdXNlZnVsIGZpZWxkcy4gYXBpVmVyc2lvbiwga2luZCwgdWlkPyIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QiLCJ4LWt1YmVybmV0ZXMtbWFwLXR5cGUiOiJhdG9taWMifSwib3B0aW9ucyI6eyJwcm9wZXJ0aWVzIjp7ImJhdGNoLXNpemUiOnsiZGVzY3JpcHRpb24iOiJCYXRjaFNpemUgZGVmaW5lcyB0aGUgc2l6ZSBvZiBlbnRyaWVzIHRvIGZsdXNoIGluIGFzIHNpbmdsZSBmbHVzaCBbZGVmYXVsdDogMTAwXSIsInR5cGUiOiJpbnRlZ2VyIn0sImZsdXNoLXBlcmlvZCI6eyJkZXNjcmlwdGlvbiI6IkZsdXNoUGVyaW9kIGZvciBjb3VudGVycyBpbiBtaWxsaXNlY29uZHMgW2RlZmF1bHQ6IDEwMDBdIiwidHlwZSI6ImludGVnZXIifSwibWF4LWNhY2hlZCI6eyJkZXNjcmlwdGlvbiI6Ik1heENhY2hlZCByZWZlcnMgdG8gdGhlIG1heGltdW0gYW1vdW50IG9mIGNvdW50ZXJzIGNhY2hlZCBbZGVmYXVsdDogMTAwMDBdIiwidHlwZSI6ImludGVnZXIifSwicmVzcG9uc2UtdGltZW91dCI6eyJkZXNjcmlwdGlvbiI6IlJlc3BvbnNlVGltZW91dCBkZWZpbmVzIHRoZSB0aW1lb3V0IGZvciBSZWRpcyBjb21tYW5kcyBpbiBtaWxsaXNlY29uZHMgW2RlZmF1bHQ6IDM1MF0iLCJ0eXBlIjoiaW50ZWdlciJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6Im9iamVjdCJ9LCJ0ZWxlbWV0cnkiOnsiZGVzY3JpcHRpb24iOiJUZWxlbWV0cnkgZGVmaW5lcyB0aGUgbGV2ZWwgb2YgbWV0cmljcyBMaW1pdGFkb3Igd2lsbCBleHBvc2UgdG8gdGhlIHVzZXIiLCJlbnVtIjpbImJhc2ljIiwiZXhoYXVzdGl2ZSJdLCJ0eXBlIjoic3RyaW5nIn0sInRyYWNpbmciOnsicHJvcGVydGllcyI6eyJlbmRwb2ludCI6eyJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJlbmRwb2ludCJdLCJ0eXBlIjoib2JqZWN0In0sInZlcmJvc2l0eSI6eyJkZXNjcmlwdGlvbiI6IlNldHMgdGhlIGxldmVsIG9mIHZlcmJvc2l0eSIsIm1heGltdW0iOjQsIm1pbmltdW0iOjEsInR5cGUiOiJpbnRlZ2VyIn0sInZlcnNpb24iOnsiZGVzY3JpcHRpb24iOiJbRGVwcmVjYXRlZF0gVXNlIHNwZWMuaW1hZ2UgaW5zdGVhZC5cbiBEb2NrZXIgdGFnIHVzZWQgYXMgbGltaXRhZG9yIGltYWdlLiBUaGUgcmVwbyBpcyBoYXJkY29kZWQgdG8gcXVheS5pby9rdWFkcmFudC9saW1pdGFkb3IiLCJ0eXBlIjoic3RyaW5nIn19LCJ0eXBlIjoib2JqZWN0IiwieC1rdWJlcm5ldGVzLXZhbGlkYXRpb25zIjpbeyJtZXNzYWdlIjoiZGlzayBzdG9yYWdlIGRvZXMgbm90IGFsbG93IG11bHRpcGxlIHJlcGxpY2FzIiwicnVsZSI6IighaGFzKHNlbGYuc3RvcmFnZSkgfHwgIWhhcyhzZWxmLnN0b3JhZ2UuZGlzaykpIHx8ICghaGFzKHNlbGYucmVwbGljYXMpIHx8IHNlbGYucmVwbGljYXMgXHUwMDNjIDIpIn1dfSwic3RhdHVzIjp7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yU3RhdHVzIGRlZmluZXMgdGhlIG9ic2VydmVkIHN0YXRlIG9mIExpbWl0YWRvciIsInByb3BlcnRpZXMiOnsiY29uZGl0aW9ucyI6eyJkZXNjcmlwdGlvbiI6IlJlcHJlc2VudHMgdGhlIG9ic2VydmF0aW9ucyBvZiBhIGZvbydzIGN1cnJlbnQgc3RhdGUuXG5Lbm93biAuc3RhdHVzLmNvbmRpdGlvbnMudHlwZSBhcmU6IFwiUmVhZHlcIiIsIml0ZW1zIjp7ImRlc2NyaXB0aW9uIjoiQ29uZGl0aW9uIGNvbnRhaW5zIGRldGFpbHMgZm9yIG9uZSBhc3BlY3Qgb2YgdGhlIGN1cnJlbnQgc3RhdGUgb2YgdGhpcyBBUEkgUmVzb3VyY2UuXG4tLS1cblRoaXMgc3RydWN0IGlzIGludGVuZGVkIGZvciBkaXJlY3QgdXNlIGFzIGFuIGFycmF5IGF0IHRoZSBmaWVsZCBwYXRoIC5zdGF0dXMuY29uZGl0aW9ucy4gIEZvciBleGFtcGxlLFxuXG5cblx0dHlwZSBGb29TdGF0dXMgc3RydWN0e1xuXHQgICAgLy8gUmVwcmVzZW50cyB0aGUgb2JzZXJ2YXRpb25zIG9mIGEgZm9vJ3MgY3VycmVudCBzdGF0ZS5cblx0ICAgIC8vIEtub3duIC5zdGF0dXMuY29uZGl0aW9ucy50eXBlIGFyZTogXCJBdmFpbGFibGVcIiwgXCJQcm9ncmVzc2luZ1wiLCBhbmQgXCJEZWdyYWRlZFwiXG5cdCAgICAvLyArcGF0Y2hNZXJnZUtleT10eXBlXG5cdCAgICAvLyArcGF0Y2hTdHJhdGVneT1tZXJnZVxuXHQgICAgLy8gK2xpc3RUeXBlPW1hcFxuXHQgICAgLy8gK2xpc3RNYXBLZXk9dHlwZVxuXHQgICAgQ29uZGl0aW9ucyBbXW1ldGF2MS5Db25kaXRpb24gYGpzb246XCJjb25kaXRpb25zLG9taXRlbXB0eVwiIHBhdGNoU3RyYXRlZ3k6XCJtZXJnZVwiIHBhdGNoTWVyZ2VLZXk6XCJ0eXBlXCIgcHJvdG9idWY6XCJieXRlcywxLHJlcCxuYW1lPWNvbmRpdGlvbnNcImBcblxuXG5cdCAgICAvLyBvdGhlciBmaWVsZHNcblx0fSIsInByb3BlcnRpZXMiOnsibGFzdFRyYW5zaXRpb25UaW1lIjp7ImRlc2NyaXB0aW9uIjoibGFzdFRyYW5zaXRpb25UaW1lIGlzIHRoZSBsYXN0IHRpbWUgdGhlIGNvbmRpdGlvbiB0cmFuc2l0aW9uZWQgZnJvbSBvbmUgc3RhdHVzIHRvIGFub3RoZXIuXG5UaGlzIHNob3VsZCBiZSB3aGVuIHRoZSB1bmRlcmx5aW5nIGNvbmRpdGlvbiBjaGFuZ2VkLiAgSWYgdGhhdCBpcyBub3Qga25vd24sIHRoZW4gdXNpbmcgdGhlIHRpbWUgd2hlbiB0aGUgQVBJIGZpZWxkIGNoYW5nZWQgaXMgYWNjZXB0YWJsZS4iLCJmb3JtYXQiOiJkYXRlLXRpbWUiLCJ0eXBlIjoic3RyaW5nIn0sIm1lc3NhZ2UiOnsiZGVzY3JpcHRpb24iOiJtZXNzYWdlIGlzIGEgaHVtYW4gcmVhZGFibGUgbWVzc2FnZSBpbmRpY2F0aW5nIGRldGFpbHMgYWJvdXQgdGhlIHRyYW5zaXRpb24uXG5UaGlzIG1heSBiZSBhbiBlbXB0eSBzdHJpbmcuIiwibWF4TGVuZ3RoIjozMjc2OCwidHlwZSI6InN0cmluZyJ9LCJvYnNlcnZlZEdlbmVyYXRpb24iOnsiZGVzY3JpcHRpb24iOiJvYnNlcnZlZEdlbmVyYXRpb24gcmVwcmVzZW50cyB0aGUgLm1ldGFkYXRhLmdlbmVyYXRpb24gdGhhdCB0aGUgY29uZGl0aW9uIHdhcyBzZXQgYmFzZWQgdXBvbi5cbkZvciBpbnN0YW5jZSwgaWYgLm1ldGFkYXRhLmdlbmVyYXRpb24gaXMgY3VycmVudGx5IDEyLCBidXQgdGhlIC5zdGF0dXMuY29uZGl0aW9uc1t4XS5vYnNlcnZlZEdlbmVyYXRpb24gaXMgOSwgdGhlIGNvbmRpdGlvbiBpcyBvdXQgb2YgZGF0ZVxud2l0aCByZXNwZWN0IHRvIHRoZSBjdXJyZW50IHN0YXRlIG9mIHRoZSBpbnN0YW5jZS4iLCJmb3JtYXQiOiJpbnQ2NCIsIm1pbmltdW0iOjAsInR5cGUiOiJpbnRlZ2VyIn0sInJlYXNvbiI6eyJkZXNjcmlwdGlvbiI6InJlYXNvbiBjb250YWlucyBhIHByb2dyYW1tYXRpYyBpZGVudGlmaWVyIGluZGljYXRpbmcgdGhlIHJlYXNvbiBmb3IgdGhlIGNvbmRpdGlvbidzIGxhc3QgdHJhbnNpdGlvbi5cblByb2R1Y2VycyBvZiBzcGVjaWZpYyBjb25kaXRpb24gdHlwZXMgbWF5IGRlZmluZSBleHBlY3RlZCB2YWx1ZXMgYW5kIG1lYW5pbmdzIGZvciB0aGlzIGZpZWxkLFxuYW5kIHdoZXRoZXIgdGhlIHZhbHVlcyBhcmUgY29uc2lkZXJlZCBhIGd1YXJhbnRlZWQgQVBJLlxuVGhlIHZhbHVlIHNob3VsZCBiZSBhIENhbWVsQ2FzZSBzdHJpbmcuXG5UaGlzIGZpZWxkIG1heSBub3QgYmUgZW1wdHkuIiwibWF4TGVuZ3RoIjoxMDI0LCJtaW5MZW5ndGgiOjEsInBhdHRlcm4iOiJeW0EtWmEtel0oW0EtWmEtejAtOV8sOl0qW0EtWmEtejAtOV9dKT8kIiwidHlwZSI6InN0cmluZyJ9LCJzdGF0dXMiOnsiZGVzY3JpcHRpb24iOiJzdGF0dXMgb2YgdGhlIGNvbmRpdGlvbiwgb25lIG9mIFRydWUsIEZhbHNlLCBVbmtub3duLiIsImVudW0iOlsiVHJ1ZSIsIkZhbHNlIiwiVW5rbm93biJdLCJ0eXBlIjoic3RyaW5nIn0sInR5cGUiOnsiZGVzY3JpcHRpb24iOiJ0eXBlIG9mIGNvbmRpdGlvbiBpbiBDYW1lbENhc2Ugb3IgaW4gZm9vLmV4YW1wbGUuY29tL0NhbWVsQ2FzZS5cbi0tLVxuTWFueSAuY29uZGl0aW9uLnR5cGUgdmFsdWVzIGFyZSBjb25zaXN0ZW50IGFjcm9zcyByZXNvdXJjZXMgbGlrZSBBdmFpbGFibGUsIGJ1dCBiZWNhdXNlIGFyYml0cmFyeSBjb25kaXRpb25zIGNhbiBiZVxudXNlZnVsIChzZWUgLm5vZGUuc3RhdHVzLmNvbmRpdGlvbnMpLCB0aGUgYWJpbGl0eSB0byBkZWNvbmZsaWN0IGlzIGltcG9ydGFudC5cblRoZSByZWdleCBpdCBtYXRjaGVzIGlzIChkbnMxMTIzU3ViZG9tYWluRm10Lyk/KHF1YWxpZmllZE5hbWVGbXQpIiwibWF4TGVuZ3RoIjozMTYsInBhdHRlcm4iOiJeKFthLXowLTldKFstYS16MC05XSpbYS16MC05XSk/KFxcLlthLXowLTldKFstYS16MC05XSpbYS16MC05XSk/KSovKT8oKFtBLVphLXowLTldWy1BLVphLXowLTlfLl0qKT9bQS1aYS16MC05XSkkIiwidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsibGFzdFRyYW5zaXRpb25UaW1lIiwibWVzc2FnZSIsInJlYXNvbiIsInN0YXR1cyIsInR5cGUiXSwidHlwZSI6Im9iamVjdCJ9LCJ0eXBlIjoiYXJyYXkiLCJ4LWt1YmVybmV0ZXMtbGlzdC1tYXAta2V5cyI6WyJ0eXBlIl0sIngta3ViZXJuZXRlcy1saXN0LXR5cGUiOiJtYXAifSwib2JzZXJ2ZWRHZW5lcmF0aW9uIjp7ImRlc2NyaXB0aW9uIjoiT2JzZXJ2ZWRHZW5lcmF0aW9uIHJlZmxlY3RzIHRoZSBnZW5lcmF0aW9uIG9mIHRoZSBtb3N0IHJlY2VudGx5IG9ic2VydmVkIHNwZWMuIiwiZm9ybWF0IjoiaW50NjQiLCJ0eXBlIjoiaW50ZWdlciJ9LCJzZXJ2aWNlIjp7ImRlc2NyaXB0aW9uIjoiU2VydmljZSBwcm92aWRlcyBpbmZvcm1hdGlvbiBhYm91dCB0aGUgc2VydmljZSBleHBvc2luZyBsaW1pdGFkb3IgQVBJIiwicHJvcGVydGllcyI6eyJob3N0Ijp7InR5cGUiOiJzdHJpbmcifSwicG9ydHMiOnsicHJvcGVydGllcyI6eyJncnBjIjp7ImZvcm1hdCI6ImludDMyIiwidHlwZSI6ImludGVnZXIifSwiaHR0cCI6eyJmb3JtYXQiOiJpbnQzMiIsInR5cGUiOiJpbnRlZ2VyIn19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19LCJzZXJ2ZWQiOnRydWUsInN0b3JhZ2UiOnRydWUsInN1YnJlc291cmNlcyI6eyJzdGF0dXMiOnt9fX1dfSwic3RhdHVzIjp7ImFjY2VwdGVkTmFtZXMiOnsia2luZCI6IiIsInBsdXJhbCI6IiJ9LCJjb25kaXRpb25zIjpudWxsLCJzdG9yZWRWZXJzaW9ucyI6bnVsbH19
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsiYWxtLWV4YW1wbGVzIjoiW1xuICB7XG4gICAgXCJhcGlWZXJzaW9uXCI6IFwibGltaXRhZG9yLmt1YWRyYW50LmlvL3YxYWxwaGExXCIsXG4gICAgXCJraW5kXCI6IFwiTGltaXRhZG9yXCIsXG4gICAgXCJtZXRhZGF0YVwiOiB7XG4gICAgICBcIm5hbWVcIjogXCJsaW1pdGFkb3Itc2FtcGxlXCJcbiAgICB9LFxuICAgIFwic3BlY1wiOiB7XG4gICAgICBcImxpbWl0c1wiOiBbXG4gICAgICAgIHtcbiAgICAgICAgICBcImNvbmRpdGlvbnNcIjogW1xuICAgICAgICAgICAgXCJnZXRfdG95ID09ICd5ZXMnXCJcbiAgICAgICAgICBdLFxuICAgICAgICAgIFwibWF4X3ZhbHVlXCI6IDIsXG4gICAgICAgICAgXCJuYW1lXCI6IFwidG95X2dldF9yb3V0ZVwiLFxuICAgICAgICAgIFwibmFtZXNwYWNlXCI6IFwidG95c3RvcmUtYXBwXCIsXG4gICAgICAgICAgXCJzZWNvbmRzXCI6IDMwLFxuICAgICAgICAgIFwidmFyaWFibGVzXCI6IFtdXG4gICAgICAgIH1cbiAgICAgIF0sXG4gICAgICBcImxpc3RlbmVyXCI6IHtcbiAgICAgICAgXCJncnBjXCI6IHtcbiAgICAgICAgICBcInBvcnRcIjogODA4MVxuICAgICAgICB9LFxuICAgICAgICBcImh0dHBcIjoge1xuICAgICAgICAgIFwicG9ydFwiOiA4MDgwXG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9XG4gIH1cbl0iLCJjYXBhYmlsaXRpZXMiOiJCYXNpYyBJbnN0YWxsIiwiY2F0ZWdvcmllcyI6IkludGVncmF0aW9uIFx1MDAyNiBEZWxpdmVyeSIsImNvbnRhaW5lckltYWdlIjoicmVnaXN0cnkucmVkaGF0LmlvL3JoY2wtMS9saW1pdGFkb3ItcmhlbDktb3BlcmF0b3JAc2hhMjU2OmIzMWJhMjkzODEyNzg4ZGM3ZTIxYzE0NzAzYWM2MWZkZDViZmYwMTA5NDhhZGEzMzcxNTU0NGJhNTA3ODUxZjciLCJjcmVhdGVkQXQiOiIyMyBTZXAgMjAyNSwgMTI6MTkiLCJkZXNjcmlwdGlvbiI6IkVuYWJsZXMgcmF0ZSBsaW1pdGluZyBmb3IgR2F0ZXdheXMgYW5kIGFwcGxpY2F0aW9ucyBpbiBhIEdhdGV3YXkgQVBJIG5ldHdvcmsiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2NuZiI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby9jbmkiOiJmYWxzZSIsImZlYXR1cmVzLm9wZXJhdG9ycy5vcGVuc2hpZnQuaW8vY3NpIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2Rpc2Nvbm5lY3RlZCI6InRydWUiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL2ZpcHMtY29tcGxpYW50IjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Byb3h5LWF3YXJlIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Rscy1wcm9maWxlcyI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby90b2tlbi1hdXRoLWF3cyI6ImZhbHNlIiwiZmVhdHVyZXMub3BlcmF0b3JzLm9wZW5zaGlmdC5pby90b2tlbi1hdXRoLWF6dXJlIjoiZmFsc2UiLCJmZWF0dXJlcy5vcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3Rva2VuLWF1dGgtZ2NwIjoiZmFsc2UiLCJvcGVyYXRvcnMub3BlbnNoaWZ0LmlvL3ZhbGlkLXN1YnNjcmlwdGlvbiI6IltcIlJlZCBIYXQgQ29ubmVjdGl2aXR5IExpbmtcIl0iLCJvcGVyYXRvcnMub3BlcmF0b3JmcmFtZXdvcmsuaW8vYnVpbGRlciI6Im9wZXJhdG9yLXNkay12MS4zMi4wIiwib3BlcmF0b3JzLm9wZXJhdG9yZnJhbWV3b3JrLmlvL3Byb2plY3RfbGF5b3V0IjoiZ28ua3ViZWJ1aWxkZXIuaW8vdjMiLCJyZXBvc2l0b3J5IjoiaHR0cHM6Ly9naXRodWIuY29tL2t1YWRyYW50L2xpbWl0YWRvci1vcGVyYXRvciIsInN1cHBvcnQiOiJrdWFkcmFudCJ9LCJsYWJlbHMiOnsib3BlcmF0b3JmcmFtZXdvcmsuaW8vb3MubGludXgiOiJzdXBwb3J0ZWQifSwibmFtZSI6ImxpbWl0YWRvci1vcGVyYXRvci52MS4xLjEiLCJuYW1lc3BhY2UiOiJwbGFjZWhvbGRlciJ9LCJzcGVjIjp7ImFwaXNlcnZpY2VkZWZpbml0aW9ucyI6e30sImN1c3RvbXJlc291cmNlZGVmaW5pdGlvbnMiOnsib3duZWQiOlt7ImRlc2NyaXB0aW9uIjoiTGltaXRhZG9yIGlzIHRoZSBTY2hlbWEgZm9yIHRoZSBsaW1pdGFkb3JzIEFQSSIsImRpc3BsYXlOYW1lIjoiTGltaXRhZG9yIiwia2luZCI6IkxpbWl0YWRvciIsIm5hbWUiOiJsaW1pdGFkb3JzLmxpbWl0YWRvci5rdWFkcmFudC5pbyIsInZlcnNpb24iOiJ2MWFscGhhMSJ9XX0sImRlc2NyaXB0aW9uIjoiVGhlIExpbWl0YWRvciBvcGVyYXRvciBpbnN0YWxscyBhbmQgbWFpbnRhaW5zIGxpbWl0YWRvciBpbnN0YW5jZXMiLCJkaXNwbGF5TmFtZSI6IkxpbWl0YWRvciIsImljb24iOlt7ImJhc2U2NGRhdGEiOiJpVkJPUncwS0dnb0FBQUFOU1VoRVVnQUFBWHdBQUFGOENBWUFBQURNNXdES0FBQUFDWEJJV1hNQUFHNjZBQUJ1dWdIVzNyRVhBQUFnQUVsRVFWUjRuTzNkZjJ6VDE3My84VGNRbDhRRTI4T0FETVVrc0lrb0lWbmNhRlNEUmpmNWE1cGEzWkpxZjFTcjdsZGswdjRvdXQ4Sjc0K3BXeldKSU8xMlEvc25hSnJhUHlZVmRMOXF0VCttaG43VmFkby9KVmZRVG1OcUhTV0FFcTJRa0FJV0VHb2JFNXZhbFB1SEU2QWRGSC9PT1o5Zi9qd2ZValhwWG81OVZLa3ZIODU1bi9kWmNmZnVYUUVBTkw2VmJrOEFBT0FNQWg4QUFvTEFCNENBSVBBQklDQUlmQUFJQ0FJZkFBS0N3QWVBZ0NEd0FTQWdDSHdBQ0lnbXR5ZlFxTHE2dXZwWHJWcjFuVkFvTkxCeTVjcHZORGMzZDZ4YXRhcFpSQ1FhamNiY25oL2d0bncrbnhNUnVYUG5UcmxjTGs5LzhjVVhuMVVxbGZFN2QrNzg0K3pac3lmZG5sOGpXa0ZyQlgwOVBUM3BWYXRXZmIrbHBlVmJMUzB0bTF0YlcxdmNuaFBnZDhWaXNWUXFsUzdmdm4xN3NsS3BqRTlPVG82NlBTZS9JL0F0NnV6c2JIdmlpU2RlWHIxNjlmZGJXMXM3Q0hmQU9jVmlzVlFzRnFkdjM3NzlsODgvLy95TmMrZk96Yms5Sno4aDhPdlEzZDM5WW5OejgvNUlKUEkwQVE5NFI3RllMQlVLaGIrWHkrWFhwNmFtL3VqMmZMeU93SCtFN3U3dUY4UGg4TTlqc1ZoM2MzTXpaeDJBeDVYTDVXb3VsNXRhWEZ6OERlSC9jQVQrQTdxNnV2ckQ0ZkN2MXExYjl3d2hEL2hYdVZ5dTNyaHg0OVRpNHVJdk9RQytqOEFYa1ZRcTlZZG9OUG9EcW1lQXhwUFA1M1A1ZlA1UG1Vem14MjdQeFcyQkRmek96czYyTld2V0hHTTFEd1REOHFyLzFxMWIrNEo2MkJ1NHdPL3E2dXB2YlczOTNmcjE2M3VibXBwV3VEMGZBTTZxVnF0M3IxKy9QbEVzRm44U3RPMmV3QVIrVjFkWGZ6UWFQYnBodzRadnVqMFhBTjV3N2RxMVQvTDUvSEJRZ3IvaEEzOTU2MmJ6NXMwRGJzOEZnRGRkdm54NVBBaGJQUTBkK0gxOWZlOGtFb205Yk4wQWVKeHF0WG8zbTgwZS8raWpqMTV3ZXk1MmFjakE3K25wU1cvYXRPbTNYajJNclZRcVVpZ1VIdnIvVzFoWWNIZzJnSDNpOGZoRC8rK1JTRVJDb1pERHM2bFB1Vnl1WHJseTVXZU4yTXFob1FLL3M3T3pMUjZQLzIzZHVuVUp0K2RTS0JSa2NYRlJDb1dDNVBQNWV5RmZxVlRjbmhyZ0dhRlE2Rjc0UjZOUmlVUWlFZzZISlJLSnVEMDF1WEhqUm5aaFllRzdqYlROMHpDQjcrYjJUYWxVa3V2WHI5OExkMWJwZ0w1NFBIN3ZSMkQ5K3ZYUzB1SjhWNU5HMitieGZlQjNkbmEyYmR5NE1lUDBwYWxzTmlzTEN3dVN6V1psY1hIUnlhOEdBaWtjRGtzaWtaQjRQQzZKaExOL2ljL244N21yVjYrbS9MN2E5M1hnOS9iMi92ckpKNTk4eFlsVmZhVlNrV3cyZSs4ZkFPNUtKQkwzL25IaVBLQmFyZDY5ZE9uUzRZbUppVi9ZL21VMjhXWGdkM1oydHExZHUzWXNrVWlrN1A2dTVZQ2ZuNSszKzZzQUtFb21rL2ZDMzI3WmJEWno4K2JOSVQrdTluMFgrRjFkWGYySlJPS3ZkcllwcmxRcWN1SENCWm1mbjJlN0J2Q1JjRGdzeVdSU3RtM2JadXVxdjFnc2xyTFo3UGY4ZG1ITFY0RnY5eFpPcVZTUzZlbHBWdk5BQTBnbWs5TFIwV0hiWWE4ZnQzaDhFL2g5ZlgzdmJObXlaY2lPejE1WVdKRHo1OCt6Tnc4MG9FUWlJZHUzYjMva25RQmRuMzc2NlpoZnFuaDhFZmk3ZCsvK3B4MDljRXFsa256ODhjZVVVUUlCRUkvSDVhbW5uckpseFgvdDJyVlBQdnp3dzI4Wi8yRERQQjM0ZHBWY1Zpb1ZPWFBtREZzM1FBQWxrMG5adVhPbjhUMStQNVJ1ZWpid096czcyelp0Mm5UTzlPSHN6TXlNbkQ5L25odXZRSUNGUWlIWnZuMjc3Tml4dytqbkZvdkYwcFVyVnpxOUd2cWVEUHlubjM3NjI2MnRyWDh6R2ZZTEN3c3lOVFgxeUI0MkFJSW5Fb2xJZDNlMzBmMTlMNGUrNXdLL3U3djd4YTFidDc1dHFoS25VcW5jVzlVRHdNTXNyL1pOYmZOVXE5VzdGeTllL0tIWEhsUDNWT0NiRHZ0Q29TQ25UNSttbGg3QVk0WERZZG0xYTVleHhtMWVESDNQQlA2V0xWdSsvZTF2Znp0akt1eG5abVprZW5yYXhFY0JDSkNPamc1amUvdlZhdlh1aFFzWHRubGxlOGNUZ1cveWdMWlNxY2pwMDZjcHRRU2dMQjZQeTY1ZHU0eHM4WGhwVDkvMXdEY1o5b1ZDUVQ3NDRBTXFjQUJvQzRWQ3NtZlBIaU5iUEY0Si9aVnVmcm1JeU1hTkd6TW13bjUrZmw3R3g4Y0pld0JHVkNvVkdSOGZOM0pmcDdXMXRXWGp4bzBaQTlQUzRtcmc3OTY5KzU4bUxsWE56TXhJSnVQNnYwc0FEU2lUeWNqTXpJejI1MFNqMGRqdTNidi9hV0JLeWx3TC9MNit2bmRNdEV2SVpESWN6Z0t3MWZUMHRKRkY1WVlORzc3WjE5ZjNqb0VwS1hFbDhIdDdlMyt0MndpdFVxbElKcE9oUFFJQVI4elB6MHNtazlIZU50NnlaY3RRYjIvdnJ3MU55eExIRDIyN3VycjYyOXZiLzBlbi9MSlNxY2dISDN6QXJWa0Fqb3RFSXJKbnp4NnRDcDVxdFhwM2RuYjIzNXp1cCsvb0NyK3pzN010a1VqOGxiQUg0RmNtcWdHYm1wcFdKQktKdjNaMmRyWVpuTnBqT1JyNGE5ZXVIZE9weUNIc0FYaUJpZEJ2YlcxdFdidDI3WmpCYVQyV1k0SGYyOXY3YTkwM2FNK2NPVVBZQS9DRVFxRWdaODZjMGZxTVJDS1JjbkkvMzVFOS9NN096clp0MjdaZDBObks0WUFXZ0JjbGswbEpwZFRYc2s2MlgzQmtoYjl4NDBhdEhqa3pNek9FUFFCUG1wK2YxNnJUYjJwcVd1SFVwU3piQTcrdnIrOGRuY3RWOC9QejFOa0Q4TFRwNldtdFJXazBHbzA1VVo5dmErQXZWZVhzVlIxZktCUzRRUXZBRnpLWmpOWVpZeUtSMkd0MzFZNnRnUitQeC8rbXVwV3pYSkVEQUg2aFU3blQxTlMwSWg2UC84M3dsTDdFdHNEdjZlbEpyMXUzTHFFNi92VHAwelJDQStBcnkrM1pWYTFidHk3UjA5T1ROamlsTDdFdDhEZHQydlJiMWJFek16UDBzd2ZnU3dzTEMxcUh1RHJaK1RpMkJINWZYOTg3emMzTlRTcGpDNFVDaDdRQWZHMTZlbHA1UDcrNXVibkpyZ05jNDRHdmMxQ3IrOWNoQVBBS25XMXB1dzV3alFmK21qVnJqcWtlMU03TXpQRGdPSUNHc0xpNHFMeTEwOVRVdEdMTm1qWEhERS9KYk9CM2RYWDFiOTY4ZVVCbDdNTENncHcvZjk3a2RBREFWZWZQbjFjK2o5eThlZk5BVjFkWHY4bjVHQTM4YURSNlZIWHMxTlNVd1prQWdEZm9aSnRPcGo2TXNjRHY2dXJxVjMzQmFtWm1ocVpvQUJwU29WQlEzdHJac0dIRE4wMnU4bzBGZm10cjYrOVV4bFVxRmJaeUFEUzA4K2ZQS3gvZ3FtYnJ3eGdKL003T3pyYjE2OWYzcW93OWMrWU1GNndBTkxSS3BhTGNTbm45K3ZXOXBpcDJqQVMrYW1WT3FWU2lDeWFBUUppZm41ZFNxV1I1bk1tS0hTT0J2MjdkdW1kVXhuMzg4Y2Ntdmg0QWZFRTE4MVF6OXF1MEF6K1ZTdjFCNVZidHdzSUM3Uk1BQklwcTdqVTNOemVsVXFrLzZINi9kdUJIbzlFZnFJempvQlpBRUtsbW4ycldQa2dyOEx1NnV2cFZIamNwbFVxU3pXWjF2aG9BZkNtYnpTcnQ1VWVqMFpodWlhWlc0SWZENFYrcGpLTTVHb0FnVTgxQTFjeGRwaFg0S2djSmxVcUZ5aHdBZ1RZL1A2OVVqcTU3ZUtzYytOM2QzUytxSE5aZXVIQkI5U3NCb0dHb1pHRnpjM05UZDNmM2k2cmZxUno0NFhENDV5cmpXTjBEZ0hvV3FtYXZpRWJneDJLeGJxdGpzdGtzN1k4QlFHcnRrMVdLVjFTeWQ1bFM0S3R1NTFDWkF3RDNxV1NpenJhT1V1QTNOemZ2dHpxR3cxb0ErRExWdzF1VkRCWlJEUHhJSlBLMDFUR3M3Z0hnWDZsa28wb0dpeWdFZm1kbloxdHJhMnVMMVhFRVBnRDhLNVZzYkcxdGJWSHBvR2s1OEo5NDRvbVhyWTRSSWZBQjRHRlVzMUVsaXkwSC91clZxNzl2ZFF4aER3Q1BwcEtSS2xsc09mQmJXMXM3ckk2aEt5WUFQSnBLUnFwa3NVcmdzMzhQQUFhcDd1TmJIV01wOEh0NmV0Sld2NkJVS25IWkNnQyt4dUxpb2xJSFRhdVpiQ253VzFwYUxPOFpYYjkrM2VvUUFBZ2NsYXdNaFVJRFZ2NjhwY0JmdFdyVnQ2eE5SNlJRS0ZnZEFnQ0JvNUtWcTFldjdySHk1NjJ1OERkYm00NUlQcCszT2dRQUFrY2xLNjFtc3FYQVZ6a2tvRUlIQUI1UHNWTEhVaWJYSGZncVQydXhuUU1BOVZQSlRDdlpYSGZncjFxMTZqdFdKMEoxRGdEVVR5VXpyV1J6M1lGdjlUUlloQlUrQUZpaGtwbFdzcm51d0YrNWN1VTNyRTZFQTFzQXFKOUtabHJKNXJvRHY3bTUyZkkxWHBVK3p3QVFWSXE5OGV2T1ppdDcrTTFXSjhLV0RnRFVUeVV6cldTejhwdTI5V0NGRHdEMXN6c3o2dzc4YURRYXMvTEJoRDBBV0djMU82MWtzMjByZkxaekFNQTZPN1BUMWkwZEFJQjNFUGdBRUJBRVBnQUVCSUVQQUFGUlYrQS8vL3p6N1ZZL21Db2RBSERHaWhVcjJ1djVjM1VGL3J2dnZqdHJkUUpVNlFDQWRTcnRGZTdldlR0Yno1OWpTd2NBUEtSYXJkcjIyUVErQUFRRWdROEFBVUhnQTBCQUVQZ0FFQkFFUGdBRUJJRVBBQUZCNEFOQVFCRDRBQkFRQkQ0QUJBU0JEd0FCUWVBRFFFQVErQUFRRUFRK0FBUUVnUThBQVVIZ0EwQkFFUGdBRUJBRVBnQUVCSUVQQUFGQjRBTkFRQkQ0QUJBUUJENEFCRVNUMnhPQW5sZ3NKcWxVeXUxcGFEdHg0b1NyMzk4aklsRlhaK0I5a3lLU2Qzc1MwRUxnKzFRc0ZwUFIwVkhadDIrZjIxTXhZbTV1VGtaR1J1VG8wYU9PZnU5ekl2S2FpQ1FkL1ZiL2VsdEVYaFdDMzYvWTB2R2hXQ3dtSjA2Y2FKaXdGeEZwYTJ1VE45OTgwOUhBZjBWRS9sc0lleXQrS0NML1gvamJrRjhSK0Q0ME5qWW12YjI5YmsvREZ2djI3Wk9ob1NIYnYrYzVxUVUrck9zV2tmL245aVNnaE1EM21hR2hJUmtZR0hCN0dyWWFIUjIxL1R0ZXMvMGJHdHN6VXZ2UmhMOFErRDZ5dkcvZjZOcmEybVJ3Y05DMnozOUYyTVl4Z1I5Ti95SHdmU1NkVGt0Ylc1dmIwL0MxcUlqc2Qzc1NEU0lwYkl2NURZSHZFKzN0N1pKT3A5MmVodSs5SmlJUnR5ZlJRUGFMeUZhM0o0RzZFZmcrTVRJeUl0RW90UkU2K3FWV1pRSnpJc0lxMzA4SWZCOFlIQnhzcUJMTXg1bWJtN1BsSWhiQlpJOGZTdTNIRk41SDRQdkF5TWlJMjFOd2xCMWJWeTlKcmJJRTl1REgxQjhJZkk4YkhoNXUrRExNQngwN2Rrekd4c2FNZm1aVUNDUzdQU08xSDFWNEc0SHZZVUVwd3hTcGJlTzg4TUlMTWp3OGJQeXpYeGJLTUozd21uQUQxK3ZvcGVOaDZYUmErYUQyUnovNmtjek96cHFka0kzc2FwNjJWZFRMTUUrSnlHR0RjL0dMSGhINUw0VnhFYW45dUFieDM1bGZFUGdlMWQ3ZUxnY1BIbFFhT3o0KzduZ1RNcS9TS2NOOFZXb2RJb1BtcElnOEsycG5IcTlJcmNIYVJhTXpnaWxzNlhpVXpsYU9IZHNpZnRRdnRlQlM4WVlFTSt5WC9hZkdXRzdnZWhlQjcwR0RnNE95ZCs5ZXBiRkhqaHp4MVZhT25WU0RweUJzUzF5VTJvK2VpbWVGTWsydkl2QTlTSFYxbjgvbkExZkMrU2d2U2Eycm80ckRRcjkza2RxL2g0TGlXRmI1M2tUZ2UwdzZuVlp1ZlR3eU1pSzVYTTd3alB3bkt1cUJNeThpcnh1Y2k1L2xSZjF2T3QxQ3p5SXZJdkE5SkJhTEthL1FKeVltQWxQQytUaXZpUHBCcmM3ZWRTTjZYVVNtRk1lK0lwUnBlZzJCN3lFNi9YSm9yRmF6VldxbGdTcE9TYTFDQlYvMnF1STQrdXg0RDRIdkVlM3Q3WExnd0FHbHNjZVBIM2Y5RVhDditMM0dXRmIzRDNkU1JQNnNPUFpsb1p1bWx4RDRIcUZUTjgvcXZxWmYxUHZsSEJacXg3K082aXBmUk85SEdHWVIrQjZnODJ6aG9VT0hLTU5jb2hvc0JWRXZRUXlLaTZKK2dQdU1VS2JwRlFTK0IraVVZWEpRVzdOZjFQdmx2Q3FVWWRiakRWRXYwMlNWN3cwRXZzdEdSa2FVbnkxTXA5T1VZWXBlTjh3cEVYbkw0RndhV1Y3VXQzWjREdEViQ0h3WHhXSXg1ZjEzK3VYY3A5c3ZCL1Y3UzJyVlRDcjJDMldhYmlQd1hUUTZPcXBjaHNtTjJwb2VVWCsyOEcyaERGT0Y2bDUrUkxpQjZ6WUMzeVdwVkVyNTJjSmp4NDVSaHJtRWZqbk9PeW0xSDBzVlA1VGFqelRjUWVDN2hINDUrcDRUOVRMTTE0VXlUQjMwMmZFbkF0OEZPczhXam82T1VvYTVSS2RmRG1XWWVpNktlcytoWjZUMll3M25FZmdPMCttWE16YzN4K3AreVN1aVhvWkpOMHd6M3BEYWo2Y0tua04wQjRIdnNIUTZyVldHQ2YxbkN5bkRORU8zVEZPMTV4SFVFZmdPYW05djF5ckRIQnNiTXp3amY5THBoa2tacGxudmlWNlpKbjEybkVYZ080aHVtUHI2UmE4TU04alBGdHFGYnByK1FlQTdaSEJ3VUtzTU01UEpHSjZSUDZrR1JFRlkzZHRsVXZUS05PbXo0eHdDM3lFNlpaaXM3bXRlRXIweVRBNXE3Zk9xVUticEJ3UytBNGFIaDNtMlVKUHVzNFZjc3JKWFh0VExOTHVsOW1NTyt4SDROb3ZGWXNxcis3bTVPYnBoTG5sWk9LajF1c05DbWFiWEVmZzJTNmZUeWdlMXc4UERaaWZqVTF0RmZlLytsTlFxU2VBTTFWZkRJa0tacGhNSWZCdTF0N2ZMd1lNSGxjYU9qNC9UTDJlSnpoNHZ6eFk2NjZTb2wybStJcFJwMm8zQXQ1SE9kZ3lyKzVwK0VYbFdjZXdiUXI4Y04rajh5SEtBYXk4QzN5YURnNE95ZCs5ZXBiRkhqaHloWDg0U3VtSDZ6MFZSNzFYMHJGQ21hU2NDM3lhcWo1UFFEZk8rL1ZLcjRGQkJ2eHgzNlhUVDVEbEUreEQ0TnREdGwwTVpwdDZ6aGZPaVhpSUlNM1Q3N0tqMlNzTFhJL0FOMCttR09URXh3Yk9GUzNUNjVYQlE2dzF2U2UzTllCV3ZDR1dhZGlEd0RhTmZqcjZ0b2w2aTkyZmgyVUl2b2MrT3R4RDRCcVZTS1RsdzRJRFMyT1BIajFPR3VVUm5ENWRMVnQ1eVVtby93aXBlRnNvMFRTUHdEZElwdzJSMVg5TXY2djF5RGd0bG1GNms4eVBNQWE1WkJMNGhRME5EeXM4V0hqcDBpRExNSmFyL2dSZUVad3U5NnFLb2w4anlIS0paQkw0aDlNdlJwL05zNGF0Q0dhYVg2VDZIQ0RNSWZBTkdSa2FVeXpEcGhsa1RGWjR0YkdSNVVWL2xKNFVEWEZNSWZFMnhXRXpyMlVMS01HdGVFL1V5VEc3VStzTmJvdmNjSW1XYStnaDhUYU9qbzhwbG1OeW9yZWtSdldjTEtjUDBEOVVmNTRpd3RXTUNnYTlCOTlsQ3lqQnI2SmNUSENkRjd6bkVIb056Q1NJQ1g0UHFDcDErT2ZjOUozclBGbEtHNlQ4NmZYWlk1ZXNoOEJVTkR3OHJsMkdPam81U2hpbjZ6eFpTaHVsUEYwVzkxOUV6d25PSU9naDhCVHI5Y3VibTVsamRMM2xaS01NTUtwM25FT216bzQ3QVY2RGJEUk8xSy9NNlpaZzhXK2gvT3QwMGVRNVJEWUZ2VVh0N3UxWVo1dGpZbU9FWitaTk9OMHo2NVRTRzkwU3ZUSk0rTzlZUitCYnBsR0d5dXEvcEY3MHl6RW1EYzdGYkxCYVR3Y0ZCR1JrWmtjSEJRV2x2YjNkN1NwNmkwMDJUQTF6ckNId0xkSjh0ekdReWhtZmtUenBsbUg1WjNjZGlNVGw2OUtoODl0bG44djc3Nzh2Qmd3ZmwvZmZmbHdzWExzaUpFeWNJL2lXVHduT0lUaUx3TFZEdGVVTVo1bjB2aWZxemhhK0xQdzVxMjl2YlpYWjI5cEYzTkFZR0JpU1R5VWdxbFhKNFp0NUVtYVp6Q1B3NkRROFBTMjl2cjlKWSt1WFU2SlpoK3VXUzFkalkyR08zL2FMUnFJeU5qVWtzRm5Ob1Z0NmwwMmVuV3lqVHRJTEFyNU5PR1NiZE1HdGVrc1ovdHRES3dxQ3RyVTJHaDRmdG5aQlB2QzU2Wlpxb0Q0RmZoOEhCUWVVeVRQNkR2dTlaeFhHbnhCLzljbUt4bU9VZjk2R2hJWnRtNHorcVArcEpZUysvWGdTK2pjYkh4K21YOHdEVkZncCtXZDJydkdlc2VsdTdFWjBVOVRKTkxtTFZoOENIcDcwaC91aVgwOTdlcnZ5ZU1lQVVBcjhPcWdldUF3TURNamc0YUhZeVBtWjE5ZWFuYnBpcTd4cU1qNCtibllpUDZieG43SWRGZ1JjUStIWElaREl5Tnplbk5KWUhUdTc3czhVL2YxajhVWVk1T0Rpb3ZEWER6ZXY3Vk44em5oZC9YY1p6RTRGZko5VXFuYmEyTm03WUxubEw2cS9FbUJMMWpvcE9VLzFSeitmekxBaVc3QmYxUm5wKytWdWdGeEQ0ZFRwNjlLaE1URXdvalIwWkdhSGVXbXFyOWYrUXgxK3lLU3o5T1QvUWJhVEgvWXphZ2F0cWFlV1U4SjZ4RlFTK0Jhb3I5V2cweWszYkpaTWk4bS95NlAzOHQwV2tWL3l4SjZ2VEpwdjNqTytqa1o1ekNId0xUcHc0SWNlUEgxY2FlK0RBQWE3U0w3a29Jdjh1SWlrUmVWNUUvdS9TLzI2VFdnbW1IL2J0UlhqUDJJUWVVVzkxL0dmeHgvME1MeUh3TFVxbjA1TFBxMFVTTjI2LzdLTFUvb045YStsLy9STDBJaUtwVklyM2pBMElRaU05THlId0xacWRuVlVPN29HQkFXNVdOZ2dhNmVualBXUG5FZmdLUmtkSGxjczBXZVg3MzlEUUVPOFpHOEI3eHM0ajhCWGtjam10TWsxV2VQNmwwaTluR1kzMDdudEY5TW93L2JUOTV5VUV2cUtqUjQ4cTM1Sk1wOU04Z09GVGxHSHEwMzNQbURKTWRRUytCdFdWT21XYS9zUjd4bVpRaHVrZUFsL0RpUk1uNU5peFkwcGo5KzNiUjU4ZG4xSHBocm1NMjlZMVFYclAySXNJZkUwNlpacXM4djFqY0hCUXF3eVQ5NHhyVkcvVVVvWnBCb0d2S1pmTGFaVnA4a0NLUDZqK09PZnplVmIzUzE0U3ZUSk1EbXIxRWZnR2pJeU1LSmRwMG1mSCs0YUhoN1hLTURtbzFldVg0NmYzakwyT3dEZEVkUlZITjAxdjB5M0RaTnV1NW1WUkw4TmtLOGNjQXQrUXNiRXg1VExOZ3djUFVxYnBVZWwwV3ZtZ2x1MjZtcTJpdnJvL0pTTHZHWnhMMEJINEJ1bXMxTG1RNHozdDdlMXk4T0JCcGJHOFozeWY2bzFhRWYrOFord1hCTDVCbVV4R2podzVvalIyNzk2OWxHbDZqTTZQTUt2N21uNFJlVlp4ckYvZU0vWVRBdCt3a1pFUnVtazJnTUhCUWRtN2Q2L1MyQ05IanRBdlo0bE9OMHdPYXMwajhBM1Q2YlBUMjl2THl0QWo2SWFwN3lVUjZWWWNTNzhjZXhENE50RHRwa21acHJ2UzZiVDA5dllxajZVTXMxYUdxZE1OMHkvdkdmc05nVzhUMVpVNmZYYmNwZk5zNGNURUJNOFdMdEhwbDhOQnJYMElmSnZvUG9kSW1hWTc2SmVqYjZ2d2JLRlhFZmcyMGdrQVZvck9hMjl2bHdNSERpaU5QWDc4T0dXWVMzNnZNWlpMVnZZaThHMDBPenNyaHc0ZFVobzdNREJBbWFiRGRINWtXZDNYOUl0NnY1ekRRaG1tM1FoOG00Mk9qaXFYYWJMS2Q0N09zNFdIRGgyaURIT0o2dXErSUR4YjZBUUMzMmE1WEk0K096N0FzNFg2OW90ZXZ4ektNTzFINER2ZzZOR2pNakV4b1RTV2JwcjJHeGtaVVg2MmNHUmtoREpNMGV1R09TVThXK2dVQXQ4aHFpdjFhRFRLQ3RKR3NWaE02OWxDdHQxcVhoT2VMZlFEQXQ4aHVzOGhwbElwd3pPQ1NHMHJSN1VNay9zU05UMmk5MndoWlpqT0lmQWRSSjhkYjBtbFVsclBGbEtHV1VPL0hQOGc4QjAwT3p1cjlSemkwTkNRNFJrRkcvMXk5RDBuZXM4V1VvYnBMQUxmWWJwOWRtQ0c3ck9GbEdIcTk4dWhETk41Qkw3RGRMcHB0clcxc2JJMFFLZGZEczhXM3FmN2JDRmxtTTRqOEYxdzlPaFI1ZWNRMCtrMGZYWTBwZE5wNVRKTTdrWFViSlZhM2IwS25pMTBENEh2RXAweVRWYVk2dHJiMjdYS01NZkd4Z3pQeUo5MHVtRlNodWtlQXQ4bG1VeEdxMHlUUGp0cTZJYXByMS8weWpBbkRjNEYxaEQ0TGtxbjA4cGxtcXp5clJzY0hOUXF3OHhrTW9abjVFK3FOMm9Md3VyZWJRUytpM0s1bkZhWkpzOGhXcU5UaHNucXZ1WWwwU3ZENUtEV1hRUyt5MFpHUm5nTzBRSER3OFBLenhiU0w2ZEd0d3lUUzFidUkvQTlRT2NBbDVYbjQ4VmlNYnBoR3ZDeThHeWgzeEg0SGpBMk5xWmNwbm53NEVIS05COGpuVTRySDlTeWJWYXpWZFQzN2s4Si9YSzhnc0QzQ0oxZ1lRWDZhTzN0N1hMdzRFR2xzZVBqNC9UTFdhSzZsU1BDNnQ1TENIeVBtSjJkbFNOSGppaU4zYnQzTDJXYWo2RFR2cGpWZlUyL2lEeXJPUFlOb1YrT2x4RDRIa0kzVGJNR0J3ZDV0dEFBdW1FMkRnTGZRM1Q2N1BUMjluS0EreFdxcS90OFBzOFA2Skw5SXRLdE9QYXdVSWJwTlFTK3g0eU9qdkljb2dHNi9YSW93OVIvdHZCMWczT0JHUVMrQjlGblI0OU9OOHlKaVFtZUxWeEN2NXpHUStCNzBJa1RKK1Q0OGVOS1l3OGNPQkQ0TWszNjVlamJLclc2ZXhWL0Zzb3d2WXJBOXlpZDRBbnlDaldWU3NtQkF3ZVV4aDQvZnB3eXpDVy8xeGpMNnQ2N210eWVBQjV1ZG5aV0RoMDZwRlJEdnR4bko0aFZKcXBiT1hiM3krbTM3WlBONnhIMWZqbUhoVEpNTHlQd1BXeDBkRlQ1bHVpYmI3NXB3NHdhbDEzUEZqNG50YkpHMVplaC9LUWdQRnZvZFd6cGVGZ3VsMk5QMlFGMjljdjV2WWo4dHdRajdFVjR0dEFQQ0h5UDAza09FZld4b3h2bWM2TCtTSWdmblJLUnQ5eWVCQjZMd1BjQlNpM3RNejQrYnNzaHQwN3ZHVC9pUnEwL0VQZytjT0xFQ2VYbkVQSDE3UGd4N1pmZ2JPT0kxSjR0cEF6VEh3aDhuOURwczRPSE8zYnNHR1dZbXVpWDR5OEV2ay9NenM3UzM4VWduaTAwNDNXaEROTlBDSHdmR1IwZFZYNE9FVjgyT2pwS3Z4eE5QRnZvUHdTK2oxQ21hY2JjM0p5dEIrRW5wUmFHalk0YnRmNUQ0UHVNem5PSXFISGlSN1BSdy9DVWlMem45aVJnR1lIdlEwTkRROG90bElQdXB6LzlxWXlOamRuK1BlOUpyWHFsRVUySnlIKzRQUWtvSWZCOUtKZkx5ZURnb1BLVGlFRTBOemNuTDd6d2dxTUgzLzhwSXY5SEdtdDc1MjBSK1hmaFJxMWYwVXZIcDViMzgwZEdSaVNWU3JrOUhVL0w1WEtTeVdSYytlNzNsdjdwa2RxREluNDJLUVM5M3hINFBwZkw1YWdsOTRGSnR5Y0FDRnM2QUJBWUJENEFCQVNCRHdBQlFlQURRRUFRK0FBUUVBUStBQVFFZ1E4QUFVSGdBMEJBRVBnQUVCQUVQZ0FFQklFUEFBRkI0QU5BUUJENEFCQVFCRDRBQkFTQkR3QUJRZUFEUUVBUStBQVFFQVErQUFRRWdROEFBVUhnQTBCQUVQZ0FFQkFFUGdBRWhHMkJINGxFN1Bwb0FHaFk4WGpjOHBqbm4zKyt2WjQvWjF2Z2gwSWh1ejRhQVBDQWQ5OTlkN2FlUDhlV0RnQUVCSUVQQUFGQjRBTkFRQkQ0QUJBUVZPa0FnSWZZbVoxMUIzNCtuODlaK1dDcWRBREFPcXZaYVNXYmJkM1NJZlFCb0g1MloyYmRnWC9uenAyeTFROW5Xd2NBNnFlU21WYXl1ZTdBTDVmTDAxWW53Z29mQU9xbmtwbFdzcm51d1AvaWl5OCtzenFSYURScWRRZ0FCSlpLWmxySjVyb0R2MUtwakZ1ZENGczZBRkEvbGN5MGtzMVc5dkQvWVhVaTRYRFk2aEFBQ0N5VnpMU1N6WFVIL3RtelowOWFuUWdyZkFDb24wcG1Xc2xtUzJXWnhXS3haSFV5S3EwK0FTQm9WTExTYWlaYkN2eFNxWFRaMm5RNHVBV0FlcWhrcGRWTXRocjQvN1EySGJaMUFLQWVLbGw1Ky9idFNTdC8zbExnMzdsejV5L1dwaU95ZnYxNnEwTUFJSEJVc3RKcTlhU2x3SitjbkJ5MU5oMlJscFlXcW5VQTRHdUV3MkZwYVdteFBNNXFKbHZ1cGFOeWNKdElKS3dPQVlEQVVNbElsU3hXQ1h6TExSYW8xQUdBUjFPczBMR2N4WllELy9idDI1YjM4Vm5oQThDanFXU2tTaFpiRHZ6UFAvLzhEYXRqUkFoOUFIZ1kxV3hVeVdMTGdYL3UzTGs1OXZFQndBelYvZnR6NTg3TldSMm45QUJLb1ZENHU5VXhCRDRBL0N1VmJGVEpZQkhGd0MrWHk2OWJIUk1LaFNTWlRLcDhIUUEwcEdReXFkb0QzM0lHaXlnRy90VFUxQi9MNVhMVjZqaFcrUUJ3bjBvbWxzdmw2dFRVMUI5VnZrLzVUZHRjTGpkbGRVd2lrZUFTRmdCSTdiS1ZTdUNyWk84eTVjQmZYRno4amNvNHRuVUFRRDBMVmJOWFJDUHdWYmQxdG0zYnB2cVZBTkF3VkxKUVp6dEhSQ1B3UlVSdTNMaHh5dW9ZRG04QkJKM3FZYTFLNWo1SUsvQVhGeGQvcVRLdW82TkQ1MnNCd05kVU0xQTFjNWRwQmY3WnMyZFA1dlA1bk5WeExTMHRWT3dBQ0tSRUlxSFVHVE9meitkVW5wcDlrRmJnTDAzaVR5cmp0bS9mcnZ2VkFPQTdxdG1ubXJVUDBnNzhUQ2J6WTVYRDIzZzhUaGROQUlHaW1udmxjcm1heVdSK3JQdjkyb0V2b242UThOUlRUNW40ZWdEd0JkWE0wejJzWFdZazhHL2R1cld2V3EzZXRUcXVwYVdGaWgwQWdaQk1KcFgyN3F2VjZ0MWJ0Mjd0TXpFSEk0Ri83dHk1dWV2WHIwK29qTjI1YzZkU2VSSUErRVVvRkpLZE8zY3FqYjErL2ZxRVNtZk1oekVTK0NJaXhXTHhKeXJqUXFFUUI3Z0FHdHIyN2R1VkY3YXEyZEw3SzFRQUFBZ0dTVVJCVlBvd3hnTC83Tm16SjY5ZHUvYUp5dGdkTzNaSUpCSXhOUlVBOEl4SUpDSTdkdXhRR252dDJyVlBkRXN4SDJRczhFVkU4dm44c09yWTd1NXVnek1CQUcvUXlUYWRUSDBZbzRGLzl1elprNWN2WHg1WEdSdVB4OW5hQWRCUXRtL2ZybHgrZnZueTVYR1RxM3NSdzRFdm9sNnhJMUxiMnFGOU1vQkdFQTZIbGJkeVRGYm1QTWg0NEo4N2QyNHVtODBlVnhrYkNvVmsxNjVkcHFjRUFJN2J0V3VYOGtGdE5wczlicW95NTBIR0ExOUU1S09QUG5wQjVmYXRTTzJBZytacUFQeXNvNk5EdVJDbFhDNVhQL3Jvb3hjTVQwbEViQXA4RVpFclY2NzhUSFhzamgwN2FMc0F3SmZpOGJqeVZvNklYblkram0yQlB6azVPWHJqeG8yczZuaWR2dzRCZ0J0MHQ2VnYzTGlSblp5Y0hEVTRwUyt4TGZCRlJCWVdGcjZyZW9BYkNvVmt6NTQ5cHFjRUFMYlpzMmVQOGtLMVdxM2VYVmhZK0s3aEtYMkpyWUd2YzRBclV0dlBUNlZTSnFjRUFMWklwVkphRjBqdE9xaDlrSzJCTDFJN3dGVjVKR1ZaTXBua0VCZUFwM1YwZEdnMWdzem44em03RG1vZlpIdmdpNGhjdlhvMXBicTFJMUk3eEtXckpnQXZTaWFUV29lMDFXcjE3dFdyVngzWnluQWs4TStkT3pkMzZkS2x3enFma1VxbENIMEFucEpNSnJXM25TOWR1blRZN3EyY1pZNEV2b2pJeE1URUw3TFpiRWJuTTNidTNFbVROUUNlRUlsRWxGc2VMOHRtczVtSmlZbGZHSnJTWXprVytDSWlOMi9lSENvV2l5WFY4Y3VWTzRRK0FEZEZJaEd0aWh3UmtXS3hXTHA1OCthUXdXazlscU9CdjFTMTh6MmQvWHhDSDRDYlRJUjl0VnE5bTgxbXYrZlVWczR5UndOZnBOWlJVM2MvZnpuMDJkTUg0S1JrTXFrZDlpSzFmWHZUblREcnNlTHVYZVhGdHBhK3ZyNTN0bXpab3YzWG1Vd21JL1B6OHlhbUJBQ1BaT0tBVmtUazAwOC9IWE9pQlBOaFhBdDhFWkhkdTNmL2M4T0dEZC9VL1p5Wm1SbVpucDQyTVNVQStCY2RIUjFhcFpmTHJsMjc5c21ISDM3NExRTlRVdUpxNEl1SURBd01mQmFOUm1PNm56TS9QeStaakZZUkVBRDhDMU1sNGZsOFBqYytQdjROQTFOUzV2Z2UvbGRkdlhvMXBWTzVzeXlaVE1yQXdBQU4xd0FZRVFxRlpHQmd3RWpZRjR2RmtsT1hxNzZPNnl0OEVaSE96czYyVFpzMm5XdHRiVzNSL2F4S3BTS25UNStXaFlVRkUxTURFRUR4ZU54WXg5NWlzVmk2Y3VWS3A5TVZPUS9qaWNBWHFZWCt0bTNiTGpRMU5hMHc4WG5zNndOUVlXcS9YcVJXZm5uaHdvVnRYZ2g3RVE4RnZvaElkM2YzaTF1M2JuM2JWT2dYQ2dVNWZmcTBMQzR1bXZnNEFBMHNIQTdMcmwyN2pOM3hxVmFyZHk5ZXZQakRxYW1wUHhyNVFBTThGZmdpNWtPL1Vxbkl6TXlNbkQ5LzNzVEhBV2hBMjdkdmx4MDdkaGc3QS9SaTJJdDRNUEJGek83cEwxdFlXSkNwcVNrcEZBcW1QaEtBejBVaUVlbnU3amI2cEtxWDl1eS95cE9CTDJKUDZJdkl2ZFYrcFZJeCtiRUFmQ1FVQ3QxYjFadms1YkFYOFhEZ2k5UkNmK1BHalJrVGRmb1BxbFFxY3ViTUdXN29BZ0dVVENabDU4NmR4a3U0OC9sODd1clZxeW12aHIySXh3Ti9tYWtidVY5VktwWGs0NDgvcG9RVENJQjRQQzVQUGZXVXRMUVkzVFFRRWZkdjBOYkxGNEV2WXE3M3pzTXNMQ3pJK2ZQbkpadk4ydkh4QUZ5VVNDUmsrL2J0UnZmcEgrUm1ieHlyZkJQNElpSzl2YjIvZnZMSkoxOHhWY0h6VmFWU1NhYW5wOW5xQVJyQThudllkcXpvUldxVk9KY3VYVHJzNUFNbXVud1YrQ0lpWFYxZC9ZbEU0cSttRDNNZlZLbFU1TUtGQ3pJL1AwOE5QK0FqNFhCWWtzbWtiTnUyemRZMks4VmlzWlROWnIvblJvdGpIYjRMZkpIYVllN2F0V3ZIRW9tRTdiMHBzdG1zWkxOWlZ2MkFoeVdUU1Vra0VwSklKR3ovcm13Mm03bDU4K2FRbHc5bkg4V1hnYi9NN2kyZUIxVXFsWHZoejE0LzRMN2xnRThrRW80MFRmVGpGczVYK1Ryd1Jld3IzWHljYkRZckN3c0xrczFtMmZZQkhCQU9oeVdSU0VnOEhuZGtKZjhnUDVSYzFzUDNnYitzcjYvdm5VUWlzZGVKMWY1WGxVb2x1WDc5dWhRS0Jjbm44NVI1QWdiRTQzR0pScU1TaVVSay9mcjF0aDIrZnAybHQyZVArNlVLNTNFYUp2QkZhcXY5ZUR6K3QzWHIxam43OC84UWhVSkJGaGNYNy8wSVZDb1ZLUlFLM1BBRkhoQUtoU1FTaVVnb0ZMb1g3dUZ3MkZnRE14MDNidHpJTGl3c2ZOZnZxL29ITlZUZ0wrdnA2VWx2MnJUcHQ4M056VTF1eitWUkh2VzNBUDUyZ0VieXFOcjM1WkQzb25LNVhMMXk1Y3JQSmljblI5MmVpMmtOR2ZqTDNOem1BZUF2amJaOTh6QU5IZmdpdFcyZU5XdldITnU4ZWZPQTIzTUI0RTJYTDE4ZXYzWHIxcjVHMnI1NW1JWVAvR1ZkWFYzOTBXajBxQjA5ZVFENDA3VnIxejdKNS9QRGZydEFwU293Z2Irc3E2dXJ2N1cxOVhmcjE2L3ZaYXNIQ0o1cXRYcjMrdlhyRThWaThTZEJDZnBsZ1F2OFpjdGJQZXZXclh2R3k0ZTdBTXdvbDh2Vkd6ZHVuQXJDMXMyakJEYndINVJLcGY0UWpVWi80UFRsTFFEMnkrZnp1WHcrLzZkTUp2Tmp0K2ZpTmdML0FWMWRYZjNoY1BoWHJQb0JmMXRlelM4dUx2NHlhTnMyWDRmQWY0VHU3dTRYdytId3oyT3hXRGZoRDNoZnVWeXU1bks1cWNYRnhkOTQ3ZkZ3cnlEdzY5RGQzZjFpYzNQei9rZ2s4clNkYlprQldGTXNGa3VGUXVIdjVYTDVkVUwrOFFoOGl6bzdPOXVlZU9LSmwxZXZYdjM5MXRiV0RuNEFBT2NVaThWU3NWaWN2bjM3OWw4Ky8venpONEo2K0txS3dEZWdwNmNuSFFxRkJsYXZYdDNUMHRLeW1SOEJRRit4V0N5VlNxWEx0Mi9mbnF4VUt1T04yT3JBYVFTK1RicTZ1dnBYclZyMW5WQW9OTEJ5NWNwdk5EYzNkNnhhdGFwWlJJUnFJS0JXUFNNaWN1Zk9uWEs1WEo3KzRvc3ZQcXRVS3VOMzd0ejVCd2V0OWlEd0FTQWdWcm85QVFDQU13aDhBQWdJQWg4QUFvTEFCNENBSVBBQklDQUlmQUFJQ0FJZkFBS0N3QWVBZ0NEd0FTQWcvaGZuYUh3a3pmaTdnZ0FBQUFCSlJVNUVya0pnZ2c9PSIsIm1lZGlhdHlwZSI6ImltYWdlL3BuZyJ9XSwiaW5zdGFsbCI6eyJzcGVjIjp7ImNsdXN0ZXJQZXJtaXNzaW9ucyI6W3sicnVsZXMiOlt7ImFwaUdyb3VwcyI6WyIiXSwicmVzb3VyY2VzIjpbImNvbmZpZ21hcHMiLCJwZXJzaXN0ZW50dm9sdW1lY2xhaW1zIiwic2VjcmV0cyIsInNlcnZpY2VzIl0sInZlcmJzIjpbImNyZWF0ZSIsImRlbGV0ZSIsImdldCIsImxpc3QiLCJ1cGRhdGUiLCJ3YXRjaCJdfSx7ImFwaUdyb3VwcyI6WyIiXSwicmVzb3VyY2VzIjpbInBvZHMiXSwidmVyYnMiOlsibGlzdCIsInVwZGF0ZSIsIndhdGNoIl19LHsiYXBpR3JvdXBzIjpbImFwcHMiXSwicmVzb3VyY2VzIjpbImRlcGxveW1lbnRzIl0sInZlcmJzIjpbImNyZWF0ZSIsImRlbGV0ZSIsImdldCIsImxpc3QiLCJ1cGRhdGUiLCJ3YXRjaCJdfSx7ImFwaUdyb3VwcyI6WyJsaW1pdGFkb3Iua3VhZHJhbnQuaW8iXSwicmVzb3VyY2VzIjpbImxpbWl0YWRvcnMiXSwidmVyYnMiOlsiY3JlYXRlIiwiZGVsZXRlIiwiZ2V0IiwibGlzdCIsInBhdGNoIiwidXBkYXRlIiwid2F0Y2giXX0seyJhcGlHcm91cHMiOlsibGltaXRhZG9yLmt1YWRyYW50LmlvIl0sInJlc291cmNlcyI6WyJsaW1pdGFkb3JzL2ZpbmFsaXplcnMiXSwidmVyYnMiOlsidXBkYXRlIl19LHsiYXBpR3JvdXBzIjpbImxpbWl0YWRvci5rdWFkcmFudC5pbyJdLCJyZXNvdXJjZXMiOlsibGltaXRhZG9ycy9zdGF0dXMiXSwidmVyYnMiOlsiZ2V0IiwicGF0Y2giLCJ1cGRhdGUiXX0seyJhcGlHcm91cHMiOlsicG9saWN5Il0sInJlc291cmNlcyI6WyJwb2RkaXNydXB0aW9uYnVkZ2V0cyJdLCJ2ZXJicyI6WyJjcmVhdGUiLCJkZWxldGUiLCJnZXQiLCJsaXN0IiwidXBkYXRlIiwid2F0Y2giXX1dLCJzZXJ2aWNlQWNjb3VudE5hbWUiOiJsaW1pdGFkb3Itb3BlcmF0b3ItY29udHJvbGxlci1tYW5hZ2VyIn1dLCJkZXBsb3ltZW50cyI6W3sibGFiZWwiOnsiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9LCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciIsInNwZWMiOnsicmVwbGljYXMiOjEsInNlbGVjdG9yIjp7Im1hdGNoTGFiZWxzIjp7ImNvbnRyb2wtcGxhbmUiOiJjb250cm9sbGVyLW1hbmFnZXIifX0sInN0cmF0ZWd5Ijp7fSwidGVtcGxhdGUiOnsibWV0YWRhdGEiOnsibGFiZWxzIjp7ImFwcCI6ImxpbWl0YWRvci1vcGVyYXRvciIsImNvbnRyb2wtcGxhbmUiOiJjb250cm9sbGVyLW1hbmFnZXIifX0sInNwZWMiOnsiY29udGFpbmVycyI6W3siYXJncyI6WyItLWxlYWRlci1lbGVjdCJdLCJjb21tYW5kIjpbIi9tYW5hZ2VyIl0sImVudiI6W3sibmFtZSI6IlJFTEFURURfSU1BR0VfTElNSVRBRE9SIiwidmFsdWUiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOUBzaGEyNTY6OTQ3MWFhZGNlMWExN2FhY2IxYmY2NTNiNzVlMGQ3OTI0ZjhmOWUxNDQ5NTQ0NDBlMGQ5YzliZTZmZDQzMmU4YyJ9XSwiaW1hZ2UiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOS1vcGVyYXRvckBzaGEyNTY6YjMxYmEyOTM4MTI3ODhkYzdlMjFjMTQ3MDNhYzYxZmRkNWJmZjAxMDk0OGFkYTMzNzE1NTQ0YmE1MDc4NTFmNyIsImxpdmVuZXNzUHJvYmUiOnsiaHR0cEdldCI6eyJwYXRoIjoiL2hlYWx0aHoiLCJwb3J0Ijo4MDgxfSwiaW5pdGlhbERlbGF5U2Vjb25kcyI6MTUsInBlcmlvZFNlY29uZHMiOjIwfSwibmFtZSI6Im1hbmFnZXIiLCJwb3J0cyI6W3siY29udGFpbmVyUG9ydCI6ODA4MCwibmFtZSI6Im1ldHJpY3MifV0sInJlYWRpbmVzc1Byb2JlIjp7Imh0dHBHZXQiOnsicGF0aCI6Ii9yZWFkeXoiLCJwb3J0Ijo4MDgxfSwiaW5pdGlhbERlbGF5U2Vjb25kcyI6NSwicGVyaW9kU2Vjb25kcyI6MTB9LCJyZXNvdXJjZXMiOnsibGltaXRzIjp7ImNwdSI6IjIwMG0iLCJtZW1vcnkiOiIzMDBNaSJ9LCJyZXF1ZXN0cyI6eyJjcHUiOiIyMDBtIiwibWVtb3J5IjoiMjAwTWkifX0sInNlY3VyaXR5Q29udGV4dCI6eyJhbGxvd1ByaXZpbGVnZUVzY2FsYXRpb24iOmZhbHNlfX1dLCJzZWN1cml0eUNvbnRleHQiOnsicnVuQXNOb25Sb290Ijp0cnVlfSwic2VydmljZUFjY291bnROYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciIsInRlcm1pbmF0aW9uR3JhY2VQZXJpb2RTZWNvbmRzIjoxMH19fX1dLCJwZXJtaXNzaW9ucyI6W3sicnVsZXMiOlt7ImFwaUdyb3VwcyI6WyIiLCJjb29yZGluYXRpb24uazhzLmlvIl0sInJlc291cmNlcyI6WyJjb25maWdtYXBzIiwibGVhc2VzIl0sInZlcmJzIjpbImdldCIsImxpc3QiLCJ3YXRjaCIsImNyZWF0ZSIsInVwZGF0ZSIsInBhdGNoIiwiZGVsZXRlIl19LHsiYXBpR3JvdXBzIjpbIiJdLCJyZXNvdXJjZXMiOlsiZXZlbnRzIl0sInZlcmJzIjpbImNyZWF0ZSIsInBhdGNoIl19XSwic2VydmljZUFjY291bnROYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLWNvbnRyb2xsZXItbWFuYWdlciJ9XX0sInN0cmF0ZWd5IjoiZGVwbG95bWVudCJ9LCJpbnN0YWxsTW9kZXMiOlt7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJPd25OYW1lc3BhY2UifSx7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJTaW5nbGVOYW1lc3BhY2UifSx7InN1cHBvcnRlZCI6ZmFsc2UsInR5cGUiOiJNdWx0aU5hbWVzcGFjZSJ9LHsic3VwcG9ydGVkIjp0cnVlLCJ0eXBlIjoiQWxsTmFtZXNwYWNlcyJ9XSwia2V5d29yZHMiOlsiYXBpIiwicmF0ZS1saW1pdCIsImt1YWRyYW50Il0sImxpbmtzIjpbeyJuYW1lIjoiTGltaXRhZG9yIE9wZXJhdG9yIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL0t1YWRyYW50L2xpbWl0YWRvci1vcGVyYXRvciJ9LHsibmFtZSI6Ikt1YWRyYW50IERvY3MiLCJ1cmwiOiJodHRwczovL2t1YWRyYW50LmlvIn1dLCJtYWludGFpbmVycyI6W3siZW1haWwiOiJlYXN0aXpsZUByZWRoYXQuY29tIiwibmFtZSI6IkVndXpraSBBc3RpeiBMZXphdW4ifSx7ImVtYWlsIjoiYXNuYXBzQHJlZGhhdC5jb20iLCJuYW1lIjoiQWxleCBTbmFwcyJ9LHsiZW1haWwiOiJkaWRpZXJAcmVkaGF0LmNvbSIsIm5hbWUiOiJEaWRpZXIgRGkgQ2VzYXJlIn1dLCJtYXR1cml0eSI6ImFscGhhIiwibWluS3ViZVZlcnNpb24iOiIxLjI1LjAiLCJwcm92aWRlciI6eyJuYW1lIjoiUmVkIEhhdCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9LdWFkcmFudC9saW1pdGFkb3Itb3BlcmF0b3IifSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJyZWdpc3RyeS5yZWRoYXQuaW8vcmhjbC0xL2xpbWl0YWRvci1yaGVsOUBzaGEyNTY6OTQ3MWFhZGNlMWExN2FhY2IxYmY2NTNiNzVlMGQ3OTI0ZjhmOWUxNDQ5NTQ0NDBlMGQ5YzliZTZmZDQzMmU4YyIsIm5hbWUiOiJsaW1pdGFkb3IifV0sInZlcnNpb24iOiIxLjEuMSJ9fQ==
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoicmJhYy5hdXRob3JpemF0aW9uLms4cy5pby92MSIsImtpbmQiOiJDbHVzdGVyUm9sZSIsIm1ldGFkYXRhIjp7ImNyZWF0aW9uVGltZXN0YW1wIjpudWxsLCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLW1ldHJpY3MtcmVhZGVyIn0sInJ1bGVzIjpbeyJub25SZXNvdXJjZVVSTHMiOlsiL21ldHJpY3MiXSwidmVyYnMiOlsiZ2V0Il19XX0=
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoidjEiLCJkYXRhIjp7ImNvbnRyb2xsZXJfbWFuYWdlcl9jb25maWcueWFtbCI6ImFwaVZlcnNpb246IGNvbnRyb2xsZXItcnVudGltZS5zaWdzLms4cy5pby92MWFscGhhMVxua2luZDogQ29udHJvbGxlck1hbmFnZXJDb25maWdcbmhlYWx0aDpcbiAgaGVhbHRoUHJvYmVCaW5kQWRkcmVzczogOjgwODFcbm1ldHJpY3M6XG4gIGJpbmRBZGRyZXNzOiA6ODA4MFxud2ViaG9vazpcbiAgcG9ydDogOTQ0M1xubGVhZGVyRWxlY3Rpb246XG4gIGxlYWRlckVsZWN0OiB0cnVlXG4gIHJlc291cmNlTmFtZTogMzc0NWExNmUua3VhZHJhbnQuaW9cbiJ9LCJraW5kIjoiQ29uZmlnTWFwIiwibWV0YWRhdGEiOnsibmFtZSI6ImxpbWl0YWRvci1vcGVyYXRvci1tYW5hZ2VyLWNvbmZpZyJ9fQ==
+  - type: olm.bundle.object
+    value:
+      data: eyJhcGlWZXJzaW9uIjoidjEiLCJraW5kIjoiU2VydmljZSIsIm1ldGFkYXRhIjp7ImNyZWF0aW9uVGltZXN0YW1wIjpudWxsLCJsYWJlbHMiOnsiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9LCJuYW1lIjoibGltaXRhZG9yLW9wZXJhdG9yLW1ldHJpY3MifSwic3BlYyI6eyJwb3J0cyI6W3sibmFtZSI6Im1ldHJpY3MiLCJwb3J0Ijo4MDgwLCJ0YXJnZXRQb3J0IjoibWV0cmljcyJ9XSwic2VsZWN0b3IiOnsiYXBwIjoibGltaXRhZG9yLW9wZXJhdG9yIiwiY29udHJvbC1wbGFuZSI6ImNvbnRyb2xsZXItbWFuYWdlciJ9fSwic3RhdHVzIjp7ImxvYWRCYWxhbmNlciI6e319fQ==
+relatedImages:
+  - image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-1-limitador-operator-bundle@sha256:93c6f058da352883789f7db0150b1097a5f09e1268e24914ad964d5fdc83f6e1
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:b31ba293812788dc7e21c14703ac61fdd5bff010948ada33715544ba507851f7
+    name: ""
+  - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:9471aadce1a17aacb1bf653b75e0d7924f8f9e144954440e0d9c9be6fd432e8c
+    name: limitador
 schema: olm.bundle


### PR DESCRIPTION
### What 

Adding limitador-operator.v1.1.1 to OCP v4.16, v4.17, v4.18, v4.19, v4.20

### How

* read snapshot from release 

```sh
SNAPSHOT=$(kubectl get releases rhcl-1-1-1-limitador-prod-rhel9 -o jsonpath='{.spec.snapshot}')
echo $SNAPSHOT
```

* read bundle url from snapshot
```sh
BUNDLE=$(kubectl get snapshot $SNAPSHOT -o yaml | yq e '.spec.components[] | select(.name == "rhcl-1-1-limitador-operator-bundle").containerImage')
echo $BUNDLE
```

* Add bundle to the catalog v4.16, v4.17, v4.18, v4.19, v4.20

> Note: adding channel entry with "replaces" semantics, replacing limitador.v1.1.0

```sh
TMPFILE=$(mktemp)
opm render $BUNDLE -o yaml > $TMPFILE

## declare an array variable
declare -a ocpversions=("4.16" "4.17" "4.18" "4.19" "4.20")

## loop through above ocp-version
for version in "${ocpversions[@]}"
do
   echo "updating OCP $version"
   # Adding new line
   echo "" >> catalog/$version/limitador-operator/catalog.yaml
   cat $TMPFILE >> catalog/$version/limitador-operator/catalog.yaml
   echo "existing bundles in OCP $version"
   yq e 'select(.schema == "olm.bundle").name' catalog/$version/limitador-operator/catalog.yaml
   # Adding channel entry with "replaces" semantics
   yq eval --inplace '(select(.schema == "olm.channel").entries) += {"name": "limitador-operator.v1.1.1", "replaces": "limitador-operator.v1.1.0"}' catalog/$version/limitador-operator/catalog.yaml
   opm validate catalog/$version/limitador-operator
done

rm $TMPFILE
```

