### PR TITLE
File Based Catalog for RHCL 1.3.2

### DIFF
--- a/catalog/4.19/rhcl-operator/catalog.yaml
+++ b/catalog/4.19/rhcl-operator/catalog.yaml
@@ -20,6 +20,8 @@ entries:
     replaces: rhcl-operator.v1.2.1
   - name: rhcl-operator.v1.3.1
     replaces: rhcl-operator.v1.3.0
+  - name: rhcl-operator.v1.3.2
+    replaces: rhcl-operator.v1.3.1
 name: stable
 package: rhcl-operator
 schema: olm.channel
@@ -1832,6 +1834,275 @@ relatedImages:
   - image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:c72f23284033de1032e2b209cd2c6087ad0f1aacb8c7312fd324df3d8fee49b9
     name: console-plugin-pf5
   - image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:a3ae38fae8566fdf66283ebfbec2cb368329ff9703890ebb1b9507f85def1edc
+    name: ""
+  - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:7aa6d6dbbde488260789adb94fa232a06d1e635cc2aaf86af24f8cf14a17eef8
+    name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:48d67fa983833603f107e353d7ff07b3bd9f44f045a265b5eaeeac8c552fc4bb
+name: rhcl-operator.v1.3.2
+package: rhcl-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: AuthPolicy
+      version: v1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: DNSPolicy
+      version: v1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: Kuadrant
+      version: v1beta1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: RateLimitPolicy
+      version: v1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TLSPolicy
+      version: v1
+  - type: olm.package
+    value:
+      packageName: rhcl-operator
+      version: 1.3.2
+  - type: olm.package.required
+    value:
+      packageName: authorino-operator
+      versionRange: 1.3.0
+  - type: olm.package.required
+    value:
+      packageName: dns-operator
+      versionRange: 1.3.0
+  - type: olm.package.required
+    value:
+      packageName: limitador-operator
+      versionRange: 1.3.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "kuadrant.io/v1",
+              "kind": "AuthPolicy",
+              "metadata": {
+                "name": "authpolicy-sample"
+              },
+              "spec": {
+                "rules": {
+                  "authentication": {
+                    "apikey": {
+                      "apiKey": {
+                        "selector": {}
+                      },
+                      "credentials": {
+                        "authorizationHeader": {
+                          "prefix": "APIKEY"
+                        }
+                      }
+                    }
+                  }
+                },
+                "targetRef": {
+                  "group": "gateway.networking.k8s.io",
+                  "kind": "HTTPRoute",
+                  "name": "toystore"
+                }
+              }
+            },
+            {
+              "apiVersion": "kuadrant.io/v1",
+              "kind": "DNSPolicy",
+              "metadata": {
+                "name": "dnspolicy-sample"
+              },
+              "spec": {
+                "healthCheck": {
+                  "protocol": "HTTP"
+                },
+                "providerRefs": [
+                  {
+                    "name": "provider-ref"
+                  }
+                ],
+                "targetRef": {
+                  "group": "gateway.networking.k8s.io",
+                  "kind": "Gateway",
+                  "name": "example-gateway"
+                }
+              }
+            },
+            {
+              "apiVersion": "kuadrant.io/v1",
+              "kind": "RateLimitPolicy",
+              "metadata": {
+                "name": "ratelimitpolicy-sample"
+              },
+              "spec": {
+                "limits": {
+                  "toys": {
+                    "rates": [
+                      {
+                        "limit": 50,
+                        "window": "1m"
+                      }
+                    ]
+                  }
+                },
+                "targetRef": {
+                  "group": "gateway.networking.k8s.io",
+                  "kind": "HTTPRoute",
+                  "name": "toystore"
+                }
+              }
+            },
+            {
+              "apiVersion": "kuadrant.io/v1",
+              "kind": "TLSPolicy",
+              "metadata": {
+                "name": "tlspolicy-sample"
+              },
+              "spec": {
+                "issuerRef": {
+                  "group": "cert-manager.io",
+                  "kind": "ClusterIssuer",
+                  "name": "self-signed-ca"
+                },
+                "targetRef": {
+                  "group": "gateway.networking.k8s.io",
+                  "kind": "Gateway",
+                  "name": "example-gateway"
+                }
+              }
+            },
+            {
+              "apiVersion": "kuadrant.io/v1beta1",
+              "kind": "Kuadrant",
+              "metadata": {
+                "name": "kuadrant-sample"
+              },
+              "spec": {}
+            }
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:7aa6d6dbbde488260789adb94fa232a06d1e635cc2aaf86af24f8cf14a17eef8
+        createdAt: 27 Nov 2025, 19:24
+        description: Red Hat Connectivity Link enables you to secure, protect, and connect your APIs and applications in multicluster, multicloud, and hybrid cloud environments
+        features.operators.openshift.io/cnf: "false"
+        features.operators.openshift.io/cni: "false"
+        features.operators.openshift.io/csi: "false"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.33.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+        repository: https://github.com/kuadrant/kuadrant-operator
+        support: kuadrant
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: AuthPolicy enables authentication and authorization for service workloads in a Gateway API network
+            displayName: AuthPolicy
+            kind: AuthPolicy
+            name: authpolicies.kuadrant.io
+            version: v1
+          - description: DNSPolicy configures how North-South based traffic should be balanced and reach the gateways
+            displayName: DNSPolicy
+            kind: DNSPolicy
+            name: dnspolicies.kuadrant.io
+            version: v1
+          - description: Kuadrant configures installations of Kuadrant Service Protection components
+            displayName: Kuadrant
+            kind: Kuadrant
+            name: kuadrants.kuadrant.io
+            version: v1beta1
+          - kind: OIDCPolicy
+            name: oidcpolicies.extensions.kuadrant.io
+            version: v1alpha1
+          - kind: PlanPolicy
+            name: planpolicies.extensions.kuadrant.io
+            version: v1alpha1
+          - description: RateLimitPolicy enables rate limiting for service workloads in a Gateway API network
+            displayName: RateLimitPolicy
+            kind: RateLimitPolicy
+            name: ratelimitpolicies.kuadrant.io
+            version: v1
+          - kind: TelemetryPolicy
+            name: telemetrypolicies.extensions.kuadrant.io
+            version: v1alpha1
+          - description: TLSPolicy provides tls for gateway listeners by managing the lifecycle of tls certificates
+            displayName: TLSPolicy
+            kind: TLSPolicy
+            name: tlspolicies.kuadrant.io
+            version: v1
+          - kind: TokenRateLimitPolicy
+            name: tokenratelimitpolicies.kuadrant.io
+            version: v1alpha1
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      displayName: Red Hat Connectivity Link
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - api-management
+        - Kuadrant
+        - kubernetes
+        - openshift
+        - cloud-service-protection
+        - rate-limiting
+        - authentication
+        - authorization
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/arch.arm64: supported
+        operatorframework.io/os.linux: supported
+      links:
+        - name: Kuadrant Operator
+          url: https://github.com/Kuadrant/kuadrant-operator
+        - name: Kuadrant Docs
+          url: https://kuadrant.io
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: mcassola@redhat.com
+          name: Guilherme Cassolato
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.19.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+  - image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:4b8cd7dea4d9cd3c7170af872c229e206155691e7dbb4a90c64699ccecc7ccbb
+    name: wasmshim
+  - image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:4ab654849ee3ffb6b2ae64386380ea2344031f9a21fdaecfdd8090836e9e8ba2
+    name: developerportal
+  - image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:41755d5e16ee5409cfe8888cf5883b262820baea4eae449fcf61f06ab1756f57
+    name: console-plugin-latest
+  - image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:c72f23284033de1032e2b209cd2c6087ad0f1aacb8c7312fd324df3d8fee49b9
+    name: console-plugin-pf5
+  - image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:48d67fa983833603f107e353d7ff07b3bd9f44f045a265b5eaeeac8c552fc4bb
     name: ""
   - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:7aa6d6dbbde488260789adb94fa232a06d1e635cc2aaf86af24f8cf14a17eef8
     name: ""

