### PR TITLE
Add RHCL 1.3.6 bundles to FBC catalogs

### DIFF
--- a/catalog/4.18/authorino-operator/catalog.yaml
+++ b/catalog/4.18/authorino-operator/catalog.yaml
@@ -37,6 +37,8 @@ entries:
     replaces: authorino-operator.v1.2.4
   - name: authorino-operator.v1.3.2
     replaces: authorino-operator.v1.3.1
+  - name: authorino-operator.v1.3.3
+    replaces: authorino-operator.v1.3.2
 name: stable
 package: authorino-operator
 schema: olm.channel
@@ -5039,5 +5041,163 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:a729d73e926f227fdba6a06520fd06d9037dc1c2d5ebebb6e4e7bbcf736d6ff1
   name: ""
 - image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:e8d5f2150ac91e13dd5486a78a7f230f0434ccd09b8c1d07edcadd30e7ec2efa
+  name: authorino
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
+name: authorino-operator.v1.3.3
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.3.3
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b325bd9a7a07302d80636efefbc987858a57a185a559952f47f77ca2ee969970
+      createdAt: "2026-07-23T13:57:46Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b325bd9a7a07302d80636efefbc987858a57a185a559952f47f77ca2ee969970
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:6d36a163669bea414ed378f6a575de3287e2ade60ebff576344156a7d44ae0c3
   name: authorino
 schema: olm.bundle

--- a/catalog/4.18/authorino-operator/catalog.yaml
+++ b/catalog/4.18/authorino-operator/catalog.yaml
@@ -5044,7 +5044,6 @@ relatedImages:
   name: authorino
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
 name: authorino-operator.v1.3.3
 package: authorino-operator

--- a/catalog/4.18/dns-operator/catalog.yaml
+++ b/catalog/4.18/dns-operator/catalog.yaml
@@ -16,6 +16,8 @@ entries:
     replaces: dns-operator.v1.1.1
   - name: dns-operator.v1.3.1
     replaces: dns-operator.v1.2.0
+  - name: dns-operator.v1.3.2
+    replaces: dns-operator.v1.3.1
 name: stable
 package: dns-operator
 schema: olm.channel
