### PR TITLE
File Based Catalog for RHCL 1.3.5 and RHCL 1.4.1

### DIFF
--- a/catalog/4.18/authorino-operator/catalog.yaml
+++ b/catalog/4.18/authorino-operator/catalog.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: authorino-operator.v1.2.3
   - name: authorino-operator.v1.3.1
     replaces: authorino-operator.v1.2.4
+  - name: authorino-operator.v1.3.2
+    replaces: authorino-operator.v1.3.1
 name: stable
 package: authorino-operator
 schema: olm.channel
@@ -4881,4 +4883,161 @@ relatedImages:
     name: ""
   - image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:b9e3aec873834dab0e8461e76931799ccd2538f1157a1626be233f8ede268c45
     name: authorino
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:a2d0d04d5637d44dbf773293bad0e273b5616b2ed477222d8b47e3842c2cb591
+name: authorino-operator.v1.3.2
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:a729d73e926f227fdba6a06520fd06d9037dc1c2d5ebebb6e4e7bbcf736d6ff1
+      createdAt: "2026-06-19T14:19:59Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:a2d0d04d5637d44dbf773293bad0e273b5616b2ed477222d8b47e3842c2cb591
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:a729d73e926f227fdba6a06520fd06d9037dc1c2d5ebebb6e4e7bbcf736d6ff1
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:e8d5f2150ac91e13dd5486a78a7f230f0434ccd09b8c1d07edcadd30e7ec2efa
+  name: authorino
 schema: olm.bundle

--- a/catalog/4.18/rhcl-operator/catalog.yaml
+++ b/catalog/4.18/rhcl-operator/catalog.yaml
@@ -18,6 +18,8 @@ entries:
     replaces: rhcl-operator.v1.2.0
   - name: rhcl-operator.v1.3.4
     replaces: rhcl-operator.v1.2.1
+  - name: rhcl-operator.v1.3.5
+    replaces: rhcl-operator.v1.3.4
 name: stable
 package: rhcl-operator
 schema: olm.channel
@@ -1762,4 +1764,431 @@ relatedImages:
     name: ""
   - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
     name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:b1cd6b34140c3c514a79449cddca319d2584cca8170689c372e65df735b2e376