--- a/catalog/4.20/rhcl-operator/catalog.yaml
+++ b/catalog/4.20/rhcl-operator/catalog.yaml
@@ -20,6 +20,8 @@ entries:
     replaces: rhcl-operator.v1.2.1
   - name: rhcl-operator.v1.3.1
     replaces: rhcl-operator.v1.3.0
+  - name: rhcl-operator.v1.3.2
+    replaces: rhcl-operator.v1.3.1
 name: stable
 package: rhcl-operator
 schema: olm.channel
@@ -1832,6 +1834,275 @@ relatedImages:
   - image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:c72f23284033de1032e2b209cd2c6087ad0f1aacb8c7312fd324df3d8fee49b9
     name: console-plugin-pf5
   - image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:a3ae38fae8566fdf66283ebfbec2cb368329ff9703890ebb1b9507f85def1edc
+    name: ""
+  - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:7aa6d6dbbde488260789adb94fa232a06d1e635cc2aaf86af24f8cf14a17eef8
+    name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:48d67fa983833603f107e353d7ff07b3bd9f44f045a265b5eaeeac8c552fc4bb
+name: rhcl-operator.v1.3.2
+package: rhcl-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: AuthPolicy
+      version: v1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: DNSPolicy
+      version: v1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: Kuadrant
+      version: v1beta1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: RateLimitPolicy
+      version: v1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TLSPolicy
+      version: v1
+  - type: olm.package
+    value:
+      packageName: rhcl-operator
+      version: 1.3.2
+  - type: olm.package.required
+    value:
+      packageName: authorino-operator
+      versionRange: 1.3.0
+  - type: olm.package.required
+    value:
+      packageName: dns-operator
+      versionRange: 1.3.0
+  - type: olm.package.required
+    value:
+      packageName: limitador-operator
+      versionRange: 1.3.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "kuadrant.io/v1",
+              "kind": "AuthPolicy",
+              "metadata": {
+                "name": "authpolicy-sample"
+              },
+              "spec": {
+                "rules": {
+                  "authentication": {
+                    "apikey": {
+                      "apiKey": {
+                        "selector": {}
+                      },
+                      "credentials": {
+                        "authorizationHeader": {
+                          "prefix": "APIKEY"
+                        }
+                      }
+                    }
+                  }
+                },
+                "targetRef": {
+                  "group": "gateway.networking.k8s.io",
+                  "kind": "HTTPRoute",
+                  "name": "toystore"
+                }
+              }
+            },
+            {
+              "apiVersion": "kuadrant.io/v1",
+              "kind": "DNSPolicy",
+              "metadata": {
+                "name": "dnspolicy-sample"
+              },
+              "spec": {
+                "healthCheck": {
+                  "protocol": "HTTP"
+                },
+                "providerRefs": [
+                  {
+                    "name": "provider-ref"
+                  }
+                ],
+                "targetRef": {
+                  "group": "gateway.networking.k8s.io",
+                  "kind": "Gateway",
+                  "name": "example-gateway"
+                }
+              }
+            },
+            {
+              "apiVersion": "kuadrant.io/v1",
+              "kind": "RateLimitPolicy",
+              "metadata": {
+                "name": "ratelimitpolicy-sample"
+              },
+              "spec": {
+                "limits": {
+                  "toys": {
+                    "rates": [
+                      {
+                        "limit": 50,
+                        "window": "1m"
+                      }
+                    ]
+                  }
+                },
+                "targetRef": {
+                  "group": "gateway.networking.k8s.io",
+                  "kind": "HTTPRoute",
+                  "name": "toystore"
+                }
+              }
+            },
+            {
+              "apiVersion": "kuadrant.io/v1",
+              "kind": "TLSPolicy",
+              "metadata": {
+                "name": "tlspolicy-sample"
+              },
+              "spec": {
+                "issuerRef": {
+                  "group": "cert-manager.io",
+                  "kind": "ClusterIssuer",
+                  "name": "self-signed-ca"
+                },
+                "targetRef": {
+                  "group": "gateway.networking.k8s.io",
+                  "kind": "Gateway",
+                  "name": "example-gateway"
+                }
+              }
+            },
+            {
+              "apiVersion": "kuadrant.io/v1beta1",
+              "kind": "Kuadrant",
+              "metadata": {
+                "name": "kuadrant-sample"
+              },
+              "spec": {}
+            }
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:7aa6d6dbbde488260789adb94fa232a06d1e635cc2aaf86af24f8cf14a17eef8
+        createdAt: 27 Nov 2025, 19:24
+        description: Red Hat Connectivity Link enables you to secure, protect, and connect your APIs and applications in multicluster, multicloud, and hybrid cloud environments
+        features.operators.openshift.io/cnf: "false"
+        features.operators.openshift.io/cni: "false"
+        features.operators.openshift.io/csi: "false"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.33.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+        repository: https://github.com/kuadrant/kuadrant-operator
+        support: kuadrant
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: AuthPolicy enables authentication and authorization for service workloads in a Gateway API network
+            displayName: AuthPolicy
+            kind: AuthPolicy
+            name: authpolicies.kuadrant.io
+            version: v1
+          - description: DNSPolicy configures how North-South based traffic should be balanced and reach the gateways
+            displayName: DNSPolicy
+            kind: DNSPolicy
+            name: dnspolicies.kuadrant.io
+            version: v1
+          - description: Kuadrant configures installations of Kuadrant Service Protection components
+            displayName: Kuadrant
+            kind: Kuadrant
+            name: kuadrants.kuadrant.io
+            version: v1beta1
+          - kind: OIDCPolicy
+            name: oidcpolicies.extensions.kuadrant.io
+            version: v1alpha1
+          - kind: PlanPolicy
+            name: planpolicies.extensions.kuadrant.io
+            version: v1alpha1
+          - description: RateLimitPolicy enables rate limiting for service workloads in a Gateway API network
+            displayName: RateLimitPolicy
+            kind: RateLimitPolicy
+            name: ratelimitpolicies.kuadrant.io
+            version: v1
+          - kind: TelemetryPolicy
+            name: telemetrypolicies.extensions.kuadrant.io
+            version: v1alpha1
+          - description: TLSPolicy provides tls for gateway listeners by managing the lifecycle of tls certificates
+            displayName: TLSPolicy
+            kind: TLSPolicy
+            name: tlspolicies.kuadrant.io
+            version: v1
+          - kind: TokenRateLimitPolicy
+            name: tokenratelimitpolicies.kuadrant.io
+            version: v1alpha1
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      displayName: Red Hat Connectivity Link
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - api-management
+        - Kuadrant
+        - kubernetes
+        - openshift
+        - cloud-service-protection
+        - rate-limiting
+        - authentication
+        - authorization
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/arch.arm64: supported
+        operatorframework.io/os.linux: supported
+      links:
+        - name: Kuadrant Operator
+          url: https://github.com/Kuadrant/kuadrant-operator
+        - name: Kuadrant Docs
+          url: https://kuadrant.io
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: mcassola@redhat.com
+          name: Guilherme Cassolato
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.19.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+  - image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:4b8cd7dea4d9cd3c7170af872c229e206155691e7dbb4a90c64699ccecc7ccbb
+    name: wasmshim
+  - image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:4ab654849ee3ffb6b2ae64386380ea2344031f9a21fdaecfdd8090836e9e8ba2
+    name: developerportal
+  - image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:41755d5e16ee5409cfe8888cf5883b262820baea4eae449fcf61f06ab1756f57
+    name: console-plugin-latest
+  - image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:c72f23284033de1032e2b209cd2c6087ad0f1aacb8c7312fd324df3d8fee49b9
+    name: console-plugin-pf5
+  - image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:48d67fa983833603f107e353d7ff07b3bd9f44f045a265b5eaeeac8c552fc4bb
     name: ""
   - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:7aa6d6dbbde488260789adb94fa232a06d1e635cc2aaf86af24f8cf14a17eef8
     name: ""

