### PR TITLE
Fix discrepancies between olm.gvk and crdDescription sections of rhcl operator catalog

### DIFF
--- a/catalog/4.17/rhcl-operator/catalog.yaml
+++ b/catalog/4.17/rhcl-operator/catalog.yaml
@@ -1303,6 +1303,26 @@ properties:
       group: kuadrant.io
       kind: TLSPolicy
       version: v1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
+      version: v1alpha1
   - type: olm.package
     value:
       packageName: rhcl-operator
@@ -1566,6 +1586,26 @@ properties:
       group: kuadrant.io
       kind: TLSPolicy
       version: v1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
+      version: v1alpha1
   - type: olm.package
     value:
       packageName: rhcl-operator

--- a/catalog/4.18/rhcl-operator/catalog.yaml
+++ b/catalog/4.18/rhcl-operator/catalog.yaml
@@ -798,6 +798,26 @@ properties:
       group: kuadrant.io
       kind: TLSPolicy
       version: v1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
+      version: v1alpha1
   - type: olm.package
     value:
       packageName: rhcl-operator
@@ -1061,6 +1081,26 @@ properties:
       group: kuadrant.io
       kind: TLSPolicy
       version: v1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
+      version: v1alpha1
   - type: olm.package
     value:
       packageName: rhcl-operator

--- a/catalog/4.19/rhcl-operator/catalog.yaml
+++ b/catalog/4.19/rhcl-operator/catalog.yaml
@@ -806,6 +806,26 @@ properties:
       group: kuadrant.io
       kind: TLSPolicy
       version: v1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
+      version: v1alpha1
   - type: olm.package
     value:
       packageName: rhcl-operator
@@ -1069,6 +1089,26 @@ properties:
       group: kuadrant.io
       kind: TLSPolicy
       version: v1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
+      version: v1alpha1
   - type: olm.package
     value:
       packageName: rhcl-operator
@@ -1341,6 +1381,26 @@ properties:
     value:
       group: devportal.kuadrant.io
       kind: APIProduct
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
       version: v1alpha1
   - type: olm.package
     value:
@@ -1627,6 +1687,26 @@ properties:
       group: devportal.kuadrant.io
       kind: APIProduct
       version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
+      version: v1alpha1
   - type: olm.package
     value:
       packageName: rhcl-operator
@@ -1911,6 +1991,26 @@ properties:
     value:
       group: devportal.kuadrant.io
       kind: APIProduct
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
       version: v1alpha1
   - type: olm.package
     value:

--- a/catalog/4.20/rhcl-operator/catalog.yaml
+++ b/catalog/4.20/rhcl-operator/catalog.yaml
@@ -806,6 +806,26 @@ properties:
       group: kuadrant.io
       kind: TLSPolicy
       version: v1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
+      version: v1alpha1
   - type: olm.package
     value:
       packageName: rhcl-operator
@@ -1069,6 +1089,26 @@ properties:
       group: kuadrant.io
       kind: TLSPolicy
       version: v1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
+      version: v1alpha1
   - type: olm.package
     value:
       packageName: rhcl-operator
@@ -1341,6 +1381,26 @@ properties:
     value:
       group: devportal.kuadrant.io
       kind: APIProduct
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
       version: v1alpha1
   - type: olm.package
     value:
@@ -1627,6 +1687,26 @@ properties:
       group: devportal.kuadrant.io
       kind: APIProduct
       version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
+      version: v1alpha1
   - type: olm.package
     value:
       packageName: rhcl-operator
@@ -1911,6 +1991,26 @@ properties:
     value:
       group: devportal.kuadrant.io
       kind: APIProduct
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
       version: v1alpha1
   - type: olm.package
     value:

--- a/catalog/4.21/rhcl-operator/catalog.yaml
+++ b/catalog/4.21/rhcl-operator/catalog.yaml
@@ -57,6 +57,26 @@ properties:
       group: devportal.kuadrant.io
       kind: APIProduct
       version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
+      version: v1alpha1
   - type: olm.package
     value:
       packageName: rhcl-operator
@@ -342,6 +362,26 @@ properties:
       group: devportal.kuadrant.io
       kind: APIProduct
       version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
+      version: v1alpha1
   - type: olm.package
     value:
       packageName: rhcl-operator
@@ -626,6 +666,26 @@ properties:
     value:
       group: devportal.kuadrant.io
       kind: APIProduct
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: OIDCPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: PlanPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: extensions.kuadrant.io
+      kind: TelemetryPolicy
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: kuadrant.io
+      kind: TokenRateLimitPolicy
       version: v1alpha1
   - type: olm.package
     value:


### PR DESCRIPTION
Some CRDs were missing from OLM.gvk in rhcl-1.2.0 and above