+name: rhcl-operator.v1.3.5
+package: rhcl-operator
+properties:
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIProduct
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: OIDCPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: PlanPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: TelemetryPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: AuthPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: Kuadrant
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: RateLimitPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TLSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TokenRateLimitPolicy
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: rhcl-operator
+    version: 1.3.5
+- type: olm.package.required
+  value:
+    packageName: authorino-operator
+    versionRange: 1.3.2
+- type: olm.package.required
+  value:
+    packageName: dns-operator
+    versionRange: 1.3.1
+- type: olm.package.required
+  value:
+    packageName: limitador-operator
+    versionRange: 1.3.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "OIDCPolicy",
+            "metadata": {
+              "name": "oidcpolicy-sample"
+            },
+            "spec": {
+              "provider": {
+                "cliendID": "exampleID",
+                "issuerURL": "https://idp.example.org/"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "PlanPolicy",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "kuadrant-operator",
+                "app.kubernetes.io/instance": "planpolicy-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "planpolicy",
+                "app.kubernetes.io/part-of": "kuadrant-operator"
+              },
+              "name": "planpolicy-sample"
+            },
+            "spec": {
+              "plans": [
+                {
+                  "limits": {
+                    "daily": 5
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"gold\"\n",
+                  "tier": "gold"
+                },
+                {
+                  "limits": {
+                    "daily": 2
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"silver\"\n",
+                  "tier": "silver"
+                },
+                {
+                  "limits": {
+                    "daily": 1
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"bronze\"\n",
+                  "tier": "bronze"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "AuthPolicy",
+            "metadata": {
+              "name": "authpolicy-sample"
+            },
+            "spec": {
+              "rules": {
+                "authentication": {
+                  "apikey": {
+                    "apiKey": {
+                      "selector": {}
+                    },
+                    "credentials": {
+                      "authorizationHeader": {
+                        "prefix": "APIKEY"
+                      }
+                    }
+                  }
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "DNSPolicy",
+            "metadata": {
+              "name": "dnspolicy-sample"
+            },
+            "spec": {
+              "healthCheck": {
+                "protocol": "HTTP"
+              },
+              "providerRefs": [
+                {
+                  "name": "provider-ref"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "RateLimitPolicy",
+            "metadata": {
+              "name": "ratelimitpolicy-sample"
+            },
+            "spec": {
+              "limits": {
+                "toys": {
+                  "rates": [
+                    {
+                      "limit": 50,
+                      "window": "1m"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "TLSPolicy",
+            "metadata": {
+              "name": "tlspolicy-sample"
+            },
+            "spec": {
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "self-signed-ca"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "TokenRateLimitPolicy",
+            "metadata": {
+              "name": "token-limit-free",
+              "namespace": "gateway-system"
+            },
+            "spec": {
+              "limits": {
+                "free": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 20000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"free\")"
+                    }
+                  ]
+                },
+                "gold": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 200000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"gold\")"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "my-llm-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "Kuadrant",
+            "metadata": {
+              "name": "kuadrant-sample"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      console.openshift.io/plugins: '["kuadrant-console-plugin"]'
+      containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
+      createdAt: "2026-06-22T17:00:01Z"
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/kuadrant-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: APIKey
+        name: apikeys.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIProduct
+        name: apiproducts.devportal.kuadrant.io
+        version: v1alpha1
+      - description: AuthPolicy enables authentication and authorization for service
+          workloads in a Gateway API network
+        displayName: AuthPolicy
+        kind: AuthPolicy
+        name: authpolicies.kuadrant.io
+        version: v1
+      - description: DNSPolicy configures how North-South based traffic should be
+          balanced and reach the gateways
+        displayName: DNSPolicy
+        kind: DNSPolicy
+        name: dnspolicies.kuadrant.io
+        version: v1
+      - description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        displayName: Kuadrant
+        kind: Kuadrant
+        name: kuadrants.kuadrant.io
+        version: v1beta1
+      - kind: OIDCPolicy
+        name: oidcpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - kind: PlanPolicy
+        name: planpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        displayName: RateLimitPolicy
+        kind: RateLimitPolicy
+        name: ratelimitpolicies.kuadrant.io
+        version: v1
+      - kind: TelemetryPolicy
+        name: telemetrypolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: TLSPolicy provides tls for gateway listeners by managing the
+          lifecycle of tls certificates
+        displayName: TLSPolicy
+        kind: TLSPolicy
+        name: tlspolicies.kuadrant.io
+        version: v1
+      - kind: TokenRateLimitPolicy
+        name: tokenratelimitpolicies.kuadrant.io
+        version: v1alpha1
+    description: Red Hat Connectivity Link enables you to secure, protect, and connect
+      your APIs and applications in multicluster, multicloud, and hybrid cloud environments.
+    displayName: Red Hat Connectivity Link
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - api-management
+    - Kuadrant
+    - kubernetes
+    - openshift
+    - cloud-service-protection
+    - rate-limiting
+    - authentication
+    - authorization
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Kuadrant Operator
+      url: https://github.com/Kuadrant/kuadrant-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+- image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:4b8cd7dea4d9cd3c7170af872c229e206155691e7dbb4a90c64699ccecc7ccbb
+  name: wasmshim
+- image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:434a6d1471a8cbe62b80b1ba077ac5b041561bd3d652ac1391a011f91b2b1ec2
+  name: developerportal
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:3ce32a816eca502581d45f4346ac81e5751b1c6a471c5dc439405f07b1db2c69
+  name: console-plugin-latest
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:be66268555a8d7043ceb6099ff02306e5a5455201dd46ff69c9c2eca9b93f760
+  name: console-plugin-pf5
+- image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:b1cd6b34140c3c514a79449cddca319d2584cca8170689c372e65df735b2e376
+  name: ""
+- image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
+  name: ""
 schema: olm.bundle

--- a/catalog/4.19/authorino-operator/catalog.yaml
+++ b/catalog/4.19/authorino-operator/catalog.yaml
@@ -30,8 +30,14 @@ entries:
     replaces: authorino-operator.v1.2.4
   - name: authorino-operator.v1.3.1
     replaces: authorino-operator.v1.3.0
+  - name: authorino-operator.v1.3.2
+    replaces: authorino-operator.v1.3.1
   - name: authorino-operator.v1.4.0
     replaces: authorino-operator.v1.3.1
+  - name: authorino-operator.v1.4.1
+    replaces: authorino-operator.v1.3.2
+    skips:
+      - authorino-operator.v1.4.0
 name: stable
 package: authorino-operator
 schema: olm.channel
@@ -3985,4 +3991,318 @@ relatedImages:
     name: ""
   - image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:76be3de77f8848f9e9f5ed0271b31255d35fdd486bb67eb6ca9ac792bc65b1ce
     name: authorino
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:a2d0d04d5637d44dbf773293bad0e273b5616b2ed477222d8b47e3842c2cb591
+name: authorino-operator.v1.3.2
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:a729d73e926f227fdba6a06520fd06d9037dc1c2d5ebebb6e4e7bbcf736d6ff1
+      createdAt: "2026-06-19T14:19:59Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:a2d0d04d5637d44dbf773293bad0e273b5616b2ed477222d8b47e3842c2cb591
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:a729d73e926f227fdba6a06520fd06d9037dc1c2d5ebebb6e4e7bbcf736d6ff1
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:e8d5f2150ac91e13dd5486a78a7f230f0434ccd09b8c1d07edcadd30e7ec2efa
+  name: authorino
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:7d936067c88c0e16935b00950637773ea7d336c0d8e96deb73d77e7c461c6245
+name: authorino-operator.v1.4.1
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.4.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b2cc2c0f0729dad98f970830816e300c0b961ba42491f362295512d886384687
+      createdAt: "2026-06-19T14:15:09Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:7d936067c88c0e16935b00950637773ea7d336c0d8e96deb73d77e7c461c6245
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b2cc2c0f0729dad98f970830816e300c0b961ba42491f362295512d886384687
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:eaadd50c0e4938926e50283a5f3e3b5f1dd24d820a3a2c7434153080180cc95a
+  name: authorino
 schema: olm.bundle

--- a/catalog/4.19/rhcl-operator/catalog.yaml
+++ b/catalog/4.19/rhcl-operator/catalog.yaml
@@ -26,8 +26,13 @@ entries:
     replaces: rhcl-operator.v1.3.2
   - name: rhcl-operator.v1.3.4
     replaces: rhcl-operator.v1.3.3
-  - name: rhcl-operator.v1.4.0
+  - name: rhcl-operator.v1.3.5
     replaces: rhcl-operator.v1.3.4
+  - name: rhcl-operator.v1.4.0
+  - name: rhcl-operator.v1.4.1
+    replaces: rhcl-operator.v1.3.5
+    skips:
+      - rhcl-operator.v1.4.0
 name: stable
 package: rhcl-operator
 schema: olm.channel
@@ -3553,4 +3558,876 @@ relatedImages:
     name: ""
   - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:63c62ca2971e5679da2d1e8615448a5653058d3a012ace13c3251ae295792bc5
     name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:b1cd6b34140c3c514a79449cddca319d2584cca8170689c372e65df735b2e376
+name: rhcl-operator.v1.3.5
+package: rhcl-operator
+properties:
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIProduct
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: OIDCPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: PlanPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: TelemetryPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: AuthPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: Kuadrant
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: RateLimitPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TLSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TokenRateLimitPolicy
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: rhcl-operator
+    version: 1.3.5
+- type: olm.package.required
+  value:
+    packageName: authorino-operator
+    versionRange: 1.3.2
+- type: olm.package.required
+  value:
+    packageName: dns-operator
+    versionRange: 1.3.1
+- type: olm.package.required
+  value:
+    packageName: limitador-operator
+    versionRange: 1.3.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "OIDCPolicy",
+            "metadata": {
+              "name": "oidcpolicy-sample"
+            },
+            "spec": {
+              "provider": {
+                "cliendID": "exampleID",
+                "issuerURL": "https://idp.example.org/"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "PlanPolicy",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "kuadrant-operator",
+                "app.kubernetes.io/instance": "planpolicy-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "planpolicy",
+                "app.kubernetes.io/part-of": "kuadrant-operator"
+              },
+              "name": "planpolicy-sample"
+            },
+            "spec": {
+              "plans": [
+                {
+                  "limits": {
+                    "daily": 5
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"gold\"\n",
+                  "tier": "gold"
+                },
+                {
+                  "limits": {
+                    "daily": 2
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"silver\"\n",
+                  "tier": "silver"
+                },
+                {
+                  "limits": {
+                    "daily": 1
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"bronze\"\n",
+                  "tier": "bronze"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "AuthPolicy",
+            "metadata": {
+              "name": "authpolicy-sample"
+            },
+            "spec": {
+              "rules": {
+                "authentication": {
+                  "apikey": {
+                    "apiKey": {
+                      "selector": {}
+                    },
+                    "credentials": {
+                      "authorizationHeader": {
+                        "prefix": "APIKEY"
+                      }
+                    }
+                  }
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "DNSPolicy",
+            "metadata": {
+              "name": "dnspolicy-sample"
+            },
+            "spec": {
+              "healthCheck": {
+                "protocol": "HTTP"
+              },
+              "providerRefs": [
+                {
+                  "name": "provider-ref"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "RateLimitPolicy",
+            "metadata": {
+              "name": "ratelimitpolicy-sample"
+            },
+            "spec": {
+              "limits": {
+                "toys": {
+                  "rates": [
+                    {
+                      "limit": 50,
+                      "window": "1m"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "TLSPolicy",
+            "metadata": {
+              "name": "tlspolicy-sample"
+            },
+            "spec": {
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "self-signed-ca"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "TokenRateLimitPolicy",
+            "metadata": {
+              "name": "token-limit-free",
+              "namespace": "gateway-system"
+            },
+            "spec": {
+              "limits": {
+                "free": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 20000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"free\")"
+                    }
+                  ]
+                },
+                "gold": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 200000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"gold\")"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "my-llm-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "Kuadrant",
+            "metadata": {
+              "name": "kuadrant-sample"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      console.openshift.io/plugins: '["kuadrant-console-plugin"]'
+      containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
+      createdAt: "2026-06-22T17:00:01Z"
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/kuadrant-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: APIKey
+        name: apikeys.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIProduct
+        name: apiproducts.devportal.kuadrant.io
+        version: v1alpha1
+      - description: AuthPolicy enables authentication and authorization for service
+          workloads in a Gateway API network
+        displayName: AuthPolicy
+        kind: AuthPolicy
+        name: authpolicies.kuadrant.io
+        version: v1
+      - description: DNSPolicy configures how North-South based traffic should be
+          balanced and reach the gateways
+        displayName: DNSPolicy
+        kind: DNSPolicy
+        name: dnspolicies.kuadrant.io
+        version: v1
+      - description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        displayName: Kuadrant
+        kind: Kuadrant
+        name: kuadrants.kuadrant.io
+        version: v1beta1
+      - kind: OIDCPolicy
+        name: oidcpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - kind: PlanPolicy
+        name: planpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        displayName: RateLimitPolicy
+        kind: RateLimitPolicy
+        name: ratelimitpolicies.kuadrant.io
+        version: v1
+      - kind: TelemetryPolicy
+        name: telemetrypolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: TLSPolicy provides tls for gateway listeners by managing the
+          lifecycle of tls certificates
+        displayName: TLSPolicy
+        kind: TLSPolicy
+        name: tlspolicies.kuadrant.io
+        version: v1
+      - kind: TokenRateLimitPolicy
+        name: tokenratelimitpolicies.kuadrant.io
+        version: v1alpha1
+    description: Red Hat Connectivity Link enables you to secure, protect, and connect
+      your APIs and applications in multicluster, multicloud, and hybrid cloud environments.
+    displayName: Red Hat Connectivity Link
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - api-management
+    - Kuadrant
+    - kubernetes
+    - openshift
+    - cloud-service-protection
+    - rate-limiting
+    - authentication
+    - authorization
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Kuadrant Operator
+      url: https://github.com/Kuadrant/kuadrant-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+- image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:4b8cd7dea4d9cd3c7170af872c229e206155691e7dbb4a90c64699ccecc7ccbb
+  name: wasmshim
+- image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:434a6d1471a8cbe62b80b1ba077ac5b041561bd3d652ac1391a011f91b2b1ec2
+  name: developerportal
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:3ce32a816eca502581d45f4346ac81e5751b1c6a471c5dc439405f07b1db2c69
+  name: console-plugin-latest
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:be66268555a8d7043ceb6099ff02306e5a5455201dd46ff69c9c2eca9b93f760
+  name: console-plugin-pf5
+- image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:b1cd6b34140c3c514a79449cddca319d2584cca8170689c372e65df735b2e376
+  name: ""
+- image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
+  name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:6e2c182d2a8502f24028a3e81f689f31cadd665667b0d309785d7ca02733eb32
+name: rhcl-operator.v1.4.1
+package: rhcl-operator
+properties:
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKeyApproval
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKeyRequest
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIProduct
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: OIDCPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: PlanPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: TelemetryPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: AuthPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: Kuadrant
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: RateLimitPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TLSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TokenRateLimitPolicy
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: rhcl-operator
+    version: 1.4.1
+- type: olm.package.required
+  value:
+    packageName: authorino-operator
+    versionRange: 1.4.1
+- type: olm.package.required
+  value:
+    packageName: dns-operator
+    versionRange: 1.4.0
+- type: olm.package.required
+  value:
+    packageName: limitador-operator
+    versionRange: 1.4.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "OIDCPolicy",
+            "metadata": {
+              "name": "oidcpolicy-sample"
+            },
+            "spec": {
+              "provider": {
+                "cliendID": "exampleID",
+                "issuerURL": "https://idp.example.org/"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "PlanPolicy",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "kuadrant-operator",
+                "app.kubernetes.io/instance": "planpolicy-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "planpolicy",
+                "app.kubernetes.io/part-of": "kuadrant-operator"
+              },
+              "name": "planpolicy-sample"
+            },
+            "spec": {
+              "plans": [
+                {
+                  "limits": {
+                    "daily": 5
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"gold\"\n",
+                  "tier": "gold"
+                },
+                {
+                  "limits": {
+                    "daily": 2
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"silver\"\n",
+                  "tier": "silver"
+                },
+                {
+                  "limits": {
+                    "daily": 1
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"bronze\"\n",
+                  "tier": "bronze"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "AuthPolicy",
+            "metadata": {
+              "name": "authpolicy-sample"
+            },
+            "spec": {
+              "rules": {
+                "authentication": {
+                  "apikey": {
+                    "apiKey": {
+                      "selector": {}
+                    },
+                    "credentials": {
+                      "authorizationHeader": {
+                        "prefix": "APIKEY"
+                      }
+                    }
+                  }
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "DNSPolicy",
+            "metadata": {
+              "name": "dnspolicy-sample"
+            },
+            "spec": {
+              "healthCheck": {
+                "protocol": "HTTP"
+              },
+              "providerRefs": [
+                {
+                  "name": "provider-ref"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "RateLimitPolicy",
+            "metadata": {
+              "name": "ratelimitpolicy-sample"
+            },
+            "spec": {
+              "limits": {
+                "toys": {
+                  "rates": [
+                    {
+                      "limit": 50,
+                      "window": "1m"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "TLSPolicy",
+            "metadata": {
+              "name": "tlspolicy-sample"
+            },
+            "spec": {
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "self-signed-ca"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "TokenRateLimitPolicy",
+            "metadata": {
+              "name": "token-limit-free",
+              "namespace": "gateway-system"
+            },
+            "spec": {
+              "limits": {
+                "free": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 20000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"free\")"
+                    }
+                  ]
+                },
+                "gold": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 200000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"gold\")"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "my-llm-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "Kuadrant",
+            "metadata": {
+              "name": "kuadrant-sample"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      console.openshift.io/plugins: '["kuadrant-console-plugin"]'
+      containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0b77e4a874b620095a0300877aea53e78559a601ce62b194537ed21c2743bbf3
+      createdAt: "2026-06-26T08:32:19Z"
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/kuadrant-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: APIKeyApproval
+        name: apikeyapprovals.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIKeyRequest
+        name: apikeyrequests.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIKey
+        name: apikeys.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIProduct
+        name: apiproducts.devportal.kuadrant.io
+        version: v1alpha1
+      - description: AuthPolicy enables authentication and authorization for service
+          workloads in a Gateway API network
+        displayName: AuthPolicy
+        kind: AuthPolicy
+        name: authpolicies.kuadrant.io
+        version: v1
+      - description: DNSPolicy configures how North-South based traffic should be
+          balanced and reach the gateways
+        displayName: DNSPolicy
+        kind: DNSPolicy
+        name: dnspolicies.kuadrant.io
+        version: v1
+      - description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        displayName: Kuadrant
+        kind: Kuadrant
+        name: kuadrants.kuadrant.io
+        version: v1beta1
+      - kind: OIDCPolicy
+        name: oidcpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - kind: PlanPolicy
+        name: planpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        displayName: RateLimitPolicy
+        kind: RateLimitPolicy
+        name: ratelimitpolicies.kuadrant.io
+        version: v1
+      - kind: TelemetryPolicy
+        name: telemetrypolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: TLSPolicy provides tls for gateway listeners by managing the
+          lifecycle of tls certificates
+        displayName: TLSPolicy
+        kind: TLSPolicy
+        name: tlspolicies.kuadrant.io
+        version: v1
+      - kind: TokenRateLimitPolicy
+        name: tokenratelimitpolicies.kuadrant.io
+        version: v1alpha1
+    description: Red Hat Connectivity Link enables you to secure, protect, and connect
+      your APIs and applications in multicluster, multicloud, and hybrid cloud environments.
+    displayName: Red Hat Connectivity Link
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - api-management
+    - Kuadrant
+    - kubernetes
+    - openshift
+    - cloud-service-protection
+    - rate-limiting
+    - authentication
+    - authorization
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Kuadrant Operator
+      url: https://github.com/Kuadrant/kuadrant-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+- image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:8384a01623b5593bb12086edb3baacf41cd7521456b36d18ca7c1ee1ce1b5fc6
+  name: wasmshim
+- image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:5fe421d8686b7d1adf5fe210eec62bc2d07ab831bfbf3e0e0f4688ec81deda77
+  name: developerportal
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:6e69f41d3d70b0afa7691a5d2400065d3bcdec2ea82830cf2992b8e69ba06e2a
+  name: console-plugin-latest
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:cb4ae73530916789ea9b2e1aa3706c82c6ca39dd0869cd4854b66759f1597a07
+  name: console-plugin-pf5
+- image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:6e2c182d2a8502f24028a3e81f689f31cadd665667b0d309785d7ca02733eb32
+  name: ""
+- image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0b77e4a874b620095a0300877aea53e78559a601ce62b194537ed21c2743bbf3
+  name: ""
 schema: olm.bundle

--- a/catalog/4.20/authorino-operator/catalog.yaml
+++ b/catalog/4.20/authorino-operator/catalog.yaml
@@ -30,8 +30,14 @@ entries:
     replaces: authorino-operator.v1.2.4
   - name: authorino-operator.v1.3.1
     replaces: authorino-operator.v1.3.0
+  - name: authorino-operator.v1.3.2
+    replaces: authorino-operator.v1.3.1
   - name: authorino-operator.v1.4.0
     replaces: authorino-operator.v1.3.1
+  - name: authorino-operator.v1.4.1
+    replaces: authorino-operator.v1.3.2
+    skips:
+      - authorino-operator.v1.4.0
 name: stable
 package: authorino-operator
 schema: olm.channel
@@ -3984,4 +3990,318 @@ relatedImages:
     name: ""
   - image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:76be3de77f8848f9e9f5ed0271b31255d35fdd486bb67eb6ca9ac792bc65b1ce
     name: authorino
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:a2d0d04d5637d44dbf773293bad0e273b5616b2ed477222d8b47e3842c2cb591
+name: authorino-operator.v1.3.2
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:a729d73e926f227fdba6a06520fd06d9037dc1c2d5ebebb6e4e7bbcf736d6ff1
+      createdAt: "2026-06-19T14:19:59Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:a2d0d04d5637d44dbf773293bad0e273b5616b2ed477222d8b47e3842c2cb591
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:a729d73e926f227fdba6a06520fd06d9037dc1c2d5ebebb6e4e7bbcf736d6ff1
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:e8d5f2150ac91e13dd5486a78a7f230f0434ccd09b8c1d07edcadd30e7ec2efa
+  name: authorino
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:7d936067c88c0e16935b00950637773ea7d336c0d8e96deb73d77e7c461c6245
+name: authorino-operator.v1.4.1
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.4.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b2cc2c0f0729dad98f970830816e300c0b961ba42491f362295512d886384687
+      createdAt: "2026-06-19T14:15:09Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:7d936067c88c0e16935b00950637773ea7d336c0d8e96deb73d77e7c461c6245
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b2cc2c0f0729dad98f970830816e300c0b961ba42491f362295512d886384687
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:eaadd50c0e4938926e50283a5f3e3b5f1dd24d820a3a2c7434153080180cc95a
+  name: authorino
 schema: olm.bundle

--- a/catalog/4.20/rhcl-operator/catalog.yaml
+++ b/catalog/4.20/rhcl-operator/catalog.yaml
@@ -26,8 +26,13 @@ entries:
     replaces: rhcl-operator.v1.3.2
   - name: rhcl-operator.v1.3.4
     replaces: rhcl-operator.v1.3.3
-  - name: rhcl-operator.v1.4.0
+  - name: rhcl-operator.v1.3.5
     replaces: rhcl-operator.v1.3.4
+  - name: rhcl-operator.v1.4.0
+  - name: rhcl-operator.v1.4.1
+    replaces: rhcl-operator.v1.3.5
+    skips:
+      - rhcl-operator.v1.4.0
 name: stable
 package: rhcl-operator
 schema: olm.channel
@@ -3553,4 +3558,876 @@ relatedImages:
     name: ""
   - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:63c62ca2971e5679da2d1e8615448a5653058d3a012ace13c3251ae295792bc5
     name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:b1cd6b34140c3c514a79449cddca319d2584cca8170689c372e65df735b2e376
+name: rhcl-operator.v1.3.5
+package: rhcl-operator
+properties:
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIProduct
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: OIDCPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: PlanPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: TelemetryPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: AuthPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: Kuadrant
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: RateLimitPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TLSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TokenRateLimitPolicy
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: rhcl-operator
+    version: 1.3.5
+- type: olm.package.required
+  value:
+    packageName: authorino-operator
+    versionRange: 1.3.2
+- type: olm.package.required
+  value:
+    packageName: dns-operator
+    versionRange: 1.3.1
+- type: olm.package.required
+  value:
+    packageName: limitador-operator
+    versionRange: 1.3.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "OIDCPolicy",
+            "metadata": {
+              "name": "oidcpolicy-sample"
+            },
+            "spec": {
+              "provider": {
+                "cliendID": "exampleID",
+                "issuerURL": "https://idp.example.org/"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "PlanPolicy",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "kuadrant-operator",
+                "app.kubernetes.io/instance": "planpolicy-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "planpolicy",
+                "app.kubernetes.io/part-of": "kuadrant-operator"
+              },
+              "name": "planpolicy-sample"
+            },
+            "spec": {
+              "plans": [
+                {
+                  "limits": {
+                    "daily": 5
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"gold\"\n",
+                  "tier": "gold"
+                },
+                {
+                  "limits": {
+                    "daily": 2
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"silver\"\n",
+                  "tier": "silver"
+                },
+                {
+                  "limits": {
+                    "daily": 1
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"bronze\"\n",
+                  "tier": "bronze"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "AuthPolicy",
+            "metadata": {
+              "name": "authpolicy-sample"
+            },
+            "spec": {
+              "rules": {
+                "authentication": {
+                  "apikey": {
+                    "apiKey": {
+                      "selector": {}
+                    },
+                    "credentials": {
+                      "authorizationHeader": {
+                        "prefix": "APIKEY"
+                      }
+                    }
+                  }
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "DNSPolicy",
+            "metadata": {
+              "name": "dnspolicy-sample"
+            },
+            "spec": {
+              "healthCheck": {
+                "protocol": "HTTP"
+              },
+              "providerRefs": [
+                {
+                  "name": "provider-ref"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "RateLimitPolicy",
+            "metadata": {
+              "name": "ratelimitpolicy-sample"
+            },
+            "spec": {
+              "limits": {
+                "toys": {
+                  "rates": [
+                    {
+                      "limit": 50,
+                      "window": "1m"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "TLSPolicy",
+            "metadata": {
+              "name": "tlspolicy-sample"
+            },
+            "spec": {
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "self-signed-ca"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "TokenRateLimitPolicy",
+            "metadata": {
+              "name": "token-limit-free",
+              "namespace": "gateway-system"
+            },
+            "spec": {
+              "limits": {
+                "free": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 20000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"free\")"
+                    }
+                  ]
+                },
+                "gold": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 200000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"gold\")"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "my-llm-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "Kuadrant",
+            "metadata": {
+              "name": "kuadrant-sample"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      console.openshift.io/plugins: '["kuadrant-console-plugin"]'
+      containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
+      createdAt: "2026-06-22T17:00:01Z"
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/kuadrant-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: APIKey
+        name: apikeys.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIProduct
+        name: apiproducts.devportal.kuadrant.io
+        version: v1alpha1
+      - description: AuthPolicy enables authentication and authorization for service
+          workloads in a Gateway API network
+        displayName: AuthPolicy
+        kind: AuthPolicy
+        name: authpolicies.kuadrant.io
+        version: v1
+      - description: DNSPolicy configures how North-South based traffic should be
+          balanced and reach the gateways
+        displayName: DNSPolicy
+        kind: DNSPolicy
+        name: dnspolicies.kuadrant.io
+        version: v1
+      - description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        displayName: Kuadrant
+        kind: Kuadrant
+        name: kuadrants.kuadrant.io
+        version: v1beta1
+      - kind: OIDCPolicy
+        name: oidcpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - kind: PlanPolicy
+        name: planpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        displayName: RateLimitPolicy
+        kind: RateLimitPolicy
+        name: ratelimitpolicies.kuadrant.io
+        version: v1
+      - kind: TelemetryPolicy
+        name: telemetrypolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: TLSPolicy provides tls for gateway listeners by managing the
+          lifecycle of tls certificates
+        displayName: TLSPolicy
+        kind: TLSPolicy
+        name: tlspolicies.kuadrant.io
+        version: v1
+      - kind: TokenRateLimitPolicy
+        name: tokenratelimitpolicies.kuadrant.io
+        version: v1alpha1
+    description: Red Hat Connectivity Link enables you to secure, protect, and connect
+      your APIs and applications in multicluster, multicloud, and hybrid cloud environments.
+    displayName: Red Hat Connectivity Link
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - api-management
+    - Kuadrant
+    - kubernetes
+    - openshift
+    - cloud-service-protection
+    - rate-limiting
+    - authentication
+    - authorization
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Kuadrant Operator
+      url: https://github.com/Kuadrant/kuadrant-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+- image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:4b8cd7dea4d9cd3c7170af872c229e206155691e7dbb4a90c64699ccecc7ccbb
+  name: wasmshim
+- image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:434a6d1471a8cbe62b80b1ba077ac5b041561bd3d652ac1391a011f91b2b1ec2
+  name: developerportal
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:3ce32a816eca502581d45f4346ac81e5751b1c6a471c5dc439405f07b1db2c69
+  name: console-plugin-latest
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:be66268555a8d7043ceb6099ff02306e5a5455201dd46ff69c9c2eca9b93f760
+  name: console-plugin-pf5
+- image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:b1cd6b34140c3c514a79449cddca319d2584cca8170689c372e65df735b2e376
+  name: ""
+- image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
+  name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:6e2c182d2a8502f24028a3e81f689f31cadd665667b0d309785d7ca02733eb32
+name: rhcl-operator.v1.4.1
+package: rhcl-operator
+properties:
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKeyApproval
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKeyRequest
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIProduct
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: OIDCPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: PlanPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: TelemetryPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: AuthPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: Kuadrant
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: RateLimitPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TLSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TokenRateLimitPolicy
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: rhcl-operator
+    version: 1.4.1
+- type: olm.package.required
+  value:
+    packageName: authorino-operator
+    versionRange: 1.4.1
+- type: olm.package.required
+  value:
+    packageName: dns-operator
+    versionRange: 1.4.0
+- type: olm.package.required
+  value:
+    packageName: limitador-operator
+    versionRange: 1.4.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "OIDCPolicy",
+            "metadata": {
+              "name": "oidcpolicy-sample"
+            },
+            "spec": {
+              "provider": {
+                "cliendID": "exampleID",
+                "issuerURL": "https://idp.example.org/"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "PlanPolicy",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "kuadrant-operator",
+                "app.kubernetes.io/instance": "planpolicy-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "planpolicy",
+                "app.kubernetes.io/part-of": "kuadrant-operator"
+              },
+              "name": "planpolicy-sample"
+            },
+            "spec": {
+              "plans": [
+                {
+                  "limits": {
+                    "daily": 5
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"gold\"\n",
+                  "tier": "gold"
+                },
+                {
+                  "limits": {
+                    "daily": 2
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"silver\"\n",
+                  "tier": "silver"
+                },
+                {
+                  "limits": {
+                    "daily": 1
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"bronze\"\n",
+                  "tier": "bronze"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "AuthPolicy",
+            "metadata": {
+              "name": "authpolicy-sample"
+            },
+            "spec": {
+              "rules": {
+                "authentication": {
+                  "apikey": {
+                    "apiKey": {
+                      "selector": {}
+                    },
+                    "credentials": {
+                      "authorizationHeader": {
+                        "prefix": "APIKEY"
+                      }
+                    }
+                  }
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "DNSPolicy",
+            "metadata": {
+              "name": "dnspolicy-sample"
+            },
+            "spec": {
+              "healthCheck": {
+                "protocol": "HTTP"
+              },
+              "providerRefs": [
+                {
+                  "name": "provider-ref"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "RateLimitPolicy",
+            "metadata": {
+              "name": "ratelimitpolicy-sample"
+            },
+            "spec": {
+              "limits": {
+                "toys": {
+                  "rates": [
+                    {
+                      "limit": 50,
+                      "window": "1m"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "TLSPolicy",
+            "metadata": {
+              "name": "tlspolicy-sample"
+            },
+            "spec": {
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "self-signed-ca"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "TokenRateLimitPolicy",
+            "metadata": {
+              "name": "token-limit-free",
+              "namespace": "gateway-system"
+            },
+            "spec": {
+              "limits": {
+                "free": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 20000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"free\")"
+                    }
+                  ]
+                },
+                "gold": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 200000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"gold\")"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "my-llm-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "Kuadrant",
+            "metadata": {
+              "name": "kuadrant-sample"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      console.openshift.io/plugins: '["kuadrant-console-plugin"]'
+      containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0b77e4a874b620095a0300877aea53e78559a601ce62b194537ed21c2743bbf3
+      createdAt: "2026-06-26T08:32:19Z"
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/kuadrant-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: APIKeyApproval
+        name: apikeyapprovals.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIKeyRequest
+        name: apikeyrequests.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIKey
+        name: apikeys.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIProduct
+        name: apiproducts.devportal.kuadrant.io
+        version: v1alpha1
+      - description: AuthPolicy enables authentication and authorization for service
+          workloads in a Gateway API network
+        displayName: AuthPolicy
+        kind: AuthPolicy
+        name: authpolicies.kuadrant.io
+        version: v1
+      - description: DNSPolicy configures how North-South based traffic should be
+          balanced and reach the gateways
+        displayName: DNSPolicy
+        kind: DNSPolicy
+        name: dnspolicies.kuadrant.io
+        version: v1
+      - description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        displayName: Kuadrant
+        kind: Kuadrant
+        name: kuadrants.kuadrant.io
+        version: v1beta1
+      - kind: OIDCPolicy
+        name: oidcpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - kind: PlanPolicy
+        name: planpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        displayName: RateLimitPolicy
+        kind: RateLimitPolicy
+        name: ratelimitpolicies.kuadrant.io
+        version: v1
+      - kind: TelemetryPolicy
+        name: telemetrypolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: TLSPolicy provides tls for gateway listeners by managing the
+          lifecycle of tls certificates
+        displayName: TLSPolicy
+        kind: TLSPolicy
+        name: tlspolicies.kuadrant.io
+        version: v1
+      - kind: TokenRateLimitPolicy
+        name: tokenratelimitpolicies.kuadrant.io
+        version: v1alpha1
+    description: Red Hat Connectivity Link enables you to secure, protect, and connect
+      your APIs and applications in multicluster, multicloud, and hybrid cloud environments.
+    displayName: Red Hat Connectivity Link
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - api-management
+    - Kuadrant
+    - kubernetes
+    - openshift
+    - cloud-service-protection
+    - rate-limiting
+    - authentication
+    - authorization
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Kuadrant Operator
+      url: https://github.com/Kuadrant/kuadrant-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+- image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:8384a01623b5593bb12086edb3baacf41cd7521456b36d18ca7c1ee1ce1b5fc6
+  name: wasmshim
+- image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:5fe421d8686b7d1adf5fe210eec62bc2d07ab831bfbf3e0e0f4688ec81deda77
+  name: developerportal
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:6e69f41d3d70b0afa7691a5d2400065d3bcdec2ea82830cf2992b8e69ba06e2a
+  name: console-plugin-latest
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:cb4ae73530916789ea9b2e1aa3706c82c6ca39dd0869cd4854b66759f1597a07
+  name: console-plugin-pf5
+- image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:6e2c182d2a8502f24028a3e81f689f31cadd665667b0d309785d7ca02733eb32
+  name: ""
+- image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0b77e4a874b620095a0300877aea53e78559a601ce62b194537ed21c2743bbf3
+  name: ""
 schema: olm.bundle

--- a/catalog/4.21/authorino-operator/catalog.yaml
+++ b/catalog/4.21/authorino-operator/catalog.yaml
@@ -30,8 +30,14 @@ entries:
     replaces: authorino-operator.v1.2.4
   - name: authorino-operator.v1.3.1
     replaces: authorino-operator.v1.3.0
+  - name: authorino-operator.v1.3.2
+    replaces: authorino-operator.v1.3.1
   - name: authorino-operator.v1.4.0
     replaces: authorino-operator.v1.3.1
+  - name: authorino-operator.v1.4.1
+    replaces: authorino-operator.v1.3.2
+    skips:
+      - authorino-operator.v1.4.0
 name: stable
 package: authorino-operator
 schema: olm.channel
@@ -3984,4 +3990,318 @@ relatedImages:
     name: ""
   - image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:76be3de77f8848f9e9f5ed0271b31255d35fdd486bb67eb6ca9ac792bc65b1ce
     name: authorino
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:a2d0d04d5637d44dbf773293bad0e273b5616b2ed477222d8b47e3842c2cb591
+name: authorino-operator.v1.3.2
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:a729d73e926f227fdba6a06520fd06d9037dc1c2d5ebebb6e4e7bbcf736d6ff1
+      createdAt: "2026-06-19T14:19:59Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:a2d0d04d5637d44dbf773293bad0e273b5616b2ed477222d8b47e3842c2cb591
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:a729d73e926f227fdba6a06520fd06d9037dc1c2d5ebebb6e4e7bbcf736d6ff1
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:e8d5f2150ac91e13dd5486a78a7f230f0434ccd09b8c1d07edcadd30e7ec2efa
+  name: authorino
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:7d936067c88c0e16935b00950637773ea7d336c0d8e96deb73d77e7c461c6245
+name: authorino-operator.v1.4.1
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.4.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b2cc2c0f0729dad98f970830816e300c0b961ba42491f362295512d886384687
+      createdAt: "2026-06-19T14:15:09Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:7d936067c88c0e16935b00950637773ea7d336c0d8e96deb73d77e7c461c6245
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b2cc2c0f0729dad98f970830816e300c0b961ba42491f362295512d886384687
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:eaadd50c0e4938926e50283a5f3e3b5f1dd24d820a3a2c7434153080180cc95a
+  name: authorino
 schema: olm.bundle

--- a/catalog/4.21/rhcl-operator/catalog.yaml
+++ b/catalog/4.21/rhcl-operator/catalog.yaml
@@ -16,8 +16,13 @@ entries:
     replaces: rhcl-operator.v1.3.2
   - name: rhcl-operator.v1.3.4
     replaces: rhcl-operator.v1.3.3
-  - name: rhcl-operator.v1.4.0
+  - name: rhcl-operator.v1.3.5
     replaces: rhcl-operator.v1.3.4
+  - name: rhcl-operator.v1.4.0
+  - name: rhcl-operator.v1.4.1
+    replaces: rhcl-operator.v1.3.5
+    skips:
+      - rhcl-operator.v1.4.0
 name: stable
 package: rhcl-operator
 schema: olm.channel
@@ -2228,4 +2233,876 @@ relatedImages:
     name: ""
   - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:63c62ca2971e5679da2d1e8615448a5653058d3a012ace13c3251ae295792bc5
     name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:b1cd6b34140c3c514a79449cddca319d2584cca8170689c372e65df735b2e376
+name: rhcl-operator.v1.3.5
+package: rhcl-operator
+properties:
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIProduct
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: OIDCPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: PlanPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: TelemetryPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: AuthPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: Kuadrant
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: RateLimitPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TLSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TokenRateLimitPolicy
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: rhcl-operator
+    version: 1.3.5
+- type: olm.package.required
+  value:
+    packageName: authorino-operator
+    versionRange: 1.3.2
+- type: olm.package.required
+  value:
+    packageName: dns-operator
+    versionRange: 1.3.1
+- type: olm.package.required
+  value:
+    packageName: limitador-operator
+    versionRange: 1.3.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "OIDCPolicy",
+            "metadata": {
+              "name": "oidcpolicy-sample"
+            },
+            "spec": {
+              "provider": {
+                "cliendID": "exampleID",
+                "issuerURL": "https://idp.example.org/"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "PlanPolicy",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "kuadrant-operator",
+                "app.kubernetes.io/instance": "planpolicy-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "planpolicy",
+                "app.kubernetes.io/part-of": "kuadrant-operator"
+              },
+              "name": "planpolicy-sample"
+            },
+            "spec": {
+              "plans": [
+                {
+                  "limits": {
+                    "daily": 5
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"gold\"\n",
+                  "tier": "gold"
+                },
+                {
+                  "limits": {
+                    "daily": 2
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"silver\"\n",
+                  "tier": "silver"
+                },
+                {
+                  "limits": {
+                    "daily": 1
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"bronze\"\n",
+                  "tier": "bronze"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "AuthPolicy",
+            "metadata": {
+              "name": "authpolicy-sample"
+            },
+            "spec": {
+              "rules": {
+                "authentication": {
+                  "apikey": {
+                    "apiKey": {
+                      "selector": {}
+                    },
+                    "credentials": {
+                      "authorizationHeader": {
+                        "prefix": "APIKEY"
+                      }
+                    }
+                  }
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "DNSPolicy",
+            "metadata": {
+              "name": "dnspolicy-sample"
+            },
+            "spec": {
+              "healthCheck": {
+                "protocol": "HTTP"
+              },
+              "providerRefs": [
+                {
+                  "name": "provider-ref"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "RateLimitPolicy",
+            "metadata": {
+              "name": "ratelimitpolicy-sample"
+            },
+            "spec": {
+              "limits": {
+                "toys": {
+                  "rates": [
+                    {
+                      "limit": 50,
+                      "window": "1m"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "TLSPolicy",
+            "metadata": {
+              "name": "tlspolicy-sample"
+            },
+            "spec": {
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "self-signed-ca"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "TokenRateLimitPolicy",
+            "metadata": {
+              "name": "token-limit-free",
+              "namespace": "gateway-system"
+            },
+            "spec": {
+              "limits": {
+                "free": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 20000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"free\")"
+                    }
+                  ]
+                },
+                "gold": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 200000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"gold\")"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "my-llm-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "Kuadrant",
+            "metadata": {
+              "name": "kuadrant-sample"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      console.openshift.io/plugins: '["kuadrant-console-plugin"]'
+      containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
+      createdAt: "2026-06-22T17:00:01Z"
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/kuadrant-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: APIKey
+        name: apikeys.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIProduct
+        name: apiproducts.devportal.kuadrant.io
+        version: v1alpha1
+      - description: AuthPolicy enables authentication and authorization for service
+          workloads in a Gateway API network
+        displayName: AuthPolicy
+        kind: AuthPolicy
+        name: authpolicies.kuadrant.io
+        version: v1
+      - description: DNSPolicy configures how North-South based traffic should be
+          balanced and reach the gateways
+        displayName: DNSPolicy
+        kind: DNSPolicy
+        name: dnspolicies.kuadrant.io
+        version: v1
+      - description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        displayName: Kuadrant
+        kind: Kuadrant
+        name: kuadrants.kuadrant.io
+        version: v1beta1
+      - kind: OIDCPolicy
+        name: oidcpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - kind: PlanPolicy
+        name: planpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        displayName: RateLimitPolicy
+        kind: RateLimitPolicy
+        name: ratelimitpolicies.kuadrant.io
+        version: v1
+      - kind: TelemetryPolicy
+        name: telemetrypolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: TLSPolicy provides tls for gateway listeners by managing the
+          lifecycle of tls certificates
+        displayName: TLSPolicy
+        kind: TLSPolicy
+        name: tlspolicies.kuadrant.io
+        version: v1
+      - kind: TokenRateLimitPolicy
+        name: tokenratelimitpolicies.kuadrant.io
+        version: v1alpha1
+    description: Red Hat Connectivity Link enables you to secure, protect, and connect
+      your APIs and applications in multicluster, multicloud, and hybrid cloud environments.
+    displayName: Red Hat Connectivity Link
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - api-management
+    - Kuadrant
+    - kubernetes
+    - openshift
+    - cloud-service-protection
+    - rate-limiting
+    - authentication
+    - authorization
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Kuadrant Operator
+      url: https://github.com/Kuadrant/kuadrant-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+- image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:4b8cd7dea4d9cd3c7170af872c229e206155691e7dbb4a90c64699ccecc7ccbb
+  name: wasmshim
+- image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:434a6d1471a8cbe62b80b1ba077ac5b041561bd3d652ac1391a011f91b2b1ec2
+  name: developerportal
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:3ce32a816eca502581d45f4346ac81e5751b1c6a471c5dc439405f07b1db2c69
+  name: console-plugin-latest
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:be66268555a8d7043ceb6099ff02306e5a5455201dd46ff69c9c2eca9b93f760
+  name: console-plugin-pf5
+- image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:b1cd6b34140c3c514a79449cddca319d2584cca8170689c372e65df735b2e376
+  name: ""
+- image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
+  name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:6e2c182d2a8502f24028a3e81f689f31cadd665667b0d309785d7ca02733eb32
+name: rhcl-operator.v1.4.1
+package: rhcl-operator
+properties:
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKeyApproval
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKeyRequest
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIProduct
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: OIDCPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: PlanPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: TelemetryPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: AuthPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: Kuadrant
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: RateLimitPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TLSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TokenRateLimitPolicy
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: rhcl-operator
+    version: 1.4.1
+- type: olm.package.required
+  value:
+    packageName: authorino-operator
+    versionRange: 1.4.1
+- type: olm.package.required
+  value:
+    packageName: dns-operator
+    versionRange: 1.4.0
+- type: olm.package.required
+  value:
+    packageName: limitador-operator
+    versionRange: 1.4.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "OIDCPolicy",
+            "metadata": {
+              "name": "oidcpolicy-sample"
+            },
+            "spec": {
+              "provider": {
+                "cliendID": "exampleID",
+                "issuerURL": "https://idp.example.org/"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "PlanPolicy",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "kuadrant-operator",
+                "app.kubernetes.io/instance": "planpolicy-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "planpolicy",
+                "app.kubernetes.io/part-of": "kuadrant-operator"
+              },
+              "name": "planpolicy-sample"
+            },
+            "spec": {
+              "plans": [
+                {
+                  "limits": {
+                    "daily": 5
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"gold\"\n",
+                  "tier": "gold"
+                },
+                {
+                  "limits": {
+                    "daily": 2
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"silver\"\n",
+                  "tier": "silver"
+                },
+                {
+                  "limits": {
+                    "daily": 1
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"bronze\"\n",
+                  "tier": "bronze"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "AuthPolicy",
+            "metadata": {
+              "name": "authpolicy-sample"
+            },
+            "spec": {
+              "rules": {
+                "authentication": {
+                  "apikey": {
+                    "apiKey": {
+                      "selector": {}
+                    },
+                    "credentials": {
+                      "authorizationHeader": {
+                        "prefix": "APIKEY"
+                      }
+                    }
+                  }
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "DNSPolicy",
+            "metadata": {
+              "name": "dnspolicy-sample"
+            },
+            "spec": {
+              "healthCheck": {
+                "protocol": "HTTP"
+              },
+              "providerRefs": [
+                {
+                  "name": "provider-ref"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "RateLimitPolicy",
+            "metadata": {
+              "name": "ratelimitpolicy-sample"
+            },
+            "spec": {
+              "limits": {
+                "toys": {
+                  "rates": [
+                    {
+                      "limit": 50,
+                      "window": "1m"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "TLSPolicy",
+            "metadata": {
+              "name": "tlspolicy-sample"
+            },
+            "spec": {
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "self-signed-ca"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "TokenRateLimitPolicy",
+            "metadata": {
+              "name": "token-limit-free",
+              "namespace": "gateway-system"
+            },
+            "spec": {
+              "limits": {
+                "free": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 20000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"free\")"
+                    }
+                  ]
+                },
+                "gold": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 200000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"gold\")"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "my-llm-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "Kuadrant",
+            "metadata": {
+              "name": "kuadrant-sample"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      console.openshift.io/plugins: '["kuadrant-console-plugin"]'
+      containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0b77e4a874b620095a0300877aea53e78559a601ce62b194537ed21c2743bbf3
+      createdAt: "2026-06-26T08:32:19Z"
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/kuadrant-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: APIKeyApproval
+        name: apikeyapprovals.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIKeyRequest
+        name: apikeyrequests.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIKey
+        name: apikeys.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIProduct
+        name: apiproducts.devportal.kuadrant.io
+        version: v1alpha1
+      - description: AuthPolicy enables authentication and authorization for service
+          workloads in a Gateway API network
+        displayName: AuthPolicy
+        kind: AuthPolicy
+        name: authpolicies.kuadrant.io
+        version: v1
+      - description: DNSPolicy configures how North-South based traffic should be
+          balanced and reach the gateways
+        displayName: DNSPolicy
+        kind: DNSPolicy
+        name: dnspolicies.kuadrant.io
+        version: v1
+      - description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        displayName: Kuadrant
+        kind: Kuadrant
+        name: kuadrants.kuadrant.io
+        version: v1beta1
+      - kind: OIDCPolicy
+        name: oidcpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - kind: PlanPolicy
+        name: planpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        displayName: RateLimitPolicy
+        kind: RateLimitPolicy
+        name: ratelimitpolicies.kuadrant.io
+        version: v1
+      - kind: TelemetryPolicy
+        name: telemetrypolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: TLSPolicy provides tls for gateway listeners by managing the
+          lifecycle of tls certificates
+        displayName: TLSPolicy
+        kind: TLSPolicy
+        name: tlspolicies.kuadrant.io
+        version: v1
+      - kind: TokenRateLimitPolicy
+        name: tokenratelimitpolicies.kuadrant.io
+        version: v1alpha1
+    description: Red Hat Connectivity Link enables you to secure, protect, and connect
+      your APIs and applications in multicluster, multicloud, and hybrid cloud environments.
+    displayName: Red Hat Connectivity Link
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - api-management
+    - Kuadrant
+    - kubernetes
+    - openshift
+    - cloud-service-protection
+    - rate-limiting
+    - authentication
+    - authorization
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Kuadrant Operator
+      url: https://github.com/Kuadrant/kuadrant-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+- image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:8384a01623b5593bb12086edb3baacf41cd7521456b36d18ca7c1ee1ce1b5fc6
+  name: wasmshim
+- image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:5fe421d8686b7d1adf5fe210eec62bc2d07ab831bfbf3e0e0f4688ec81deda77
+  name: developerportal
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:6e69f41d3d70b0afa7691a5d2400065d3bcdec2ea82830cf2992b8e69ba06e2a
+  name: console-plugin-latest
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:cb4ae73530916789ea9b2e1aa3706c82c6ca39dd0869cd4854b66759f1597a07
+  name: console-plugin-pf5
+- image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:6e2c182d2a8502f24028a3e81f689f31cadd665667b0d309785d7ca02733eb32
+  name: ""
+- image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0b77e4a874b620095a0300877aea53e78559a601ce62b194537ed21c2743bbf3
+  name: ""
 schema: olm.bundle

--- a/catalog/4.22/authorino-operator/catalog.yaml
+++ b/catalog/4.22/authorino-operator/catalog.yaml
@@ -30,8 +30,14 @@ entries:
     replaces: authorino-operator.v1.2.4
   - name: authorino-operator.v1.3.1
     replaces: authorino-operator.v1.3.0
+  - name: authorino-operator.v1.3.2
+    replaces: authorino-operator.v1.3.1
   - name: authorino-operator.v1.4.0
     replaces: authorino-operator.v1.3.1
+  - name: authorino-operator.v1.4.1
+    replaces: authorino-operator.v1.3.2
+    skips:
+      - authorino-operator.v1.4.0
 name: stable
 package: authorino-operator
 schema: olm.channel
@@ -3984,4 +3990,318 @@ relatedImages:
     name: ""
   - image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:76be3de77f8848f9e9f5ed0271b31255d35fdd486bb67eb6ca9ac792bc65b1ce
     name: authorino
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:a2d0d04d5637d44dbf773293bad0e273b5616b2ed477222d8b47e3842c2cb591
+name: authorino-operator.v1.3.2
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:a729d73e926f227fdba6a06520fd06d9037dc1c2d5ebebb6e4e7bbcf736d6ff1
+      createdAt: "2026-06-19T14:19:59Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:a2d0d04d5637d44dbf773293bad0e273b5616b2ed477222d8b47e3842c2cb591
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:a729d73e926f227fdba6a06520fd06d9037dc1c2d5ebebb6e4e7bbcf736d6ff1
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:e8d5f2150ac91e13dd5486a78a7f230f0434ccd09b8c1d07edcadd30e7ec2efa
+  name: authorino
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:7d936067c88c0e16935b00950637773ea7d336c0d8e96deb73d77e7c461c6245
+name: authorino-operator.v1.4.1
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.4.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b2cc2c0f0729dad98f970830816e300c0b961ba42491f362295512d886384687
+      createdAt: "2026-06-19T14:15:09Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:7d936067c88c0e16935b00950637773ea7d336c0d8e96deb73d77e7c461c6245
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b2cc2c0f0729dad98f970830816e300c0b961ba42491f362295512d886384687
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:eaadd50c0e4938926e50283a5f3e3b5f1dd24d820a3a2c7434153080180cc95a
+  name: authorino
 schema: olm.bundle

--- a/catalog/4.22/rhcl-operator/catalog.yaml
+++ b/catalog/4.22/rhcl-operator/catalog.yaml
@@ -8,6 +8,8 @@ schema: olm.package
 ---
 entries:
   - name: rhcl-operator.v1.4.0
+  - name: rhcl-operator.v1.4.1
+    replaces: rhcl-operator.v1.4.0
 name: stable
 package: rhcl-operator
 schema: olm.channel
@@ -455,4 +457,449 @@ relatedImages:
     name: ""
   - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:63c62ca2971e5679da2d1e8615448a5653058d3a012ace13c3251ae295792bc5
     name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:6e2c182d2a8502f24028a3e81f689f31cadd665667b0d309785d7ca02733eb32
+name: rhcl-operator.v1.4.1
+package: rhcl-operator
+properties:
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKeyApproval
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKeyRequest
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIProduct
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: OIDCPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: PlanPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: TelemetryPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: AuthPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: Kuadrant
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: RateLimitPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TLSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TokenRateLimitPolicy
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: rhcl-operator
+    version: 1.4.1
+- type: olm.package.required
+  value:
+    packageName: authorino-operator
+    versionRange: 1.4.1
+- type: olm.package.required
+  value:
+    packageName: dns-operator
+    versionRange: 1.4.0
+- type: olm.package.required
+  value:
+    packageName: limitador-operator
+    versionRange: 1.4.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "OIDCPolicy",
+            "metadata": {
+              "name": "oidcpolicy-sample"
+            },
+            "spec": {
+              "provider": {
+                "cliendID": "exampleID",
+                "issuerURL": "https://idp.example.org/"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "PlanPolicy",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "kuadrant-operator",
+                "app.kubernetes.io/instance": "planpolicy-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "planpolicy",
+                "app.kubernetes.io/part-of": "kuadrant-operator"
+              },
+              "name": "planpolicy-sample"
+            },
+            "spec": {
+              "plans": [
+                {
+                  "limits": {
+                    "daily": 5
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"gold\"\n",
+                  "tier": "gold"
+                },
+                {
+                  "limits": {
+                    "daily": 2
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"silver\"\n",
+                  "tier": "silver"
+                },
+                {
+                  "limits": {
+                    "daily": 1
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"bronze\"\n",
+                  "tier": "bronze"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "AuthPolicy",
+            "metadata": {
+              "name": "authpolicy-sample"
+            },
+            "spec": {
+              "rules": {
+                "authentication": {
+                  "apikey": {
+                    "apiKey": {
+                      "selector": {}
+                    },
+                    "credentials": {
+                      "authorizationHeader": {
+                        "prefix": "APIKEY"
+                      }
+                    }
+                  }
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "DNSPolicy",
+            "metadata": {
+              "name": "dnspolicy-sample"
+            },
+            "spec": {
+              "healthCheck": {
+                "protocol": "HTTP"
+              },
+              "providerRefs": [
+                {
+                  "name": "provider-ref"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "RateLimitPolicy",
+            "metadata": {
+              "name": "ratelimitpolicy-sample"
+            },
+            "spec": {
+              "limits": {
+                "toys": {
+                  "rates": [
+                    {
+                      "limit": 50,
+                      "window": "1m"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "TLSPolicy",
+            "metadata": {
+              "name": "tlspolicy-sample"
+            },
+            "spec": {
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "self-signed-ca"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "TokenRateLimitPolicy",
+            "metadata": {
+              "name": "token-limit-free",
+              "namespace": "gateway-system"
+            },
+            "spec": {
+              "limits": {
+                "free": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 20000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"free\")"
+                    }
+                  ]
+                },
+                "gold": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 200000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"gold\")"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "my-llm-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "Kuadrant",
+            "metadata": {
+              "name": "kuadrant-sample"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      console.openshift.io/plugins: '["kuadrant-console-plugin"]'
+      containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0b77e4a874b620095a0300877aea53e78559a601ce62b194537ed21c2743bbf3
+      createdAt: "2026-06-26T08:32:19Z"
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/kuadrant-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: APIKeyApproval
+        name: apikeyapprovals.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIKeyRequest
+        name: apikeyrequests.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIKey
+        name: apikeys.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIProduct
+        name: apiproducts.devportal.kuadrant.io
+        version: v1alpha1
+      - description: AuthPolicy enables authentication and authorization for service
+          workloads in a Gateway API network
+        displayName: AuthPolicy
+        kind: AuthPolicy
+        name: authpolicies.kuadrant.io
+        version: v1
+      - description: DNSPolicy configures how North-South based traffic should be
+          balanced and reach the gateways
+        displayName: DNSPolicy
+        kind: DNSPolicy
+        name: dnspolicies.kuadrant.io
+        version: v1
+      - description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        displayName: Kuadrant
+        kind: Kuadrant
+        name: kuadrants.kuadrant.io
+        version: v1beta1
+      - kind: OIDCPolicy
+        name: oidcpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - kind: PlanPolicy
+        name: planpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        displayName: RateLimitPolicy
+        kind: RateLimitPolicy
+        name: ratelimitpolicies.kuadrant.io
+        version: v1
+      - kind: TelemetryPolicy
+        name: telemetrypolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: TLSPolicy provides tls for gateway listeners by managing the
+          lifecycle of tls certificates
+        displayName: TLSPolicy
+        kind: TLSPolicy
+        name: tlspolicies.kuadrant.io
+        version: v1
+      - kind: TokenRateLimitPolicy
+        name: tokenratelimitpolicies.kuadrant.io
+        version: v1alpha1
+    description: Red Hat Connectivity Link enables you to secure, protect, and connect
+      your APIs and applications in multicluster, multicloud, and hybrid cloud environments.
+    displayName: Red Hat Connectivity Link
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - api-management
+    - Kuadrant
+    - kubernetes
+    - openshift
+    - cloud-service-protection
+    - rate-limiting
+    - authentication
+    - authorization
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Kuadrant Operator
+      url: https://github.com/Kuadrant/kuadrant-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+- image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:8384a01623b5593bb12086edb3baacf41cd7521456b36d18ca7c1ee1ce1b5fc6
+  name: wasmshim
+- image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:5fe421d8686b7d1adf5fe210eec62bc2d07ab831bfbf3e0e0f4688ec81deda77
+  name: developerportal
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:6e69f41d3d70b0afa7691a5d2400065d3bcdec2ea82830cf2992b8e69ba06e2a
+  name: console-plugin-latest
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:cb4ae73530916789ea9b2e1aa3706c82c6ca39dd0869cd4854b66759f1597a07
+  name: console-plugin-pf5
+- image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:6e2c182d2a8502f24028a3e81f689f31cadd665667b0d309785d7ca02733eb32
+  name: ""
+- image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0b77e4a874b620095a0300877aea53e78559a601ce62b194537ed21c2743bbf3
+  name: ""
 schema: olm.bundle


### PR DESCRIPTION
### Changes

- **Add v1.3.5**: replaces v1.3.4
- **Add v1.4.1**: replaces v1.3.5, skips v1.4.0

### New upgrade graphs (1.3.x/1.4.x portion only)

```
4.18:      ... → 1.2.1 → 1.3.4 → 1.3.5 (head)

4.19/4.20: ... → 1.3.3 → 1.3.4 → 1.3.5 → 1.4.1 (head)
                                             ↑
                                      (skips 1.4.0)

4.21:      ... → 1.3.3 → 1.3.4 → 1.3.5 → 1.4.1 (head)
                                             ↑
                                      (skips 1.4.0)

4.22:      1.4.0 → 1.4.1 (head)
           (1.4.1 replaces 1.4.0 here, since there's no 1.3.x)
```

### Effect per OCP version

| OCP  | New channel head | User on 1.3.4    | User on 1.4.0     |
|------|------------------|-------------------|--------------------|
| 4.16 | 1.2.1 (unchanged)| n/a               | n/a                |
| 4.17 | 1.2.1 (unchanged)| n/a               | n/a                |
| 4.18 | 1.3.5            | → 1.3.5           | n/a                |
| 4.19 | 1.4.1            | → 1.3.5 → 1.4.1  | → 1.4.1 (via skip) |
| 4.20 | 1.4.1            | → 1.3.5 → 1.4.1  | → 1.4.1 (via skip) |
| 4.21 | 1.4.1            | → 1.3.5 → 1.4.1  | → 1.4.1 (via skip) |
| 4.22 | 1.4.1            | n/a               | → 1.4.1            |