--- a/catalog/4.21/rhcl-operator/catalog.yaml
+++ b/catalog/4.21/rhcl-operator/catalog.yaml
@@ -10,6 +10,8 @@ entries:
   - name: rhcl-operator.v1.3.0
   - name: rhcl-operator.v1.3.1
     replaces: rhcl-operator.v1.3.0
+  - name: rhcl-operator.v1.3.2
+    replaces: rhcl-operator.v1.3.1
 name: stable
 package: rhcl-operator
 schema: olm.channel
@@ -547,6 +549,275 @@ relatedImages:
   - image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:c72f23284033de1032e2b209cd2c6087ad0f1aacb8c7312fd324df3d8fee49b9
     name: console-plugin-pf5
   - image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:a3ae38fae8566fdf66283ebfbec2cb368329ff9703890ebb1b9507f85def1edc
+    name: ""
+  - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:7aa6d6dbbde488260789adb94fa232a06d1e635cc2aaf86af24f8cf14a17eef8
+    name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:48d67fa983833603f107e353d7ff07b3bd9f44f045a265b5eaeeac8c552fc4bb
+name: rhcl-operator.v1.3.2
+package: rhcl-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: AuthPolicy
+      version: v1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: DNSPolicy
+      version: v1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: Kuadrant
+      version: v1beta1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: RateLimitPolicy
+      version: v1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TLSPolicy
+      version: v1
+  - type: olm.package
+    value:
+      packageName: rhcl-operator
+      version: 1.3.2
+  - type: olm.package.required
+    value:
+      packageName: authorino-operator
+      versionRange: 1.3.0
+  - type: olm.package.required
+    value:
+      packageName: dns-operator
+      versionRange: 1.3.0
+  - type: olm.package.required
+    value:
+      packageName: limitador-operator
+      versionRange: 1.3.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "kuadrant.io/v1",
+              "kind": "AuthPolicy",
+              "metadata": {
+                "name": "authpolicy-sample"
+              },
+              "spec": {
+                "rules": {
+                  "authentication": {
+                    "apikey": {
+                      "apiKey": {
+                        "selector": {}
+                      },
+                      "credentials": {
+                        "authorizationHeader": {
+                          "prefix": "APIKEY"
+                        }
+                      }
+                    }
+                  }
+                },
+                "targetRef": {
+                  "group": "gateway.networking.k8s.io",
+                  "kind": "HTTPRoute",
+                  "name": "toystore"
+                }
+              }
+            },
+            {
+              "apiVersion": "kuadrant.io/v1",
+              "kind": "DNSPolicy",
+              "metadata": {
+                "name": "dnspolicy-sample"
+              },
+              "spec": {
+                "healthCheck": {
+                  "protocol": "HTTP"
+                },
+                "providerRefs": [
+                  {
+                    "name": "provider-ref"
+                  }
+                ],
+                "targetRef": {
+                  "group": "gateway.networking.k8s.io",
+                  "kind": "Gateway",
+                  "name": "example-gateway"
+                }
+              }
+            },
+            {
+              "apiVersion": "kuadrant.io/v1",
+              "kind": "RateLimitPolicy",
+              "metadata": {
+                "name": "ratelimitpolicy-sample"
+              },
+              "spec": {
+                "limits": {
+                  "toys": {
+                    "rates": [
+                      {
+                        "limit": 50,
+                        "window": "1m"
+                      }
+                    ]
+                  }
+                },
+                "targetRef": {
+                  "group": "gateway.networking.k8s.io",
+                  "kind": "HTTPRoute",
+                  "name": "toystore"
+                }
+              }
+            },
+            {
+              "apiVersion": "kuadrant.io/v1",
+              "kind": "TLSPolicy",
+              "metadata": {
+                "name": "tlspolicy-sample"
+              },
+              "spec": {
+                "issuerRef": {
+                  "group": "cert-manager.io",
+                  "kind": "ClusterIssuer",
+                  "name": "self-signed-ca"
+                },
+                "targetRef": {
+                  "group": "gateway.networking.k8s.io",
+                  "kind": "Gateway",
+                  "name": "example-gateway"
+                }
+              }
+            },
+            {
+              "apiVersion": "kuadrant.io/v1beta1",
+              "kind": "Kuadrant",
+              "metadata": {
+                "name": "kuadrant-sample"
+              },
+              "spec": {}
+            }
+          ]
+        capabilities: Basic Install
+        categories: Integration & Delivery
+        containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:7aa6d6dbbde488260789adb94fa232a06d1e635cc2aaf86af24f8cf14a17eef8
+        createdAt: 27 Nov 2025, 19:24
+        description: Red Hat Connectivity Link enables you to secure, protect, and connect your APIs and applications in multicluster, multicloud, and hybrid cloud environments
+        features.operators.openshift.io/cnf: "false"
+        features.operators.openshift.io/cni: "false"
+        features.operators.openshift.io/csi: "false"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.33.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+        repository: https://github.com/kuadrant/kuadrant-operator
+        support: kuadrant
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: AuthPolicy enables authentication and authorization for service workloads in a Gateway API network
+            displayName: AuthPolicy
+            kind: AuthPolicy
+            name: authpolicies.kuadrant.io
+            version: v1
+          - description: DNSPolicy configures how North-South based traffic should be balanced and reach the gateways
+            displayName: DNSPolicy
+            kind: DNSPolicy
+            name: dnspolicies.kuadrant.io
+            version: v1
+          - description: Kuadrant configures installations of Kuadrant Service Protection components
+            displayName: Kuadrant
+            kind: Kuadrant
+            name: kuadrants.kuadrant.io
+            version: v1beta1
+          - kind: OIDCPolicy
+            name: oidcpolicies.extensions.kuadrant.io
+            version: v1alpha1
+          - kind: PlanPolicy
+            name: planpolicies.extensions.kuadrant.io
+            version: v1alpha1
+          - description: RateLimitPolicy enables rate limiting for service workloads in a Gateway API network
+            displayName: RateLimitPolicy
+            kind: RateLimitPolicy
+            name: ratelimitpolicies.kuadrant.io
+            version: v1
+          - kind: TelemetryPolicy
+            name: telemetrypolicies.extensions.kuadrant.io
+            version: v1alpha1
+          - description: TLSPolicy provides tls for gateway listeners by managing the lifecycle of tls certificates
+            displayName: TLSPolicy
+            kind: TLSPolicy
+            name: tlspolicies.kuadrant.io
+            version: v1
+          - kind: TokenRateLimitPolicy
+            name: tokenratelimitpolicies.kuadrant.io
+            version: v1alpha1
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      displayName: Red Hat Connectivity Link
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - api
+        - api-management
+        - Kuadrant
+        - kubernetes
+        - openshift
+        - cloud-service-protection
+        - rate-limiting
+        - authentication
+        - authorization
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/arch.arm64: supported
+        operatorframework.io/os.linux: supported
+      links:
+        - name: Kuadrant Operator
+          url: https://github.com/Kuadrant/kuadrant-operator
+        - name: Kuadrant Docs
+          url: https://kuadrant.io
+      maintainers:
+        - email: eastizle@redhat.com
+          name: Eguzki Astiz Lezaun
+        - email: mcassola@redhat.com
+          name: Guilherme Cassolato
+        - email: didier@redhat.com
+          name: Didier Di Cesare
+      maturity: alpha
+      minKubeVersion: 1.19.0
+      provider:
+        name: Red Hat
+        url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+  - image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:4b8cd7dea4d9cd3c7170af872c229e206155691e7dbb4a90c64699ccecc7ccbb
+    name: wasmshim
+  - image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:4ab654849ee3ffb6b2ae64386380ea2344031f9a21fdaecfdd8090836e9e8ba2
+    name: developerportal
+  - image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:41755d5e16ee5409cfe8888cf5883b262820baea4eae449fcf61f06ab1756f57
+    name: console-plugin-latest
+  - image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:c72f23284033de1032e2b209cd2c6087ad0f1aacb8c7312fd324df3d8fee49b9
+    name: console-plugin-pf5
+  - image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:48d67fa983833603f107e353d7ff07b3bd9f44f045a265b5eaeeac8c552fc4bb
     name: ""
   - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:7aa6d6dbbde488260789adb94fa232a06d1e635cc2aaf86af24f8cf14a17eef8
     name: ""


### PR DESCRIPTION
Snapshot used for release: `rhcl-1-3-2-rhcl-operator-rc2-new-bundle-to-fix-conforma`
This is a different bundle than what was used to do the testing by QE, but the bundle content is the same, just with newer konflux build refs and such things.

We were not allowed to ship `rhcl-1-3-2-rhcl-operator-rc2` due to a conforma failure

