### PR TITLE
Fix incorrect skips introduced into RHCL catalogs

### DIFF
--- a/catalog/4.19/dns-operator/catalog.yaml
+++ b/catalog/4.19/dns-operator/catalog.yaml
@@ -8,10 +8,6 @@ schema: olm.package
 ---
 entries:
   - name: dns-operator.v1.0.2
-  - name: dns-operator.v1.4.1
-    replaces: dns-operator.v1.3.2
-    skips:
-    - dns-operator.v1.4.0
   - name: dns-operator.v1.1.0
     replaces: dns-operator.v1.0.2
   - name: dns-operator.v1.1.1
@@ -25,6 +21,9 @@ entries:
   - name: dns-operator.v1.3.2
     replaces: dns-operator.v1.3.1
   - name: dns-operator.v1.4.0
+    replaces: dns-operator.v1.3.2
+  - name: dns-operator.v1.4.1
+    replaces: dns-operator.v1.4.0
 name: stable
 package: dns-operator
 schema: olm.channel

--- a/catalog/4.19/limitador-operator/catalog.yaml
+++ b/catalog/4.19/limitador-operator/catalog.yaml
@@ -21,10 +21,9 @@ entries:
   - name: limitador-operator.v1.3.2
     replaces: limitador-operator.v1.3.1
   - name: limitador-operator.v1.4.0
-  - name: limitador-operator.v1.4.1
     replaces: limitador-operator.v1.3.2
-    skips:
-    - limitador-operator.v1.4.0
+  - name: limitador-operator.v1.4.1
+    replaces: limitador-operator.v1.4.0
 name: stable
 package: limitador-operator
 schema: olm.channel

--- a/catalog/4.20/dns-operator/catalog.yaml
+++ b/catalog/4.20/dns-operator/catalog.yaml
@@ -8,10 +8,6 @@ schema: olm.package
 ---
 entries:
   - name: dns-operator.v1.0.2
-  - name: dns-operator.v1.4.1
-    replaces: dns-operator.v1.3.2
-    skips:
-    - dns-operator.v1.4.0
   - name: dns-operator.v1.1.0
     replaces: dns-operator.v1.0.2
   - name: dns-operator.v1.1.1
@@ -25,6 +21,9 @@ entries:
   - name: dns-operator.v1.3.2
     replaces: dns-operator.v1.3.1
   - name: dns-operator.v1.4.0
+    replaces: dns-operator.v1.3.2
+  - name: dns-operator.v1.4.1
+    replaces: dns-operator.v1.4.0
 name: stable
 package: dns-operator
 schema: olm.channel

--- a/catalog/4.20/limitador-operator/catalog.yaml
+++ b/catalog/4.20/limitador-operator/catalog.yaml
@@ -21,10 +21,9 @@ entries:
   - name: limitador-operator.v1.3.2
     replaces: limitador-operator.v1.3.1
   - name: limitador-operator.v1.4.0
-  - name: limitador-operator.v1.4.1
     replaces: limitador-operator.v1.3.2
-    skips:
-    - limitador-operator.v1.4.0
+  - name: limitador-operator.v1.4.1
+    replaces: limitador-operator.v1.4.0
 name: stable
 package: limitador-operator
 schema: olm.channel

--- a/catalog/4.21/dns-operator/catalog.yaml
+++ b/catalog/4.21/dns-operator/catalog.yaml
@@ -8,15 +8,14 @@ schema: olm.package
 ---
 entries:
   - name: dns-operator.v1.3.0
-  - name: dns-operator.v1.4.1
-    replaces: dns-operator.v1.3.2
-    skips:
-    - dns-operator.v1.4.0
   - name: dns-operator.v1.3.1
     replaces: dns-operator.v1.3.0
   - name: dns-operator.v1.3.2
     replaces: dns-operator.v1.3.1
   - name: dns-operator.v1.4.0
+    replaces: dns-operator.v1.3.2
+  - name: dns-operator.v1.4.1
+    replaces: dns-operator.v1.4.0
 name: stable
 package: dns-operator
 schema: olm.channel

--- a/catalog/4.21/limitador-operator/catalog.yaml
+++ b/catalog/4.21/limitador-operator/catalog.yaml
@@ -13,10 +13,9 @@ entries:
   - name: limitador-operator.v1.3.2
     replaces: limitador-operator.v1.3.1
   - name: limitador-operator.v1.4.0
-  - name: limitador-operator.v1.4.1
     replaces: limitador-operator.v1.3.2
-    skips:
-    - limitador-operator.v1.4.0
+  - name: limitador-operator.v1.4.1
+    replaces: limitador-operator.v1.4.0
 name: stable
 package: limitador-operator
 schema: olm.channel

--- a/catalog/4.22/authorino-operator/catalog.yaml
+++ b/catalog/4.22/authorino-operator/catalog.yaml
@@ -35,7 +35,6 @@ entries:
   - name: authorino-operator.v1.3.3
     replaces: authorino-operator.v1.3.2
   - name: authorino-operator.v1.4.0
-    replaces: authorino-operator.v1.3.2
   - name: authorino-operator.v1.4.1
     replaces: authorino-operator.v1.3.3
     skips:


### PR DESCRIPTION
Reverts https://github.com/rh-api-management/rhcl-file-based-catalog/commit/c96dbc6464e13c80f1622dfff7bac722f50901ca

And implements expected upgrade path