@@ -745,4 +747,154 @@ relatedImages:
     name: ""
   - image: registry.redhat.io/rhcl-1/dns-rhel9-operator@sha256:c555c210c8d6f0512f446d18f44269677594cf7ff62f29903914f13413de7007
     name: ""
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:3e9f92b9767f13bf71c457fe04a14b34eb0fb3dfea5cb7e84bc22bb3df5edf2a
+name: dns-operator.v1.3.2
+package: dns-operator
+properties:
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSHealthCheckProbe
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSRecord
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: dns-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "DNSHealthCheckProbe",
+            "metadata": {
+              "name": "$NAME"
+            },
+            "spec": {
+              "additionalHeadersRef": {
+                "name": "headers"
+              },
+              "address": "192.168.0.16",
+              "allowInsecureCertificate": true,
+              "failureThreshold": 5,
+              "hostname": "test.com",
+              "interval": "60s",
+              "path": "/healthz",
+              "port": 443,
+              "protocol": "HTTPS"
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "DNSRecord",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "dns-operator",
+                "app.kubernetes.io/instance": "dnsrecord-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "dnsrecord",
+                "app.kubernetes.io/part-of": "dns-operator"
+              },
+              "name": "dnsrecord-sample"
+            },
+            "spec": {
+              "endpoints": [
+                {
+                  "dnsName": "dnsrecord-simple.kuadrant.local",
+                  "recordTTL": 60,
+                  "recordType": "A",
+                  "targets": [
+                    "52.215.108.61",
+                    "52.30.101.221"
+                  ]
+                }
+              ],
+              "providerRef": {
+                "name": "dns-provider-credentials-inmemory"
+              },
+              "rootHost": "dnsrecord-simple.kuadrant.local"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/dns-rhel9-operator@sha256:1cee71c721d4ced752ab52b94554418125f3be68bbd811b203d5dc4cf931934d
+      createdAt: "2026-07-23T14:50:37Z"
+      description: A Kubernetes Operator to manage the lifecycle of DNS resources
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/dns-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: DNSHealthCheckProbe is the Schema for the dnshealthcheckprobes
+          API
+        displayName: DNSHealthCheckProbe
+        kind: DNSHealthCheckProbe
+        name: dnshealthcheckprobes.kuadrant.io
+        version: v1alpha1
+      - description: DNSRecord is the Schema for the dnsrecords API
+        displayName: DNSRecord
+        kind: DNSRecord
+        name: dnsrecords.kuadrant.io
+        version: v1alpha1
+    description: Configures how north-south traffic from outside the network is balanced
+      and reaches Gateways.
+    displayName: DNS Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - dns
+    - kuadrant
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: DNS Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    maintainers:
+    - email: mnairn@redhat.com
+      name: Michael Nairn
+    - email: pbrookes@redhat.com
+      name: Phil Brookes
+    - email: cbrookes@redhat.com
+      name: Craig Brookes
+    maturity: alpha
+    minKubeVersion: 1.8.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:3e9f92b9767f13bf71c457fe04a14b34eb0fb3dfea5cb7e84bc22bb3df5edf2a
+  name: ""
+- image: registry.redhat.io/rhcl-1/dns-rhel9-operator@sha256:1cee71c721d4ced752ab52b94554418125f3be68bbd811b203d5dc4cf931934d
+  name: ""
 schema: olm.bundle

--- a/catalog/4.18/dns-operator/catalog.yaml
+++ b/catalog/4.18/dns-operator/catalog.yaml
@@ -749,7 +749,6 @@ relatedImages:
     name: ""
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:3e9f92b9767f13bf71c457fe04a14b34eb0fb3dfea5cb7e84bc22bb3df5edf2a
 name: dns-operator.v1.3.2
 package: dns-operator

--- a/catalog/4.18/limitador-operator/catalog.yaml
+++ b/catalog/4.18/limitador-operator/catalog.yaml
@@ -617,7 +617,6 @@ relatedImages:
     name: limitador
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:416895351e21b9f5dbfa6ba6b44287a38a5ded3f0782e508268160bb3140b6d2
 name: limitador-operator.v1.3.2
 package: limitador-operator

--- a/catalog/4.18/limitador-operator/catalog.yaml
+++ b/catalog/4.18/limitador-operator/catalog.yaml
@@ -16,6 +16,8 @@ entries:
     replaces: limitador-operator.v1.1.1
   - name: limitador-operator.v1.3.1
     replaces: limitador-operator.v1.2.0
+  - name: limitador-operator.v1.3.2
+    replaces: limitador-operator.v1.3.1
 name: stable
 package: limitador-operator
 schema: olm.channel
@@ -613,4 +615,127 @@ relatedImages:
     name: ""
   - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:920e39df7f66cf6dde655597f0b4efd09e853064208d56a7743fc27ed7d3bf71
     name: limitador
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:416895351e21b9f5dbfa6ba6b44287a38a5ded3f0782e508268160bb3140b6d2
+name: limitador-operator.v1.3.2
+package: limitador-operator
+properties:
+- type: olm.gvk
+  value:
+    group: limitador.kuadrant.io
+    kind: Limitador
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: limitador-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "limitador.kuadrant.io/v1alpha1",
+            "kind": "Limitador",
+            "metadata": {
+              "name": "limitador-sample"
+            },
+            "spec": {
+              "limits": [
+                {
+                  "conditions": [
+                    "get_toy == 'yes'"
+                  ],
+                  "max_value": 2,
+                  "name": "toy_get_route",
+                  "namespace": "toystore-app",
+                  "seconds": 30,
+                  "variables": []
+                }
+              ],
+              "listener": {
+                "grpc": {
+                  "port": 8081
+                },
+                "http": {
+                  "port": 8080
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:38990ad0bc3d1ac80a751be22e16326110affb76bd5ed934bc70e3b65848e595
+      createdAt: "2026-07-23T14:43:27Z"
+      description: The Limitador operator installs and maintains limitador instances
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/limitador-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Limitador is the Schema for the limitadors API
+        displayName: Limitador
+        kind: Limitador
+        name: limitadors.limitador.kuadrant.io
+        version: v1alpha1
+    description: Enables rate limiting for Gateways and applications in a Gateway
+      API network. Part of Red Hat Connectivity Link
+    displayName: Limitador Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - rate-limit
+    - kuadrant
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Limitador Operator
+      url: https://github.com/Kuadrant/limitador-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: asnaps@redhat.com
+      name: Alex Snaps
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/limitador-operator
+relatedImages:
+- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:416895351e21b9f5dbfa6ba6b44287a38a5ded3f0782e508268160bb3140b6d2
+  name: ""
+- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:38990ad0bc3d1ac80a751be22e16326110affb76bd5ed934bc70e3b65848e595
+  name: ""
+- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:302b04993a5a77df09901e1eefbb0a22d3cd9ed10b6b41aa26f2598ba8e3cbde
+  name: limitador
 schema: olm.bundle

--- a/catalog/4.18/rhcl-operator/catalog.yaml
+++ b/catalog/4.18/rhcl-operator/catalog.yaml
@@ -20,6 +20,8 @@ entries:
     replaces: rhcl-operator.v1.2.1
   - name: rhcl-operator.v1.3.5
     replaces: rhcl-operator.v1.3.4
+  - name: rhcl-operator.v1.3.6
+    replaces: rhcl-operator.v1.3.5
 name: stable
 package: rhcl-operator
 schema: olm.channel
@@ -2190,5 +2192,433 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:b1cd6b34140c3c514a79449cddca319d2584cca8170689c372e65df735b2e376
   name: ""
 - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
+  name: ""
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:dfd39aa4a280135b4917e4698b01ac6caf4f0f4e2f3d436928eaa098c2659a47
+name: rhcl-operator.v1.3.6
+package: rhcl-operator
+properties:
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIProduct
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: OIDCPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: PlanPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: TelemetryPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: AuthPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: Kuadrant
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: RateLimitPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TLSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TokenRateLimitPolicy
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: rhcl-operator
+    version: 1.3.6
+- type: olm.package.required
+  value:
+    packageName: authorino-operator
+    versionRange: 1.3.3
+- type: olm.package.required
+  value:
+    packageName: dns-operator
+    versionRange: 1.3.2
+- type: olm.package.required
+  value:
+    packageName: limitador-operator
+    versionRange: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "OIDCPolicy",
+            "metadata": {
+              "name": "oidcpolicy-sample"
+            },
+            "spec": {
+              "provider": {
+                "cliendID": "exampleID",
+                "issuerURL": "https://idp.example.org/"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "PlanPolicy",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "kuadrant-operator",
+                "app.kubernetes.io/instance": "planpolicy-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "planpolicy",
+                "app.kubernetes.io/part-of": "kuadrant-operator"
+              },
+              "name": "planpolicy-sample"
+            },
+            "spec": {
+              "plans": [
+                {
+                  "limits": {
+                    "daily": 5
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"gold\"\n",
+                  "tier": "gold"
+                },
+                {
+                  "limits": {
+                    "daily": 2
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"silver\"\n",
+                  "tier": "silver"
+                },
+                {
+                  "limits": {
+                    "daily": 1
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"bronze\"\n",
+                  "tier": "bronze"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "AuthPolicy",
+            "metadata": {
+              "name": "authpolicy-sample"
+            },
+            "spec": {
+              "rules": {
+                "authentication": {
+                  "apikey": {
+                    "apiKey": {
+                      "selector": {}
+                    },
+                    "credentials": {
+                      "authorizationHeader": {
+                        "prefix": "APIKEY"
+                      }
+                    }
+                  }
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "DNSPolicy",
+            "metadata": {
+              "name": "dnspolicy-sample"
+            },
+            "spec": {
+              "healthCheck": {
+                "protocol": "HTTP"
+              },
+              "providerRefs": [
+                {
+                  "name": "provider-ref"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "RateLimitPolicy",
+            "metadata": {
+              "name": "ratelimitpolicy-sample"
+            },
+            "spec": {
+              "limits": {
+                "toys": {
+                  "rates": [
+                    {
+                      "limit": 50,
+                      "window": "1m"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "TLSPolicy",
+            "metadata": {
+              "name": "tlspolicy-sample"
+            },
+            "spec": {
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "self-signed-ca"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "TokenRateLimitPolicy",
+            "metadata": {
+              "name": "token-limit-free",
+              "namespace": "gateway-system"
+            },
+            "spec": {
+              "limits": {
+                "free": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 20000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"free\")"
+                    }
+                  ]
+                },
+                "gold": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 200000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"gold\")"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "my-llm-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "Kuadrant",
+            "metadata": {
+              "name": "kuadrant-sample"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      console.openshift.io/plugins: '["kuadrant-console-plugin"]'
+      containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0e20ad95a5b04d8ea9d670de14c8cb6f9a3aab70fc1153c3a979b75dcb327643
+      createdAt: "2026-07-24T07:45:23Z"
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/kuadrant-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: APIKey
+        name: apikeys.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIProduct
+        name: apiproducts.devportal.kuadrant.io
+        version: v1alpha1
+      - description: AuthPolicy enables authentication and authorization for service
+          workloads in a Gateway API network
+        displayName: AuthPolicy
+        kind: AuthPolicy
+        name: authpolicies.kuadrant.io
+        version: v1
+      - description: DNSPolicy configures how North-South based traffic should be
+          balanced and reach the gateways
+        displayName: DNSPolicy
+        kind: DNSPolicy
+        name: dnspolicies.kuadrant.io
+        version: v1
+      - description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        displayName: Kuadrant
+        kind: Kuadrant
+        name: kuadrants.kuadrant.io
+        version: v1beta1
+      - kind: OIDCPolicy
+        name: oidcpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - kind: PlanPolicy
+        name: planpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        displayName: RateLimitPolicy
+        kind: RateLimitPolicy
+        name: ratelimitpolicies.kuadrant.io
+        version: v1
+      - kind: TelemetryPolicy
+        name: telemetrypolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: TLSPolicy provides tls for gateway listeners by managing the
+          lifecycle of tls certificates
+        displayName: TLSPolicy
+        kind: TLSPolicy
+        name: tlspolicies.kuadrant.io
+        version: v1
+      - kind: TokenRateLimitPolicy
+        name: tokenratelimitpolicies.kuadrant.io
+        version: v1alpha1
+    description: Red Hat Connectivity Link enables you to secure, protect, and connect
+      your APIs and applications in multicluster, multicloud, and hybrid cloud environments.
+    displayName: Red Hat Connectivity Link
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - api-management
+    - Kuadrant
+    - kubernetes
+    - openshift
+    - cloud-service-protection
+    - rate-limiting
+    - authentication
+    - authorization
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Kuadrant Operator
+      url: https://github.com/Kuadrant/kuadrant-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+- image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:ed34543a7a226b3f0d9382e21a81db6d60e0240154a6632a303bf4bff6ed8bd0
+  name: wasmshim
+- image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:1446ac58a230a94309baf7c631a3540fe376ab64a54c92f25b77801fb290c8d2
+  name: developerportal
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:7b91ed74be258ed5d4a74a89bdfb7a0e064ce75bf34d48be887d751c65c32ff0
+  name: console-plugin-latest
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:9901b78b5c7c3170357c1ebb00590561e3b16f20df6163ee7fc45c53a1393c15
+  name: console-plugin-pf5
+- image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:dfd39aa4a280135b4917e4698b01ac6caf4f0f4e2f3d436928eaa098c2659a47
+  name: ""
+- image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0e20ad95a5b04d8ea9d670de14c8cb6f9a3aab70fc1153c3a979b75dcb327643
   name: ""
 schema: olm.bundle

--- a/catalog/4.18/rhcl-operator/catalog.yaml
+++ b/catalog/4.18/rhcl-operator/catalog.yaml
@@ -2195,7 +2195,6 @@ relatedImages:
   name: ""
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:dfd39aa4a280135b4917e4698b01ac6caf4f0f4e2f3d436928eaa098c2659a47
 name: rhcl-operator.v1.3.6
 package: rhcl-operator

--- a/catalog/4.19/authorino-operator/catalog.yaml
+++ b/catalog/4.19/authorino-operator/catalog.yaml
@@ -32,10 +32,12 @@ entries:
     replaces: authorino-operator.v1.3.0
   - name: authorino-operator.v1.3.2
     replaces: authorino-operator.v1.3.1
-  - name: authorino-operator.v1.4.0
-    replaces: authorino-operator.v1.3.1
-  - name: authorino-operator.v1.4.1
+  - name: authorino-operator.v1.3.3
     replaces: authorino-operator.v1.3.2
+  - name: authorino-operator.v1.4.0
+    replaces: authorino-operator.v1.3.2
+  - name: authorino-operator.v1.4.1
+    replaces: authorino-operator.v1.3.3
     skips:
       - authorino-operator.v1.4.0
   - name: authorino-operator.v1.4.2
@@ -4463,5 +4465,163 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:414262da59a55c48837807274db11cedb7da50b5984d03d3bd0445e4f7b1a0ea
   name: ""
 - image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:fbe9e2e767530eae72a421f541325640feba03322441cd7a294f8a6bf1fb4d97
+  name: authorino
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
+name: authorino-operator.v1.3.3
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.3.3
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b325bd9a7a07302d80636efefbc987858a57a185a559952f47f77ca2ee969970
+      createdAt: "2026-07-23T13:57:46Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b325bd9a7a07302d80636efefbc987858a57a185a559952f47f77ca2ee969970
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:6d36a163669bea414ed378f6a575de3287e2ade60ebff576344156a7d44ae0c3
   name: authorino
 schema: olm.bundle

--- a/catalog/4.19/authorino-operator/catalog.yaml
+++ b/catalog/4.19/authorino-operator/catalog.yaml
@@ -35,7 +35,6 @@ entries:
   - name: authorino-operator.v1.3.3
     replaces: authorino-operator.v1.3.2
   - name: authorino-operator.v1.4.0
-    replaces: authorino-operator.v1.3.2
   - name: authorino-operator.v1.4.1
     replaces: authorino-operator.v1.3.3
     skips:

--- a/catalog/4.19/authorino-operator/catalog.yaml
+++ b/catalog/4.19/authorino-operator/catalog.yaml
@@ -4468,7 +4468,6 @@ relatedImages:
   name: authorino
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
 name: authorino-operator.v1.3.3
 package: authorino-operator

--- a/catalog/4.19/dns-operator/catalog.yaml
+++ b/catalog/4.19/dns-operator/catalog.yaml
@@ -20,8 +20,10 @@ entries:
     replaces: dns-operator.v1.2.0
   - name: dns-operator.v1.3.1
     replaces: dns-operator.v1.3.0
-  - name: dns-operator.v1.4.0
+  - name: dns-operator.v1.3.2
     replaces: dns-operator.v1.3.1
+  - name: dns-operator.v1.4.0
+    replaces: dns-operator.v1.3.2
 name: stable
 package: dns-operator
 schema: olm.channel
@@ -1199,5 +1201,155 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:d967a3865d196856b88cf23a8468decefb13312c256b7436fc2acc503c888cbb
   name: ""
 - image: registry.redhat.io/rhcl-1/dns-rhel9-operator@sha256:ca946bb88274562b8027c90d7b6945a426ec799b1b0017056f6189160c591c2d
+  name: ""
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:3e9f92b9767f13bf71c457fe04a14b34eb0fb3dfea5cb7e84bc22bb3df5edf2a
+name: dns-operator.v1.3.2
+package: dns-operator
+properties:
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSHealthCheckProbe
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSRecord
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: dns-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "DNSHealthCheckProbe",
+            "metadata": {
+              "name": "$NAME"
+            },
+            "spec": {
+              "additionalHeadersRef": {
+                "name": "headers"
+              },
+              "address": "192.168.0.16",
+              "allowInsecureCertificate": true,
+              "failureThreshold": 5,
+              "hostname": "test.com",
+              "interval": "60s",
+              "path": "/healthz",
+              "port": 443,
+              "protocol": "HTTPS"
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "DNSRecord",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "dns-operator",
+                "app.kubernetes.io/instance": "dnsrecord-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "dnsrecord",
+                "app.kubernetes.io/part-of": "dns-operator"
+              },
+              "name": "dnsrecord-sample"
+            },
+            "spec": {
+              "endpoints": [
+                {
+                  "dnsName": "dnsrecord-simple.kuadrant.local",
+                  "recordTTL": 60,
+                  "recordType": "A",
+                  "targets": [
+                    "52.215.108.61",
+                    "52.30.101.221"
+                  ]
+                }
+              ],
+              "providerRef": {
+                "name": "dns-provider-credentials-inmemory"
+              },
+              "rootHost": "dnsrecord-simple.kuadrant.local"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/dns-rhel9-operator@sha256:1cee71c721d4ced752ab52b94554418125f3be68bbd811b203d5dc4cf931934d
+      createdAt: "2026-07-23T14:50:37Z"
+      description: A Kubernetes Operator to manage the lifecycle of DNS resources
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/dns-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: DNSHealthCheckProbe is the Schema for the dnshealthcheckprobes
+          API
+        displayName: DNSHealthCheckProbe
+        kind: DNSHealthCheckProbe
+        name: dnshealthcheckprobes.kuadrant.io
+        version: v1alpha1
+      - description: DNSRecord is the Schema for the dnsrecords API
+        displayName: DNSRecord
+        kind: DNSRecord
+        name: dnsrecords.kuadrant.io
+        version: v1alpha1
+    description: Configures how north-south traffic from outside the network is balanced
+      and reaches Gateways.
+    displayName: DNS Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - dns
+    - kuadrant
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: DNS Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    maintainers:
+    - email: mnairn@redhat.com
+      name: Michael Nairn
+    - email: pbrookes@redhat.com
+      name: Phil Brookes
+    - email: cbrookes@redhat.com
+      name: Craig Brookes
+    maturity: alpha
+    minKubeVersion: 1.8.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:3e9f92b9767f13bf71c457fe04a14b34eb0fb3dfea5cb7e84bc22bb3df5edf2a
+  name: ""
+- image: registry.redhat.io/rhcl-1/dns-rhel9-operator@sha256:1cee71c721d4ced752ab52b94554418125f3be68bbd811b203d5dc4cf931934d
   name: ""
 schema: olm.bundle

--- a/catalog/4.19/dns-operator/catalog.yaml
+++ b/catalog/4.19/dns-operator/catalog.yaml
@@ -9,7 +9,9 @@ schema: olm.package
 entries:
   - name: dns-operator.v1.0.2
   - name: dns-operator.v1.4.1
-    replaces: dns-operator.v1.4.0
+    replaces: dns-operator.v1.3.2
+    skips:
+    - dns-operator.v1.4.0
   - name: dns-operator.v1.1.0
     replaces: dns-operator.v1.0.2
   - name: dns-operator.v1.1.1
@@ -23,7 +25,6 @@ entries:
   - name: dns-operator.v1.3.2
     replaces: dns-operator.v1.3.1
   - name: dns-operator.v1.4.0
-    replaces: dns-operator.v1.3.2
 name: stable
 package: dns-operator
 schema: olm.channel

--- a/catalog/4.19/dns-operator/catalog.yaml
+++ b/catalog/4.19/dns-operator/catalog.yaml
@@ -1204,7 +1204,6 @@ relatedImages:
   name: ""
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:3e9f92b9767f13bf71c457fe04a14b34eb0fb3dfea5cb7e84bc22bb3df5edf2a
 name: dns-operator.v1.3.2
 package: dns-operator

--- a/catalog/4.19/limitador-operator/catalog.yaml
+++ b/catalog/4.19/limitador-operator/catalog.yaml
@@ -21,9 +21,10 @@ entries:
   - name: limitador-operator.v1.3.2
     replaces: limitador-operator.v1.3.1
   - name: limitador-operator.v1.4.0
-    replaces: limitador-operator.v1.3.2
   - name: limitador-operator.v1.4.1
-    replaces: limitador-operator.v1.4.0
+    replaces: limitador-operator.v1.3.2
+    skips:
+    - limitador-operator.v1.4.0
 name: stable
 package: limitador-operator
 schema: olm.channel

--- a/catalog/4.19/limitador-operator/catalog.yaml
+++ b/catalog/4.19/limitador-operator/catalog.yaml
@@ -18,8 +18,10 @@ entries:
     replaces: limitador-operator.v1.2.0
   - name: limitador-operator.v1.3.1
     replaces: limitador-operator.v1.3.0
-  - name: limitador-operator.v1.4.0
+  - name: limitador-operator.v1.3.2
     replaces: limitador-operator.v1.3.1
+  - name: limitador-operator.v1.4.0
+    replaces: limitador-operator.v1.3.2
   - name: limitador-operator.v1.4.1
     replaces: limitador-operator.v1.4.0
 name: stable
@@ -987,5 +989,128 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:5261170dafd0c9b5a89d3509ada864624e4aaf62a7763bf595980de5b450cc04
   name: ""
 - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:a233ab32e26cf2ea46c31dfc4fcaf89ce541a9351bba99182036a91f357cc2b4
+  name: limitador
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:416895351e21b9f5dbfa6ba6b44287a38a5ded3f0782e508268160bb3140b6d2
+name: limitador-operator.v1.3.2
+package: limitador-operator
+properties:
+- type: olm.gvk
+  value:
+    group: limitador.kuadrant.io
+    kind: Limitador
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: limitador-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "limitador.kuadrant.io/v1alpha1",
+            "kind": "Limitador",
+            "metadata": {
+              "name": "limitador-sample"
+            },
+            "spec": {
+              "limits": [
+                {
+                  "conditions": [
+                    "get_toy == 'yes'"
+                  ],
+                  "max_value": 2,
+                  "name": "toy_get_route",
+                  "namespace": "toystore-app",
+                  "seconds": 30,
+                  "variables": []
+                }
+              ],
+              "listener": {
+                "grpc": {
+                  "port": 8081
+                },
+                "http": {
+                  "port": 8080
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:38990ad0bc3d1ac80a751be22e16326110affb76bd5ed934bc70e3b65848e595
+      createdAt: "2026-07-23T14:43:27Z"
+      description: The Limitador operator installs and maintains limitador instances
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/limitador-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Limitador is the Schema for the limitadors API
+        displayName: Limitador
+        kind: Limitador
+        name: limitadors.limitador.kuadrant.io
+        version: v1alpha1
+    description: Enables rate limiting for Gateways and applications in a Gateway
+      API network. Part of Red Hat Connectivity Link
+    displayName: Limitador Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - rate-limit
+    - kuadrant
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Limitador Operator
+      url: https://github.com/Kuadrant/limitador-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: asnaps@redhat.com
+      name: Alex Snaps
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/limitador-operator
+relatedImages:
+- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:416895351e21b9f5dbfa6ba6b44287a38a5ded3f0782e508268160bb3140b6d2
+  name: ""
+- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:38990ad0bc3d1ac80a751be22e16326110affb76bd5ed934bc70e3b65848e595
+  name: ""
+- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:302b04993a5a77df09901e1eefbb0a22d3cd9ed10b6b41aa26f2598ba8e3cbde
   name: limitador
 schema: olm.bundle

--- a/catalog/4.19/limitador-operator/catalog.yaml
+++ b/catalog/4.19/limitador-operator/catalog.yaml
@@ -992,7 +992,6 @@ relatedImages:
   name: limitador
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:416895351e21b9f5dbfa6ba6b44287a38a5ded3f0782e508268160bb3140b6d2
 name: limitador-operator.v1.3.2
 package: limitador-operator

--- a/catalog/4.19/rhcl-operator/catalog.yaml
+++ b/catalog/4.19/rhcl-operator/catalog.yaml
@@ -28,9 +28,11 @@ entries:
     replaces: rhcl-operator.v1.3.3
   - name: rhcl-operator.v1.3.5
     replaces: rhcl-operator.v1.3.4
+  - name: rhcl-operator.v1.3.6
+    replaces: rhcl-operator.v1.3.5
   - name: rhcl-operator.v1.4.0
   - name: rhcl-operator.v1.4.1
-    replaces: rhcl-operator.v1.3.5
+    replaces: rhcl-operator.v1.3.6
   - name: rhcl-operator.v1.4.2
     replaces: rhcl-operator.v1.4.1
     skips:
@@ -4876,5 +4878,433 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:e74d5a4a7e8a72f9faf242d8df0b37243980ab48018b70e1ce04b9e6fb136ca8
   name: ""
 - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:8c2d9a84169e86454e4fb3df6f4846c5c5495d19b01137b6e78e113161981e47
+  name: ""
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:dfd39aa4a280135b4917e4698b01ac6caf4f0f4e2f3d436928eaa098c2659a47
+name: rhcl-operator.v1.3.6
+package: rhcl-operator
+properties:
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIProduct
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: OIDCPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: PlanPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: TelemetryPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: AuthPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: Kuadrant
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: RateLimitPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TLSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TokenRateLimitPolicy
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: rhcl-operator
+    version: 1.3.6
+- type: olm.package.required
+  value:
+    packageName: authorino-operator
+    versionRange: 1.3.3
+- type: olm.package.required
+  value:
+    packageName: dns-operator
+    versionRange: 1.3.2
+- type: olm.package.required
+  value:
+    packageName: limitador-operator
+    versionRange: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "OIDCPolicy",
+            "metadata": {
+              "name": "oidcpolicy-sample"
+            },
+            "spec": {
+              "provider": {
+                "cliendID": "exampleID",
+                "issuerURL": "https://idp.example.org/"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "PlanPolicy",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "kuadrant-operator",
+                "app.kubernetes.io/instance": "planpolicy-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "planpolicy",
+                "app.kubernetes.io/part-of": "kuadrant-operator"
+              },
+              "name": "planpolicy-sample"
+            },
+            "spec": {
+              "plans": [
+                {
+                  "limits": {
+                    "daily": 5
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"gold\"\n",
+                  "tier": "gold"
+                },
+                {
+                  "limits": {
+                    "daily": 2
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"silver\"\n",
+                  "tier": "silver"
+                },
+                {
+                  "limits": {
+                    "daily": 1
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"bronze\"\n",
+                  "tier": "bronze"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "AuthPolicy",
+            "metadata": {
+              "name": "authpolicy-sample"
+            },
+            "spec": {
+              "rules": {
+                "authentication": {
+                  "apikey": {
+                    "apiKey": {
+                      "selector": {}
+                    },
+                    "credentials": {
+                      "authorizationHeader": {
+                        "prefix": "APIKEY"
+                      }
+                    }
+                  }
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "DNSPolicy",
+            "metadata": {
+              "name": "dnspolicy-sample"
+            },
+            "spec": {
+              "healthCheck": {
+                "protocol": "HTTP"
+              },
+              "providerRefs": [
+                {
+                  "name": "provider-ref"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "RateLimitPolicy",
+            "metadata": {
+              "name": "ratelimitpolicy-sample"
+            },
+            "spec": {
+              "limits": {
+                "toys": {
+                  "rates": [
+                    {
+                      "limit": 50,
+                      "window": "1m"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "TLSPolicy",
+            "metadata": {
+              "name": "tlspolicy-sample"
+            },
+            "spec": {
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "self-signed-ca"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "TokenRateLimitPolicy",
+            "metadata": {
+              "name": "token-limit-free",
+              "namespace": "gateway-system"
+            },
+            "spec": {
+              "limits": {
+                "free": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 20000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"free\")"
+                    }
+                  ]
+                },
+                "gold": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 200000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"gold\")"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "my-llm-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "Kuadrant",
+            "metadata": {
+              "name": "kuadrant-sample"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      console.openshift.io/plugins: '["kuadrant-console-plugin"]'
+      containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0e20ad95a5b04d8ea9d670de14c8cb6f9a3aab70fc1153c3a979b75dcb327643
+      createdAt: "2026-07-24T07:45:23Z"
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/kuadrant-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: APIKey
+        name: apikeys.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIProduct
+        name: apiproducts.devportal.kuadrant.io
+        version: v1alpha1
+      - description: AuthPolicy enables authentication and authorization for service
+          workloads in a Gateway API network
+        displayName: AuthPolicy
+        kind: AuthPolicy
+        name: authpolicies.kuadrant.io
+        version: v1
+      - description: DNSPolicy configures how North-South based traffic should be
+          balanced and reach the gateways
+        displayName: DNSPolicy
+        kind: DNSPolicy
+        name: dnspolicies.kuadrant.io
+        version: v1
+      - description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        displayName: Kuadrant
+        kind: Kuadrant
+        name: kuadrants.kuadrant.io
+        version: v1beta1
+      - kind: OIDCPolicy
+        name: oidcpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - kind: PlanPolicy
+        name: planpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        displayName: RateLimitPolicy
+        kind: RateLimitPolicy
+        name: ratelimitpolicies.kuadrant.io
+        version: v1
+      - kind: TelemetryPolicy
+        name: telemetrypolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: TLSPolicy provides tls for gateway listeners by managing the
+          lifecycle of tls certificates
+        displayName: TLSPolicy
+        kind: TLSPolicy
+        name: tlspolicies.kuadrant.io
+        version: v1
+      - kind: TokenRateLimitPolicy
+        name: tokenratelimitpolicies.kuadrant.io
+        version: v1alpha1
+    description: Red Hat Connectivity Link enables you to secure, protect, and connect
+      your APIs and applications in multicluster, multicloud, and hybrid cloud environments.
+    displayName: Red Hat Connectivity Link
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - api-management
+    - Kuadrant
+    - kubernetes
+    - openshift
+    - cloud-service-protection
+    - rate-limiting
+    - authentication
+    - authorization
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Kuadrant Operator
+      url: https://github.com/Kuadrant/kuadrant-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+- image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:ed34543a7a226b3f0d9382e21a81db6d60e0240154a6632a303bf4bff6ed8bd0
+  name: wasmshim
+- image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:1446ac58a230a94309baf7c631a3540fe376ab64a54c92f25b77801fb290c8d2
+  name: developerportal
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:7b91ed74be258ed5d4a74a89bdfb7a0e064ce75bf34d48be887d751c65c32ff0
+  name: console-plugin-latest
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:9901b78b5c7c3170357c1ebb00590561e3b16f20df6163ee7fc45c53a1393c15
+  name: console-plugin-pf5
+- image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:dfd39aa4a280135b4917e4698b01ac6caf4f0f4e2f3d436928eaa098c2659a47
+  name: ""
+- image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0e20ad95a5b04d8ea9d670de14c8cb6f9a3aab70fc1153c3a979b75dcb327643
   name: ""
 schema: olm.bundle

--- a/catalog/4.19/rhcl-operator/catalog.yaml
+++ b/catalog/4.19/rhcl-operator/catalog.yaml
@@ -4881,7 +4881,6 @@ relatedImages:
   name: ""
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:dfd39aa4a280135b4917e4698b01ac6caf4f0f4e2f3d436928eaa098c2659a47
 name: rhcl-operator.v1.3.6
 package: rhcl-operator

--- a/catalog/4.20/authorino-operator/catalog.yaml
+++ b/catalog/4.20/authorino-operator/catalog.yaml
@@ -32,10 +32,12 @@ entries:
     replaces: authorino-operator.v1.3.0
   - name: authorino-operator.v1.3.2
     replaces: authorino-operator.v1.3.1
-  - name: authorino-operator.v1.4.0
-    replaces: authorino-operator.v1.3.1
-  - name: authorino-operator.v1.4.1
+  - name: authorino-operator.v1.3.3
     replaces: authorino-operator.v1.3.2
+  - name: authorino-operator.v1.4.0
+    replaces: authorino-operator.v1.3.2
+  - name: authorino-operator.v1.4.1
+    replaces: authorino-operator.v1.3.3
     skips:
       - authorino-operator.v1.4.0
   - name: authorino-operator.v1.4.2
@@ -4462,5 +4464,163 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:414262da59a55c48837807274db11cedb7da50b5984d03d3bd0445e4f7b1a0ea
   name: ""
 - image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:fbe9e2e767530eae72a421f541325640feba03322441cd7a294f8a6bf1fb4d97
+  name: authorino
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
+name: authorino-operator.v1.3.3
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.3.3
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b325bd9a7a07302d80636efefbc987858a57a185a559952f47f77ca2ee969970
+      createdAt: "2026-07-23T13:57:46Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b325bd9a7a07302d80636efefbc987858a57a185a559952f47f77ca2ee969970
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:6d36a163669bea414ed378f6a575de3287e2ade60ebff576344156a7d44ae0c3
   name: authorino
 schema: olm.bundle

--- a/catalog/4.20/authorino-operator/catalog.yaml
+++ b/catalog/4.20/authorino-operator/catalog.yaml
@@ -35,7 +35,6 @@ entries:
   - name: authorino-operator.v1.3.3
     replaces: authorino-operator.v1.3.2
   - name: authorino-operator.v1.4.0
-    replaces: authorino-operator.v1.3.2
   - name: authorino-operator.v1.4.1
     replaces: authorino-operator.v1.3.3
     skips:

--- a/catalog/4.20/authorino-operator/catalog.yaml
+++ b/catalog/4.20/authorino-operator/catalog.yaml
@@ -4467,7 +4467,6 @@ relatedImages:
   name: authorino
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
 name: authorino-operator.v1.3.3
 package: authorino-operator

--- a/catalog/4.20/dns-operator/catalog.yaml
+++ b/catalog/4.20/dns-operator/catalog.yaml
@@ -20,8 +20,10 @@ entries:
     replaces: dns-operator.v1.2.0
   - name: dns-operator.v1.3.1
     replaces: dns-operator.v1.3.0
-  - name: dns-operator.v1.4.0
+  - name: dns-operator.v1.3.2
     replaces: dns-operator.v1.3.1
+  - name: dns-operator.v1.4.0
+    replaces: dns-operator.v1.3.2
 name: stable
 package: dns-operator
 schema: olm.channel
@@ -1199,5 +1201,155 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:d967a3865d196856b88cf23a8468decefb13312c256b7436fc2acc503c888cbb
   name: ""
 - image: registry.redhat.io/rhcl-1/dns-rhel9-operator@sha256:ca946bb88274562b8027c90d7b6945a426ec799b1b0017056f6189160c591c2d
+  name: ""
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:3e9f92b9767f13bf71c457fe04a14b34eb0fb3dfea5cb7e84bc22bb3df5edf2a
+name: dns-operator.v1.3.2
+package: dns-operator
+properties:
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSHealthCheckProbe
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSRecord
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: dns-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "DNSHealthCheckProbe",
+            "metadata": {
+              "name": "$NAME"
+            },
+            "spec": {
+              "additionalHeadersRef": {
+                "name": "headers"
+              },
+              "address": "192.168.0.16",
+              "allowInsecureCertificate": true,
+              "failureThreshold": 5,
+              "hostname": "test.com",
+              "interval": "60s",
+              "path": "/healthz",
+              "port": 443,
+              "protocol": "HTTPS"
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "DNSRecord",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "dns-operator",
+                "app.kubernetes.io/instance": "dnsrecord-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "dnsrecord",
+                "app.kubernetes.io/part-of": "dns-operator"
+              },
+              "name": "dnsrecord-sample"
+            },
+            "spec": {
+              "endpoints": [
+                {
+                  "dnsName": "dnsrecord-simple.kuadrant.local",
+                  "recordTTL": 60,
+                  "recordType": "A",
+                  "targets": [
+                    "52.215.108.61",
+                    "52.30.101.221"
+                  ]
+                }
+              ],
+              "providerRef": {
+                "name": "dns-provider-credentials-inmemory"
+              },
+              "rootHost": "dnsrecord-simple.kuadrant.local"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/dns-rhel9-operator@sha256:1cee71c721d4ced752ab52b94554418125f3be68bbd811b203d5dc4cf931934d
+      createdAt: "2026-07-23T14:50:37Z"
+      description: A Kubernetes Operator to manage the lifecycle of DNS resources
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/dns-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: DNSHealthCheckProbe is the Schema for the dnshealthcheckprobes
+          API
+        displayName: DNSHealthCheckProbe
+        kind: DNSHealthCheckProbe
+        name: dnshealthcheckprobes.kuadrant.io
+        version: v1alpha1
+      - description: DNSRecord is the Schema for the dnsrecords API
+        displayName: DNSRecord
+        kind: DNSRecord
+        name: dnsrecords.kuadrant.io
+        version: v1alpha1
+    description: Configures how north-south traffic from outside the network is balanced
+      and reaches Gateways.
+    displayName: DNS Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - dns
+    - kuadrant
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: DNS Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    maintainers:
+    - email: mnairn@redhat.com
+      name: Michael Nairn
+    - email: pbrookes@redhat.com
+      name: Phil Brookes
+    - email: cbrookes@redhat.com
+      name: Craig Brookes
+    maturity: alpha
+    minKubeVersion: 1.8.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:3e9f92b9767f13bf71c457fe04a14b34eb0fb3dfea5cb7e84bc22bb3df5edf2a
+  name: ""
+- image: registry.redhat.io/rhcl-1/dns-rhel9-operator@sha256:1cee71c721d4ced752ab52b94554418125f3be68bbd811b203d5dc4cf931934d
   name: ""
 schema: olm.bundle

--- a/catalog/4.20/dns-operator/catalog.yaml
+++ b/catalog/4.20/dns-operator/catalog.yaml
@@ -9,7 +9,9 @@ schema: olm.package
 entries:
   - name: dns-operator.v1.0.2
   - name: dns-operator.v1.4.1
-    replaces: dns-operator.v1.4.0
+    replaces: dns-operator.v1.3.2
+    skips:
+    - dns-operator.v1.4.0
   - name: dns-operator.v1.1.0
     replaces: dns-operator.v1.0.2
   - name: dns-operator.v1.1.1
@@ -23,7 +25,6 @@ entries:
   - name: dns-operator.v1.3.2
     replaces: dns-operator.v1.3.1
   - name: dns-operator.v1.4.0
-    replaces: dns-operator.v1.3.2
 name: stable
 package: dns-operator
 schema: olm.channel

--- a/catalog/4.20/dns-operator/catalog.yaml
+++ b/catalog/4.20/dns-operator/catalog.yaml
@@ -1204,7 +1204,6 @@ relatedImages:
   name: ""
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:3e9f92b9767f13bf71c457fe04a14b34eb0fb3dfea5cb7e84bc22bb3df5edf2a
 name: dns-operator.v1.3.2
 package: dns-operator

--- a/catalog/4.20/limitador-operator/catalog.yaml
+++ b/catalog/4.20/limitador-operator/catalog.yaml
@@ -21,9 +21,10 @@ entries:
   - name: limitador-operator.v1.3.2
     replaces: limitador-operator.v1.3.1
   - name: limitador-operator.v1.4.0
-    replaces: limitador-operator.v1.3.2
   - name: limitador-operator.v1.4.1
-    replaces: limitador-operator.v1.4.0
+    replaces: limitador-operator.v1.3.2
+    skips:
+    - limitador-operator.v1.4.0
 name: stable
 package: limitador-operator
 schema: olm.channel

--- a/catalog/4.20/limitador-operator/catalog.yaml
+++ b/catalog/4.20/limitador-operator/catalog.yaml
@@ -18,8 +18,10 @@ entries:
     replaces: limitador-operator.v1.2.0
   - name: limitador-operator.v1.3.1
     replaces: limitador-operator.v1.3.0
-  - name: limitador-operator.v1.4.0
+  - name: limitador-operator.v1.3.2
     replaces: limitador-operator.v1.3.1
+  - name: limitador-operator.v1.4.0
+    replaces: limitador-operator.v1.3.2
   - name: limitador-operator.v1.4.1
     replaces: limitador-operator.v1.4.0
 name: stable
@@ -987,5 +989,128 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:5261170dafd0c9b5a89d3509ada864624e4aaf62a7763bf595980de5b450cc04
   name: ""
 - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:a233ab32e26cf2ea46c31dfc4fcaf89ce541a9351bba99182036a91f357cc2b4
+  name: limitador
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:416895351e21b9f5dbfa6ba6b44287a38a5ded3f0782e508268160bb3140b6d2
+name: limitador-operator.v1.3.2
+package: limitador-operator
+properties:
+- type: olm.gvk
+  value:
+    group: limitador.kuadrant.io
+    kind: Limitador
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: limitador-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "limitador.kuadrant.io/v1alpha1",
+            "kind": "Limitador",
+            "metadata": {
+              "name": "limitador-sample"
+            },
+            "spec": {
+              "limits": [
+                {
+                  "conditions": [
+                    "get_toy == 'yes'"
+                  ],
+                  "max_value": 2,
+                  "name": "toy_get_route",
+                  "namespace": "toystore-app",
+                  "seconds": 30,
+                  "variables": []
+                }
+              ],
+              "listener": {
+                "grpc": {
+                  "port": 8081
+                },
+                "http": {
+                  "port": 8080
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:38990ad0bc3d1ac80a751be22e16326110affb76bd5ed934bc70e3b65848e595
+      createdAt: "2026-07-23T14:43:27Z"
+      description: The Limitador operator installs and maintains limitador instances
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/limitador-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Limitador is the Schema for the limitadors API
+        displayName: Limitador
+        kind: Limitador
+        name: limitadors.limitador.kuadrant.io
+        version: v1alpha1
+    description: Enables rate limiting for Gateways and applications in a Gateway
+      API network. Part of Red Hat Connectivity Link
+    displayName: Limitador Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - rate-limit
+    - kuadrant
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Limitador Operator
+      url: https://github.com/Kuadrant/limitador-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: asnaps@redhat.com
+      name: Alex Snaps
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/limitador-operator
+relatedImages:
+- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:416895351e21b9f5dbfa6ba6b44287a38a5ded3f0782e508268160bb3140b6d2
+  name: ""
+- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:38990ad0bc3d1ac80a751be22e16326110affb76bd5ed934bc70e3b65848e595
+  name: ""
+- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:302b04993a5a77df09901e1eefbb0a22d3cd9ed10b6b41aa26f2598ba8e3cbde
   name: limitador
 schema: olm.bundle

--- a/catalog/4.20/limitador-operator/catalog.yaml
+++ b/catalog/4.20/limitador-operator/catalog.yaml
@@ -992,7 +992,6 @@ relatedImages:
   name: limitador
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:416895351e21b9f5dbfa6ba6b44287a38a5ded3f0782e508268160bb3140b6d2
 name: limitador-operator.v1.3.2
 package: limitador-operator

--- a/catalog/4.20/rhcl-operator/catalog.yaml
+++ b/catalog/4.20/rhcl-operator/catalog.yaml
@@ -28,9 +28,11 @@ entries:
     replaces: rhcl-operator.v1.3.3
   - name: rhcl-operator.v1.3.5
     replaces: rhcl-operator.v1.3.4
+  - name: rhcl-operator.v1.3.6
+    replaces: rhcl-operator.v1.3.5
   - name: rhcl-operator.v1.4.0
   - name: rhcl-operator.v1.4.1
-    replaces: rhcl-operator.v1.3.5
+    replaces: rhcl-operator.v1.3.6
   - name: rhcl-operator.v1.4.2
     replaces: rhcl-operator.v1.4.1
     skips:
@@ -4876,5 +4878,433 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:e74d5a4a7e8a72f9faf242d8df0b37243980ab48018b70e1ce04b9e6fb136ca8
   name: ""
 - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:8c2d9a84169e86454e4fb3df6f4846c5c5495d19b01137b6e78e113161981e47
+  name: ""
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:dfd39aa4a280135b4917e4698b01ac6caf4f0f4e2f3d436928eaa098c2659a47
+name: rhcl-operator.v1.3.6
+package: rhcl-operator
+properties:
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIProduct
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: OIDCPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: PlanPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: TelemetryPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: AuthPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: Kuadrant
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: RateLimitPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TLSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TokenRateLimitPolicy
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: rhcl-operator
+    version: 1.3.6
+- type: olm.package.required
+  value:
+    packageName: authorino-operator
+    versionRange: 1.3.3
+- type: olm.package.required
+  value:
+    packageName: dns-operator
+    versionRange: 1.3.2
+- type: olm.package.required
+  value:
+    packageName: limitador-operator
+    versionRange: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "OIDCPolicy",
+            "metadata": {
+              "name": "oidcpolicy-sample"
+            },
+            "spec": {
+              "provider": {
+                "cliendID": "exampleID",
+                "issuerURL": "https://idp.example.org/"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "PlanPolicy",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "kuadrant-operator",
+                "app.kubernetes.io/instance": "planpolicy-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "planpolicy",
+                "app.kubernetes.io/part-of": "kuadrant-operator"
+              },
+              "name": "planpolicy-sample"
+            },
+            "spec": {
+              "plans": [
+                {
+                  "limits": {
+                    "daily": 5
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"gold\"\n",
+                  "tier": "gold"
+                },
+                {
+                  "limits": {
+                    "daily": 2
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"silver\"\n",
+                  "tier": "silver"
+                },
+                {
+                  "limits": {
+                    "daily": 1
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"bronze\"\n",
+                  "tier": "bronze"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "AuthPolicy",
+            "metadata": {
+              "name": "authpolicy-sample"
+            },
+            "spec": {
+              "rules": {
+                "authentication": {
+                  "apikey": {
+                    "apiKey": {
+                      "selector": {}
+                    },
+                    "credentials": {
+                      "authorizationHeader": {
+                        "prefix": "APIKEY"
+                      }
+                    }
+                  }
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "DNSPolicy",
+            "metadata": {
+              "name": "dnspolicy-sample"
+            },
+            "spec": {
+              "healthCheck": {
+                "protocol": "HTTP"
+              },
+              "providerRefs": [
+                {
+                  "name": "provider-ref"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "RateLimitPolicy",
+            "metadata": {
+              "name": "ratelimitpolicy-sample"
+            },
+            "spec": {
+              "limits": {
+                "toys": {
+                  "rates": [
+                    {
+                      "limit": 50,
+                      "window": "1m"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "TLSPolicy",
+            "metadata": {
+              "name": "tlspolicy-sample"
+            },
+            "spec": {
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "self-signed-ca"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "TokenRateLimitPolicy",
+            "metadata": {
+              "name": "token-limit-free",
+              "namespace": "gateway-system"
+            },
+            "spec": {
+              "limits": {
+                "free": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 20000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"free\")"
+                    }
+                  ]
+                },
+                "gold": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 200000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"gold\")"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "my-llm-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "Kuadrant",
+            "metadata": {
+              "name": "kuadrant-sample"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      console.openshift.io/plugins: '["kuadrant-console-plugin"]'
+      containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0e20ad95a5b04d8ea9d670de14c8cb6f9a3aab70fc1153c3a979b75dcb327643
+      createdAt: "2026-07-24T07:45:23Z"
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/kuadrant-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: APIKey
+        name: apikeys.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIProduct
+        name: apiproducts.devportal.kuadrant.io
+        version: v1alpha1
+      - description: AuthPolicy enables authentication and authorization for service
+          workloads in a Gateway API network
+        displayName: AuthPolicy
+        kind: AuthPolicy
+        name: authpolicies.kuadrant.io
+        version: v1
+      - description: DNSPolicy configures how North-South based traffic should be
+          balanced and reach the gateways
+        displayName: DNSPolicy
+        kind: DNSPolicy
+        name: dnspolicies.kuadrant.io
+        version: v1
+      - description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        displayName: Kuadrant
+        kind: Kuadrant
+        name: kuadrants.kuadrant.io
+        version: v1beta1
+      - kind: OIDCPolicy
+        name: oidcpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - kind: PlanPolicy
+        name: planpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        displayName: RateLimitPolicy
+        kind: RateLimitPolicy
+        name: ratelimitpolicies.kuadrant.io
+        version: v1
+      - kind: TelemetryPolicy
+        name: telemetrypolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: TLSPolicy provides tls for gateway listeners by managing the
+          lifecycle of tls certificates
+        displayName: TLSPolicy
+        kind: TLSPolicy
+        name: tlspolicies.kuadrant.io
+        version: v1
+      - kind: TokenRateLimitPolicy
+        name: tokenratelimitpolicies.kuadrant.io
+        version: v1alpha1
+    description: Red Hat Connectivity Link enables you to secure, protect, and connect
+      your APIs and applications in multicluster, multicloud, and hybrid cloud environments.
+    displayName: Red Hat Connectivity Link
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - api-management
+    - Kuadrant
+    - kubernetes
+    - openshift
+    - cloud-service-protection
+    - rate-limiting
+    - authentication
+    - authorization
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Kuadrant Operator
+      url: https://github.com/Kuadrant/kuadrant-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+- image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:ed34543a7a226b3f0d9382e21a81db6d60e0240154a6632a303bf4bff6ed8bd0
+  name: wasmshim
+- image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:1446ac58a230a94309baf7c631a3540fe376ab64a54c92f25b77801fb290c8d2
+  name: developerportal
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:7b91ed74be258ed5d4a74a89bdfb7a0e064ce75bf34d48be887d751c65c32ff0
+  name: console-plugin-latest
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:9901b78b5c7c3170357c1ebb00590561e3b16f20df6163ee7fc45c53a1393c15
+  name: console-plugin-pf5
+- image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:dfd39aa4a280135b4917e4698b01ac6caf4f0f4e2f3d436928eaa098c2659a47
+  name: ""
+- image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0e20ad95a5b04d8ea9d670de14c8cb6f9a3aab70fc1153c3a979b75dcb327643
   name: ""
 schema: olm.bundle

--- a/catalog/4.20/rhcl-operator/catalog.yaml
+++ b/catalog/4.20/rhcl-operator/catalog.yaml
@@ -4881,7 +4881,6 @@ relatedImages:
   name: ""
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:dfd39aa4a280135b4917e4698b01ac6caf4f0f4e2f3d436928eaa098c2659a47
 name: rhcl-operator.v1.3.6
 package: rhcl-operator

--- a/catalog/4.21/authorino-operator/catalog.yaml
+++ b/catalog/4.21/authorino-operator/catalog.yaml
@@ -32,10 +32,12 @@ entries:
     replaces: authorino-operator.v1.3.0
   - name: authorino-operator.v1.3.2
     replaces: authorino-operator.v1.3.1
-  - name: authorino-operator.v1.4.0
-    replaces: authorino-operator.v1.3.1
-  - name: authorino-operator.v1.4.1
+  - name: authorino-operator.v1.3.3
     replaces: authorino-operator.v1.3.2
+  - name: authorino-operator.v1.4.0
+    replaces: authorino-operator.v1.3.2
+  - name: authorino-operator.v1.4.1
+    replaces: authorino-operator.v1.3.3
     skips:
       - authorino-operator.v1.4.0
   - name: authorino-operator.v1.4.2
@@ -4462,5 +4464,163 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:414262da59a55c48837807274db11cedb7da50b5984d03d3bd0445e4f7b1a0ea
   name: ""
 - image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:fbe9e2e767530eae72a421f541325640feba03322441cd7a294f8a6bf1fb4d97
+  name: authorino
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
+name: authorino-operator.v1.3.3
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.3.3
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b325bd9a7a07302d80636efefbc987858a57a185a559952f47f77ca2ee969970
+      createdAt: "2026-07-23T13:57:46Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b325bd9a7a07302d80636efefbc987858a57a185a559952f47f77ca2ee969970
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:6d36a163669bea414ed378f6a575de3287e2ade60ebff576344156a7d44ae0c3
   name: authorino
 schema: olm.bundle

--- a/catalog/4.21/authorino-operator/catalog.yaml
+++ b/catalog/4.21/authorino-operator/catalog.yaml
@@ -35,7 +35,6 @@ entries:
   - name: authorino-operator.v1.3.3
     replaces: authorino-operator.v1.3.2
   - name: authorino-operator.v1.4.0
-    replaces: authorino-operator.v1.3.2
   - name: authorino-operator.v1.4.1
     replaces: authorino-operator.v1.3.3
     skips:

--- a/catalog/4.21/authorino-operator/catalog.yaml
+++ b/catalog/4.21/authorino-operator/catalog.yaml
@@ -4467,7 +4467,6 @@ relatedImages:
   name: authorino
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
 name: authorino-operator.v1.3.3
 package: authorino-operator

--- a/catalog/4.21/dns-operator/catalog.yaml
+++ b/catalog/4.21/dns-operator/catalog.yaml
@@ -618,7 +618,6 @@ relatedImages:
   name: ""
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:3e9f92b9767f13bf71c457fe04a14b34eb0fb3dfea5cb7e84bc22bb3df5edf2a
 name: dns-operator.v1.3.2
 package: dns-operator

--- a/catalog/4.21/dns-operator/catalog.yaml
+++ b/catalog/4.21/dns-operator/catalog.yaml
@@ -9,13 +9,14 @@ schema: olm.package
 entries:
   - name: dns-operator.v1.3.0
   - name: dns-operator.v1.4.1
-    replaces: dns-operator.v1.4.0
+    replaces: dns-operator.v1.3.2
+    skips:
+    - dns-operator.v1.4.0
   - name: dns-operator.v1.3.1
     replaces: dns-operator.v1.3.0
   - name: dns-operator.v1.3.2
     replaces: dns-operator.v1.3.1
   - name: dns-operator.v1.4.0
-    replaces: dns-operator.v1.3.2
 name: stable
 package: dns-operator
 schema: olm.channel

--- a/catalog/4.21/dns-operator/catalog.yaml
+++ b/catalog/4.21/dns-operator/catalog.yaml
@@ -12,8 +12,10 @@ entries:
     replaces: dns-operator.v1.4.0
   - name: dns-operator.v1.3.1
     replaces: dns-operator.v1.3.0
-  - name: dns-operator.v1.4.0
+  - name: dns-operator.v1.3.2
     replaces: dns-operator.v1.3.1
+  - name: dns-operator.v1.4.0
+    replaces: dns-operator.v1.3.2
 name: stable
 package: dns-operator
 schema: olm.channel
@@ -613,5 +615,155 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:d967a3865d196856b88cf23a8468decefb13312c256b7436fc2acc503c888cbb
   name: ""
 - image: registry.redhat.io/rhcl-1/dns-rhel9-operator@sha256:ca946bb88274562b8027c90d7b6945a426ec799b1b0017056f6189160c591c2d
+  name: ""
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:3e9f92b9767f13bf71c457fe04a14b34eb0fb3dfea5cb7e84bc22bb3df5edf2a
+name: dns-operator.v1.3.2
+package: dns-operator
+properties:
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSHealthCheckProbe
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSRecord
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: dns-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "DNSHealthCheckProbe",
+            "metadata": {
+              "name": "$NAME"
+            },
+            "spec": {
+              "additionalHeadersRef": {
+                "name": "headers"
+              },
+              "address": "192.168.0.16",
+              "allowInsecureCertificate": true,
+              "failureThreshold": 5,
+              "hostname": "test.com",
+              "interval": "60s",
+              "path": "/healthz",
+              "port": 443,
+              "protocol": "HTTPS"
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "DNSRecord",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "dns-operator",
+                "app.kubernetes.io/instance": "dnsrecord-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "dnsrecord",
+                "app.kubernetes.io/part-of": "dns-operator"
+              },
+              "name": "dnsrecord-sample"
+            },
+            "spec": {
+              "endpoints": [
+                {
+                  "dnsName": "dnsrecord-simple.kuadrant.local",
+                  "recordTTL": 60,
+                  "recordType": "A",
+                  "targets": [
+                    "52.215.108.61",
+                    "52.30.101.221"
+                  ]
+                }
+              ],
+              "providerRef": {
+                "name": "dns-provider-credentials-inmemory"
+              },
+              "rootHost": "dnsrecord-simple.kuadrant.local"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/dns-rhel9-operator@sha256:1cee71c721d4ced752ab52b94554418125f3be68bbd811b203d5dc4cf931934d
+      createdAt: "2026-07-23T14:50:37Z"
+      description: A Kubernetes Operator to manage the lifecycle of DNS resources
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/dns-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: DNSHealthCheckProbe is the Schema for the dnshealthcheckprobes
+          API
+        displayName: DNSHealthCheckProbe
+        kind: DNSHealthCheckProbe
+        name: dnshealthcheckprobes.kuadrant.io
+        version: v1alpha1
+      - description: DNSRecord is the Schema for the dnsrecords API
+        displayName: DNSRecord
+        kind: DNSRecord
+        name: dnsrecords.kuadrant.io
+        version: v1alpha1
+    description: Configures how north-south traffic from outside the network is balanced
+      and reaches Gateways.
+    displayName: DNS Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - dns
+    - kuadrant
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: DNS Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    maintainers:
+    - email: mnairn@redhat.com
+      name: Michael Nairn
+    - email: pbrookes@redhat.com
+      name: Phil Brookes
+    - email: cbrookes@redhat.com
+      name: Craig Brookes
+    maturity: alpha
+    minKubeVersion: 1.8.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/dns-operator-bundle@sha256:3e9f92b9767f13bf71c457fe04a14b34eb0fb3dfea5cb7e84bc22bb3df5edf2a
+  name: ""
+- image: registry.redhat.io/rhcl-1/dns-rhel9-operator@sha256:1cee71c721d4ced752ab52b94554418125f3be68bbd811b203d5dc4cf931934d
   name: ""
 schema: olm.bundle

--- a/catalog/4.21/limitador-operator/catalog.yaml
+++ b/catalog/4.21/limitador-operator/catalog.yaml
@@ -10,8 +10,10 @@ entries:
   - name: limitador-operator.v1.3.0
   - name: limitador-operator.v1.3.1
     replaces: limitador-operator.v1.3.0
-  - name: limitador-operator.v1.4.0
+  - name: limitador-operator.v1.3.2
     replaces: limitador-operator.v1.3.1
+  - name: limitador-operator.v1.4.0
+    replaces: limitador-operator.v1.3.2
   - name: limitador-operator.v1.4.1
     replaces: limitador-operator.v1.4.0
 name: stable
@@ -506,5 +508,128 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:5261170dafd0c9b5a89d3509ada864624e4aaf62a7763bf595980de5b450cc04
   name: ""
 - image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:a233ab32e26cf2ea46c31dfc4fcaf89ce541a9351bba99182036a91f357cc2b4
+  name: limitador
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:416895351e21b9f5dbfa6ba6b44287a38a5ded3f0782e508268160bb3140b6d2
+name: limitador-operator.v1.3.2
+package: limitador-operator
+properties:
+- type: olm.gvk
+  value:
+    group: limitador.kuadrant.io
+    kind: Limitador
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: limitador-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "limitador.kuadrant.io/v1alpha1",
+            "kind": "Limitador",
+            "metadata": {
+              "name": "limitador-sample"
+            },
+            "spec": {
+              "limits": [
+                {
+                  "conditions": [
+                    "get_toy == 'yes'"
+                  ],
+                  "max_value": 2,
+                  "name": "toy_get_route",
+                  "namespace": "toystore-app",
+                  "seconds": 30,
+                  "variables": []
+                }
+              ],
+              "listener": {
+                "grpc": {
+                  "port": 8081
+                },
+                "http": {
+                  "port": 8080
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:38990ad0bc3d1ac80a751be22e16326110affb76bd5ed934bc70e3b65848e595
+      createdAt: "2026-07-23T14:43:27Z"
+      description: The Limitador operator installs and maintains limitador instances
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/limitador-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: Limitador is the Schema for the limitadors API
+        displayName: Limitador
+        kind: Limitador
+        name: limitadors.limitador.kuadrant.io
+        version: v1alpha1
+    description: Enables rate limiting for Gateways and applications in a Gateway
+      API network. Part of Red Hat Connectivity Link
+    displayName: Limitador Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - rate-limit
+    - kuadrant
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Limitador Operator
+      url: https://github.com/Kuadrant/limitador-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: asnaps@redhat.com
+      name: Alex Snaps
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/limitador-operator
+relatedImages:
+- image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:416895351e21b9f5dbfa6ba6b44287a38a5ded3f0782e508268160bb3140b6d2
+  name: ""
+- image: registry.redhat.io/rhcl-1/limitador-rhel9-operator@sha256:38990ad0bc3d1ac80a751be22e16326110affb76bd5ed934bc70e3b65848e595
+  name: ""
+- image: registry.redhat.io/rhcl-1/limitador-rhel9@sha256:302b04993a5a77df09901e1eefbb0a22d3cd9ed10b6b41aa26f2598ba8e3cbde
   name: limitador
 schema: olm.bundle

--- a/catalog/4.21/limitador-operator/catalog.yaml
+++ b/catalog/4.21/limitador-operator/catalog.yaml
@@ -511,7 +511,6 @@ relatedImages:
   name: limitador
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/limitador-operator-bundle@sha256:416895351e21b9f5dbfa6ba6b44287a38a5ded3f0782e508268160bb3140b6d2
 name: limitador-operator.v1.3.2
 package: limitador-operator

--- a/catalog/4.21/limitador-operator/catalog.yaml
+++ b/catalog/4.21/limitador-operator/catalog.yaml
@@ -13,9 +13,10 @@ entries:
   - name: limitador-operator.v1.3.2
     replaces: limitador-operator.v1.3.1
   - name: limitador-operator.v1.4.0
-    replaces: limitador-operator.v1.3.2
   - name: limitador-operator.v1.4.1
-    replaces: limitador-operator.v1.4.0
+    replaces: limitador-operator.v1.3.2
+    skips:
+    - limitador-operator.v1.4.0
 name: stable
 package: limitador-operator
 schema: olm.channel

--- a/catalog/4.21/rhcl-operator/catalog.yaml
+++ b/catalog/4.21/rhcl-operator/catalog.yaml
@@ -18,9 +18,11 @@ entries:
     replaces: rhcl-operator.v1.3.3
   - name: rhcl-operator.v1.3.5
     replaces: rhcl-operator.v1.3.4
+  - name: rhcl-operator.v1.3.6
+    replaces: rhcl-operator.v1.3.5
   - name: rhcl-operator.v1.4.0
   - name: rhcl-operator.v1.4.1
-    replaces: rhcl-operator.v1.3.5
+    replaces: rhcl-operator.v1.3.6
   - name: rhcl-operator.v1.4.2
     replaces: rhcl-operator.v1.4.1
     skips:
@@ -3551,5 +3553,433 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:e74d5a4a7e8a72f9faf242d8df0b37243980ab48018b70e1ce04b9e6fb136ca8
   name: ""
 - image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:8c2d9a84169e86454e4fb3df6f4846c5c5495d19b01137b6e78e113161981e47
+  name: ""
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:dfd39aa4a280135b4917e4698b01ac6caf4f0f4e2f3d436928eaa098c2659a47
+name: rhcl-operator.v1.3.6
+package: rhcl-operator
+properties:
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIKey
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: devportal.kuadrant.io
+    kind: APIProduct
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: OIDCPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: PlanPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: extensions.kuadrant.io
+    kind: TelemetryPolicy
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: AuthPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: DNSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: Kuadrant
+    version: v1beta1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: RateLimitPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TLSPolicy
+    version: v1
+- type: olm.gvk
+  value:
+    group: kuadrant.io
+    kind: TokenRateLimitPolicy
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: rhcl-operator
+    version: 1.3.6
+- type: olm.package.required
+  value:
+    packageName: authorino-operator
+    versionRange: 1.3.3
+- type: olm.package.required
+  value:
+    packageName: dns-operator
+    versionRange: 1.3.2
+- type: olm.package.required
+  value:
+    packageName: limitador-operator
+    versionRange: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "OIDCPolicy",
+            "metadata": {
+              "name": "oidcpolicy-sample"
+            },
+            "spec": {
+              "provider": {
+                "cliendID": "exampleID",
+                "issuerURL": "https://idp.example.org/"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "PlanPolicy",
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/created-by": "kuadrant-operator",
+                "app.kubernetes.io/instance": "planpolicy-sample",
+                "app.kubernetes.io/managed-by": "kustomize",
+                "app.kubernetes.io/name": "planpolicy",
+                "app.kubernetes.io/part-of": "kuadrant-operator"
+              },
+              "name": "planpolicy-sample"
+            },
+            "spec": {
+              "plans": [
+                {
+                  "limits": {
+                    "daily": 5
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"gold\"\n",
+                  "tier": "gold"
+                },
+                {
+                  "limits": {
+                    "daily": 2
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"silver\"\n",
+                  "tier": "silver"
+                },
+                {
+                  "limits": {
+                    "daily": 1
+                  },
+                  "predicate": "has(auth.identity) \u0026\u0026 auth.identity.metadata.annotations[\"secret.kuadrant.io/plan-id\"] == \"bronze\"\n",
+                  "tier": "bronze"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "example-route"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "AuthPolicy",
+            "metadata": {
+              "name": "authpolicy-sample"
+            },
+            "spec": {
+              "rules": {
+                "authentication": {
+                  "apikey": {
+                    "apiKey": {
+                      "selector": {}
+                    },
+                    "credentials": {
+                      "authorizationHeader": {
+                        "prefix": "APIKEY"
+                      }
+                    }
+                  }
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "DNSPolicy",
+            "metadata": {
+              "name": "dnspolicy-sample"
+            },
+            "spec": {
+              "healthCheck": {
+                "protocol": "HTTP"
+              },
+              "providerRefs": [
+                {
+                  "name": "provider-ref"
+                }
+              ],
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "RateLimitPolicy",
+            "metadata": {
+              "name": "ratelimitpolicy-sample"
+            },
+            "spec": {
+              "limits": {
+                "toys": {
+                  "rates": [
+                    {
+                      "limit": 50,
+                      "window": "1m"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "HTTPRoute",
+                "name": "toystore"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1",
+            "kind": "TLSPolicy",
+            "metadata": {
+              "name": "tlspolicy-sample"
+            },
+            "spec": {
+              "issuerRef": {
+                "group": "cert-manager.io",
+                "kind": "ClusterIssuer",
+                "name": "self-signed-ca"
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "example-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1alpha1",
+            "kind": "TokenRateLimitPolicy",
+            "metadata": {
+              "name": "token-limit-free",
+              "namespace": "gateway-system"
+            },
+            "spec": {
+              "limits": {
+                "free": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 20000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"free\")"
+                    }
+                  ]
+                },
+                "gold": {
+                  "counters": [
+                    {
+                      "expression": "auth.identity.userid"
+                    }
+                  ],
+                  "rates": [
+                    {
+                      "limit": 200000,
+                      "window": "1d"
+                    }
+                  ],
+                  "when": [
+                    {
+                      "predicate": "request.auth.claims[\"kuadrant.io/groups\"].split(\",\").exists(g, g == \"gold\")"
+                    }
+                  ]
+                }
+              },
+              "targetRef": {
+                "group": "gateway.networking.k8s.io",
+                "kind": "Gateway",
+                "name": "my-llm-gateway"
+              }
+            }
+          },
+          {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "Kuadrant",
+            "metadata": {
+              "name": "kuadrant-sample"
+            },
+            "spec": {}
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      console.openshift.io/plugins: '["kuadrant-console-plugin"]'
+      containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0e20ad95a5b04d8ea9d670de14c8cb6f9a3aab70fc1153c3a979b75dcb327643
+      createdAt: "2026-07-24T07:45:23Z"
+      description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/Kuadrant/kuadrant-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: APIKey
+        name: apikeys.devportal.kuadrant.io
+        version: v1alpha1
+      - kind: APIProduct
+        name: apiproducts.devportal.kuadrant.io
+        version: v1alpha1
+      - description: AuthPolicy enables authentication and authorization for service
+          workloads in a Gateway API network
+        displayName: AuthPolicy
+        kind: AuthPolicy
+        name: authpolicies.kuadrant.io
+        version: v1
+      - description: DNSPolicy configures how North-South based traffic should be
+          balanced and reach the gateways
+        displayName: DNSPolicy
+        kind: DNSPolicy
+        name: dnspolicies.kuadrant.io
+        version: v1
+      - description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        displayName: Kuadrant
+        kind: Kuadrant
+        name: kuadrants.kuadrant.io
+        version: v1beta1
+      - kind: OIDCPolicy
+        name: oidcpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - kind: PlanPolicy
+        name: planpolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        displayName: RateLimitPolicy
+        kind: RateLimitPolicy
+        name: ratelimitpolicies.kuadrant.io
+        version: v1
+      - kind: TelemetryPolicy
+        name: telemetrypolicies.extensions.kuadrant.io
+        version: v1alpha1
+      - description: TLSPolicy provides tls for gateway listeners by managing the
+          lifecycle of tls certificates
+        displayName: TLSPolicy
+        kind: TLSPolicy
+        name: tlspolicies.kuadrant.io
+        version: v1
+      - kind: TokenRateLimitPolicy
+        name: tokenratelimitpolicies.kuadrant.io
+        version: v1alpha1
+    description: Red Hat Connectivity Link enables you to secure, protect, and connect
+      your APIs and applications in multicluster, multicloud, and hybrid cloud environments.
+    displayName: Red Hat Connectivity Link
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - api
+    - api-management
+    - Kuadrant
+    - kubernetes
+    - openshift
+    - cloud-service-protection
+    - rate-limiting
+    - authentication
+    - authorization
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Kuadrant Operator
+      url: https://github.com/Kuadrant/kuadrant-operator
+    - name: Kuadrant Docs
+      url: https://kuadrant.io
+    maintainers:
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    - email: didier@redhat.com
+      name: Didier Di Cesare
+    maturity: alpha
+    minKubeVersion: 1.19.0
+    provider:
+      name: Red Hat
+      url: https://github.com/Kuadrant/kuadrant-operator
+relatedImages:
+- image: registry.access.redhat.com/rhcl-1/wasm-shim-rhel9@sha256:ed34543a7a226b3f0d9382e21a81db6d60e0240154a6632a303bf4bff6ed8bd0
+  name: wasmshim
+- image: registry.redhat.io/rhcl-1/developer-portal-controller-rhel9@sha256:1446ac58a230a94309baf7c631a3540fe376ab64a54c92f25b77801fb290c8d2
+  name: developerportal
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:7b91ed74be258ed5d4a74a89bdfb7a0e064ce75bf34d48be887d751c65c32ff0
+  name: console-plugin-latest
+- image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:9901b78b5c7c3170357c1ebb00590561e3b16f20df6163ee7fc45c53a1393c15
+  name: console-plugin-pf5
+- image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:dfd39aa4a280135b4917e4698b01ac6caf4f0f4e2f3d436928eaa098c2659a47
+  name: ""
+- image: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:0e20ad95a5b04d8ea9d670de14c8cb6f9a3aab70fc1153c3a979b75dcb327643
   name: ""
 schema: olm.bundle

--- a/catalog/4.21/rhcl-operator/catalog.yaml
+++ b/catalog/4.21/rhcl-operator/catalog.yaml
@@ -3556,7 +3556,6 @@ relatedImages:
   name: ""
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/rhcl-operator-bundle@sha256:dfd39aa4a280135b4917e4698b01ac6caf4f0f4e2f3d436928eaa098c2659a47
 name: rhcl-operator.v1.3.6
 package: rhcl-operator

--- a/catalog/4.22/authorino-operator/catalog.yaml
+++ b/catalog/4.22/authorino-operator/catalog.yaml
@@ -32,10 +32,12 @@ entries:
     replaces: authorino-operator.v1.3.0
   - name: authorino-operator.v1.3.2
     replaces: authorino-operator.v1.3.1
-  - name: authorino-operator.v1.4.0
-    replaces: authorino-operator.v1.3.1
-  - name: authorino-operator.v1.4.1
+  - name: authorino-operator.v1.3.3
     replaces: authorino-operator.v1.3.2
+  - name: authorino-operator.v1.4.0
+    replaces: authorino-operator.v1.3.2
+  - name: authorino-operator.v1.4.1
+    replaces: authorino-operator.v1.3.3
     skips:
       - authorino-operator.v1.4.0
   - name: authorino-operator.v1.4.2
@@ -4462,5 +4464,163 @@ relatedImages:
 - image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:414262da59a55c48837807274db11cedb7da50b5984d03d3bd0445e4f7b1a0ea
   name: ""
 - image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:fbe9e2e767530eae72a421f541325640feba03322441cd7a294f8a6bf1fb4d97
+  name: authorino
+schema: olm.bundle
+---
+---
+image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
+name: authorino-operator.v1.3.3
+package: authorino-operator
+properties:
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta2
+- type: olm.gvk
+  value:
+    group: authorino.kuadrant.io
+    kind: AuthConfig
+    version: v1beta3
+- type: olm.gvk
+  value:
+    group: operator.authorino.kuadrant.io
+    kind: Authorino
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: authorino-operator
+    version: 1.3.3
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "authorino.kuadrant.io/v1beta3",
+            "kind": "AuthConfig",
+            "metadata": {
+              "name": "my-api-protection"
+            },
+            "spec": {
+              "authentication": {
+                "api-key-users": {
+                  "apiKey": {
+                    "selector": {
+                      "matchLabels": {
+                        "group": "friends"
+                      }
+                    }
+                  },
+                  "credentials": {
+                    "authorizationHeader": {
+                      "prefix": "APIKEY"
+                    }
+                  }
+                }
+              },
+              "hosts": [
+                "my-api.io"
+              ]
+            }
+          },
+          {
+            "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
+            "kind": "Authorino",
+            "metadata": {
+              "name": "authorino-sample"
+            },
+            "spec": {
+              "listener": {
+                "tls": {
+                  "enabled": false
+                }
+              },
+              "oidcServer": {
+                "tls": {
+                  "enabled": false
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b325bd9a7a07302d80636efefbc987858a57a185a559952f47f77ca2ee969970
+      createdAt: "2026-07-23T13:57:46Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/Kuadrant/authorino-operator
+      support: kuadrant
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: API to describe the desired protection for a service
+        displayName: AuthConfig
+        kind: AuthConfig
+        name: authconfigs.authorino.kuadrant.io
+        version: v1beta3
+      - description: API to create instances of authorino
+        displayName: Authorino
+        kind: Authorino
+        name: authorinos.operator.authorino.kuadrant.io
+        version: v1beta1
+    description: Enables authentication and authorization for Gateways and applications
+      in a Gateway API network. Part of Red Hat Connectivity Link
+    displayName: Authorino Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - Authorino
+    - Authorino Operator
+    - Kuadrant
+    - Authorization
+    - Authentication
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Authorino Operator
+      url: https://docs.redhat.com/en/documentation/red_hat_connectivity_link
+    - name: Authorino
+      url: https://github.com/Kuadrant/authorino
+    maintainers:
+    - email: dcesare@redhat.com
+      name: Didier Di Cesare
+    - email: eastizle@redhat.com
+      name: Eguzki Astiz Lezaun
+    - email: mcassola@redhat.com
+      name: Guilherme Cassolato
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9-operator@sha256:b325bd9a7a07302d80636efefbc987858a57a185a559952f47f77ca2ee969970
+  name: ""
+- image: registry.redhat.io/rhcl-1/authorino-rhel9@sha256:6d36a163669bea414ed378f6a575de3287e2ade60ebff576344156a7d44ae0c3
   name: authorino
 schema: olm.bundle

--- a/catalog/4.22/authorino-operator/catalog.yaml
+++ b/catalog/4.22/authorino-operator/catalog.yaml
@@ -4467,7 +4467,6 @@ relatedImages:
   name: authorino
 schema: olm.bundle
 ---
----
 image: registry.redhat.io/rhcl-1/authorino-operator-bundle@sha256:aa88111452a385c56ea221fe9d20e44723613e1a967eb641d9e07b89acb87c6d
 name: authorino-operator.v1.3.3
 package: authorino-operator


### PR DESCRIPTION
## Summary

Add RHCL 1.3.6 operator bundles to the file-based catalogs across OCP 4.18–4.22.

### Bundles added

| Operator | Bundle version | OCP versions |
|----------|---------------|--------------|
| authorino-operator | v1.3.3 | 4.18, 4.19, 4.20, 4.21, 4.22 |
| dns-operator | v1.3.2 | 4.18, 4.19, 4.20, 4.21 |
| limitador-operator | v1.3.2 | 4.18, 4.19, 4.20, 4.21 |
| rhcl-operator | v1.3.6 | 4.18, 4.19, 4.20, 4.21 |

Notes:
- dns-operator, limitador-operator and rhcl-operator are not added to 4.22 as RHCL 1.3 was never shipped for that OCP version
- authorino-operator carries full catalog history across all OCP versions per support arrangement
- Upgrade chain updated so 1.4.x entries correctly replace the new 1.3.6 heads
- All catalogs validated with `opm validate`

## Test plan
- [ ] Verify `opm validate` passes for all modified OCP versions
- [ ] Wait for Konflux FBC builds to succeed
- [ ] Create Release object against `rhcl-1-3-file-based-catalog-prod` ReleasePlan